### PR TITLE
[feat] : 파일 업로드 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,12 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    //spring bean validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dnd/gongmuin/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/dnd/gongmuin/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.dnd.gongmuin.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/dnd/gongmuin/common/config/S3Config.java
+++ b/src/main/java/com/dnd/gongmuin/common/config/S3Config.java
@@ -1,0 +1,33 @@
+package com.dnd.gongmuin.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class S3Config {
+
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public AmazonS3 amazonS3Client() {
+		AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+		return AmazonS3ClientBuilder.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+			.build();
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/s3/controller/S3Controller.java
+++ b/src/main/java/com/dnd/gongmuin/s3/controller/S3Controller.java
@@ -1,0 +1,42 @@
+package com.dnd.gongmuin.s3.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dnd.gongmuin.s3.dto.ImagesUploadRequest;
+import com.dnd.gongmuin.s3.dto.ImagesUploadResponse;
+import com.dnd.gongmuin.s3.dto.VideoUploadRequest;
+import com.dnd.gongmuin.s3.dto.VideoUploadResponse;
+import com.dnd.gongmuin.s3.service.S3Service;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/files")
+public class S3Controller {
+	private final S3Service s3Service;
+
+	@PostMapping("/images")
+	public ResponseEntity<ImagesUploadResponse> uploadImages(
+		@ModelAttribute @Valid ImagesUploadRequest request
+	) {
+		List<String> imageUrls = s3Service.uploadImages(request.imageFiles());
+		return ResponseEntity.ok(ImagesUploadResponse.from(imageUrls));
+	}
+
+	@PostMapping("/videos")
+	public ResponseEntity<VideoUploadResponse> uploadVideo(
+		@ModelAttribute @Valid VideoUploadRequest request
+	){
+		String videoUrl = s3Service.uploadVideo(request.videoFile());
+		return ResponseEntity.ok(VideoUploadResponse.from(videoUrl));
+	}
+
+}

--- a/src/main/java/com/dnd/gongmuin/s3/controller/S3Controller.java
+++ b/src/main/java/com/dnd/gongmuin/s3/controller/S3Controller.java
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/api/files")
 public class S3Controller {
+
 	private final S3Service s3Service;
 
 	@PostMapping("/images")
@@ -34,7 +35,7 @@ public class S3Controller {
 	@PostMapping("/videos")
 	public ResponseEntity<VideoUploadResponse> uploadVideo(
 		@ModelAttribute @Valid VideoUploadRequest request
-	){
+	) {
 		String videoUrl = s3Service.uploadVideo(request.videoFile());
 		return ResponseEntity.ok(VideoUploadResponse.from(videoUrl));
 	}

--- a/src/main/java/com/dnd/gongmuin/s3/dto/ImagesUploadRequest.java
+++ b/src/main/java/com/dnd/gongmuin/s3/dto/ImagesUploadRequest.java
@@ -8,8 +8,9 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record ImagesUploadRequest(
+
 	@NotNull(message = "이미지 파일은 필수 입력 항목입니다.")
-	@Size(min=1, max = 10, message = "이미지는 1장 이상 10장 이하로 선택하세요.")
+	@Size(min = 1, max = 10, message = "이미지는 1장 이상 10장 이하로 선택하세요.")
 	List<MultipartFile> imageFiles
-){
+) {
 }

--- a/src/main/java/com/dnd/gongmuin/s3/dto/ImagesUploadRequest.java
+++ b/src/main/java/com/dnd/gongmuin/s3/dto/ImagesUploadRequest.java
@@ -1,0 +1,15 @@
+package com.dnd.gongmuin.s3.dto;
+
+import java.util.List;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ImagesUploadRequest(
+	@NotNull(message = "이미지 파일은 필수 입력 항목입니다.")
+	@Size(min=1, max = 10, message = "이미지는 1장 이상 10장 이하로 선택하세요.")
+	List<MultipartFile> imageFiles
+){
+}

--- a/src/main/java/com/dnd/gongmuin/s3/dto/ImagesUploadResponse.java
+++ b/src/main/java/com/dnd/gongmuin/s3/dto/ImagesUploadResponse.java
@@ -1,0 +1,11 @@
+package com.dnd.gongmuin.s3.dto;
+
+import java.util.List;
+
+public record ImagesUploadResponse(
+	List<String> imageUrls
+) {
+	public static ImagesUploadResponse from(List<String> imageUrls) {
+		return new ImagesUploadResponse(imageUrls);
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/s3/dto/VideoUploadRequest.java
+++ b/src/main/java/com/dnd/gongmuin/s3/dto/VideoUploadRequest.java
@@ -1,0 +1,11 @@
+package com.dnd.gongmuin.s3.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.validation.constraints.NotNull;
+
+public record VideoUploadRequest(
+	@NotNull(message = "비디오 파일은 필수 입력 항목입니다.")
+	MultipartFile videoFile
+) {
+}

--- a/src/main/java/com/dnd/gongmuin/s3/dto/VideoUploadResponse.java
+++ b/src/main/java/com/dnd/gongmuin/s3/dto/VideoUploadResponse.java
@@ -1,0 +1,9 @@
+package com.dnd.gongmuin.s3.dto;
+
+public record VideoUploadResponse(
+	String videoUrl
+) {
+	public static VideoUploadResponse from(String videoUrl) {
+		return new VideoUploadResponse(videoUrl);
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/s3/exception/S3ErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/s3/exception/S3ErrorCode.java
@@ -8,9 +8,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum S3ErrorCode implements ErrorCode {
-	EMPTY_FILE_NAME("원본 파일명은 필수입니다.","S3_001"),
+	EMPTY_FILE_NAME("원본 파일명은 필수입니다.", "S3_001"),
 
-	UNSUPPORTED_FILE_TYPE("지원하지 않는 파일 형식입니다.","S3_002"),
+	UNSUPPORTED_FILE_TYPE("지원하지 않는 파일 형식입니다.", "S3_002"),
 
 	FAILED_TO_UPLOAD("s3에 파일을 업로드하는데 실패했습니다.", "S3_003"),
 	INVALID_FILE_EXTENSION("파일 형식이 올바르지 않습니다.", "S4_004");

--- a/src/main/java/com/dnd/gongmuin/s3/exception/S3ErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/s3/exception/S3ErrorCode.java
@@ -9,11 +9,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum S3ErrorCode implements ErrorCode {
 	EMPTY_FILE_NAME("원본 파일명은 필수입니다.", "S3_001"),
+	INVALID_FILE_EXTENSION("잘못된 되었거나 지원하지 않는 파일 형식입니다.", "S3_002"),
 
-	UNSUPPORTED_FILE_TYPE("지원하지 않는 파일 형식입니다.", "S3_002"),
+	FAILED_TO_UPLOAD("파일을 업로드하는데 실패했습니다.", "S3_003");
 
-	FAILED_TO_UPLOAD("s3에 파일을 업로드하는데 실패했습니다.", "S3_003"),
-	INVALID_FILE_EXTENSION("파일 형식이 올바르지 않습니다.", "S4_004");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/s3/exception/S3ErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/s3/exception/S3ErrorCode.java
@@ -1,0 +1,20 @@
+package com.dnd.gongmuin.s3.exception;
+
+import com.dnd.gongmuin.common.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum S3ErrorCode implements ErrorCode {
+	EMPTY_FILE_NAME("원본 파일명은 필수입니다.","S3_001"),
+
+	UNSUPPORTED_FILE_TYPE("지원하지 않는 파일 형식입니다.","S3_002"),
+
+	FAILED_TO_UPLOAD("s3에 파일을 업로드하는데 실패했습니다.", "S3_003"),
+	INVALID_FILE_EXTENSION("파일 형식이 올바르지 않습니다.", "S4_004");
+
+	private final String message;
+	private final String code;
+}

--- a/src/main/java/com/dnd/gongmuin/s3/service/S3Service.java
+++ b/src/main/java/com/dnd/gongmuin/s3/service/S3Service.java
@@ -25,7 +25,7 @@ public class S3Service {
 
 	private static final String IMAGE_FOLDER_NAME = "images";
 	private static final String VIDEO_FOLDER_NAME = "videos";
-	private static final Set<String> ALLOWED_FILE_EXTENSIONS = Set.of("jpg", "jpeg", "png", "mp4", "avi", "mov");
+	private static final Set<String> ALLOWED_FILE_EXTENSIONS = Set.of(".jpg", ".jpeg", ".png", ".mp4", ".avi", ".mov");
 	private final AmazonS3 amazonS3;
 
 	@Value("${cloud.aws.s3.bucket}")
@@ -72,6 +72,7 @@ public class S3Service {
 			throw new ValidationException(S3ErrorCode.EMPTY_FILE_NAME);
 		}
 		String extension = fileName.substring(fileName.lastIndexOf(".")).toLowerCase();
+		System.out.println("extension = " + extension);
 		if (!ALLOWED_FILE_EXTENSIONS.contains(extension)){
 			throw new ValidationException(S3ErrorCode.INVALID_FILE_EXTENSION);
 		}

--- a/src/main/java/com/dnd/gongmuin/s3/service/S3Service.java
+++ b/src/main/java/com/dnd/gongmuin/s3/service/S3Service.java
@@ -1,0 +1,81 @@
+package com.dnd.gongmuin.s3.service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.dnd.gongmuin.common.exception.runtime.ValidationException;
+import com.dnd.gongmuin.s3.exception.S3ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+	private static final String IMAGE_FOLDER_NAME = "images";
+	private static final String VIDEO_FOLDER_NAME = "videos";
+	private static final Set<String> ALLOWED_FILE_EXTENSIONS = Set.of("jpg", "jpeg", "png", "mp4", "avi", "mov");
+	private final AmazonS3 amazonS3;
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	public List<String> uploadImages(List<MultipartFile> multipartFileList) {
+		List<String> fileUrls = new ArrayList<>();
+
+		for (MultipartFile multipartFile : multipartFileList) {
+			fileUrls.add(uploadFile(multipartFile, IMAGE_FOLDER_NAME));
+		}
+		return fileUrls;
+	}
+
+	public String uploadVideo(MultipartFile multipartFile) {
+		return uploadFile(multipartFile, VIDEO_FOLDER_NAME);
+	}
+
+	private String uploadFile(MultipartFile multipartFile, String folderName) {
+		ObjectMetadata metadata = new ObjectMetadata();
+		String fileName = createFileName(multipartFile.getOriginalFilename());
+		metadata.setContentLength(multipartFile.getSize());
+		metadata.setContentType(multipartFile.getContentType());
+
+		String bucketName = bucket + "/" + folderName;
+
+		try {
+			amazonS3.putObject(
+				new PutObjectRequest(bucketName, fileName, multipartFile.getInputStream(), metadata)
+			);
+
+		} catch (IOException exception) {
+			throw new ValidationException(S3ErrorCode.FAILED_TO_UPLOAD);
+		}
+		return amazonS3.getUrl(bucketName, fileName).toString();
+	}
+
+	private String createFileName(String fileName) {
+		return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+	}
+
+	private String getFileExtension(String fileName) {
+		if (Objects.isNull(fileName) || fileName.isBlank()) {
+			throw new ValidationException(S3ErrorCode.EMPTY_FILE_NAME);
+		}
+		String extension = fileName.substring(fileName.lastIndexOf(".")).toLowerCase();
+		if (!ALLOWED_FILE_EXTENSIONS.contains(extension)){
+			throw new ValidationException(S3ErrorCode.INVALID_FILE_EXTENSION);
+		}
+		return extension;
+	}
+
+}

--- a/src/main/java/com/dnd/gongmuin/s3/service/S3Service.java
+++ b/src/main/java/com/dnd/gongmuin/s3/service/S3Service.java
@@ -72,7 +72,6 @@ public class S3Service {
 			throw new ValidationException(S3ErrorCode.EMPTY_FILE_NAME);
 		}
 		String extension = fileName.substring(fileName.lastIndexOf(".")).toLowerCase();
-		System.out.println("extension = " + extension);
 		if (!ALLOWED_FILE_EXTENSIONS.contains(extension)) {
 			throw new ValidationException(S3ErrorCode.INVALID_FILE_EXTENSION);
 		}

--- a/src/main/java/com/dnd/gongmuin/s3/service/S3Service.java
+++ b/src/main/java/com/dnd/gongmuin/s3/service/S3Service.java
@@ -73,7 +73,7 @@ public class S3Service {
 		}
 		String extension = fileName.substring(fileName.lastIndexOf(".")).toLowerCase();
 		System.out.println("extension = " + extension);
-		if (!ALLOWED_FILE_EXTENSIONS.contains(extension)){
+		if (!ALLOWED_FILE_EXTENSIONS.contains(extension)) {
 			throw new ValidationException(S3ErrorCode.INVALID_FILE_EXTENSION);
 		}
 		return extension;


### PR DESCRIPTION
### 관련 이슈
- close #9 
- close #8 

### 📑 작업 상세 내용
- S3 세팅
- 파일 업로드 API
  - 이미지는 여러 개 첨부, 동영상은 한 개만 첨부할 수 있도록 했습니다.
  - 성공적으로 S3에 업로드하면 url을 반환합니다.

### 💫 작업 요약
- 파일 업로드 API 구현

### 🔍 중점적으로 리뷰 할 부분
- 동영상으로 인해 용량 제한이 걸려서 application.yml 수정했습니다. 
  - 노션에 application.yml 수정해서 업로드 하였습니다. 
