### PR TITLE
[fix] : 배포 시 권한 없음 해결

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,10 +8,11 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  build-and-push-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
       # 자바 버전 설정
       - name: Set up JDK 17
@@ -24,7 +25,7 @@ jobs:
       - name: Generate application.yml
         run: |
           mkdir -p ./src/main/resources
-          echo "${{ secrets.APPLICATION_CORE }}" | base64 -d > ./src/main/resources/application.yml
+          echo "${{ secrets.APPLICATION_YML }}" | base64 -d > ./src/main/resources/application.yml
 
       # gradle 권한 부여
       - name: Grant execute permission for gradlew
@@ -46,7 +47,6 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build -x test
 
-
       # 도커 허브 로그인
       - name: Docker Hub Login
         uses: docker/login-action@v2
@@ -54,20 +54,23 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-
       # 도커 이미지 빌드 및 푸시
       - name: docker image build and push
         run: |
           docker build -f Dockerfile -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_NAME }} .
           docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_NAME }}
 
+  deploy:
+    needs: build-and-push-image
+    runs-on: ubuntu-latest
+    steps:
       # 서버 백그라운드 실행
       - name: pull image and run container
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
-          password: ${{ secrets.EC2_PASSWORD }}
+          key: ${{ secrets.EC2_KEY }}
           port: ${{ secrets.EC2_PORT }}
           script: |
             cd compose


### PR DESCRIPTION
### 관련 이슈
- close #11 

### 📑 작업 상세 내용
- github action에서 패스워드로 EC2에 접근하려고 할 때 인증이 안되어서 key 인증 방식으로 수정
- workflow에서 단일 job을 build and push, deploy로 분할

### 💫 작업 요약
- 배포 시 권한 없음 문제 해결
- cd.yml job 분할

### 🔍 중점적으로 리뷰 할 부분
- 
