### PR TITLE
[fix #33] 시류리티 config 변경 및 API 인증 예외 처리

### DIFF
--- a/src/main/java/com/dnd/gongmuin/security/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/gongmuin/security/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.dnd.gongmuin.security.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -35,7 +36,7 @@ public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http
-			.cors((auth) -> auth.disable())
+			.cors(Customizer.withDefaults())
 			.csrf((auth) -> auth.disable())
 			.formLogin((auth) -> auth.disable())
 			.httpBasic((auth) -> auth.disable())
@@ -47,11 +48,8 @@ public class SecurityConfig {
 			.authorizeHttpRequests(
 				(auth) -> auth
 					.requestMatchers("/").permitAll()
-					.requestMatchers("/api/**").permitAll()
 					.requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
 					.requestMatchers("/api/auth/signin/kakao").permitAll()
-					.requestMatchers("/api/auth/member").permitAll()
-					.requestMatchers("/api/auth/check-email").permitAll()
 					.requestMatchers("/additional-info").permitAll()
 					.anyRequest().authenticated()
 			)

--- a/src/main/java/com/dnd/gongmuin/security/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/gongmuin/security/config/SecurityConfig.java
@@ -1,13 +1,17 @@
 package com.dnd.gongmuin.security.config;
 
+import java.util.Arrays;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import com.dnd.gongmuin.security.handler.CustomAuthenticationEntryPoint;
 import com.dnd.gongmuin.security.handler.CustomOauth2FailureHandler;
@@ -28,15 +32,9 @@ public class SecurityConfig {
 	private final TokenAuthenticationFilter tokenAuthenticationFilter;
 
 	@Bean
-	public WebSecurityCustomizer webSecurityCustomizer() {
-		return web -> web.ignoring()
-			.requestMatchers("/error", "/favicon.ico");
-	}
-
-	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http
-			.cors(Customizer.withDefaults())
+			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
 			.csrf((auth) -> auth.disable())
 			.formLogin((auth) -> auth.disable())
 			.httpBasic((auth) -> auth.disable())
@@ -68,5 +66,28 @@ public class SecurityConfig {
 				.authenticationEntryPoint(new CustomAuthenticationEntryPoint()));
 
 		return http.build();
+	}
+
+	@Bean
+	public WebSecurityCustomizer webSecurityCustomizer() {
+		return web -> web.ignoring()
+			.requestMatchers("/error", "/favicon.ico");
+	}
+
+	// Spring Security cors Bean 등록
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+
+		configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "https://gongmuin.netlify.app/",
+			"https://gongmuin.site/", "http://localhost:8080"));
+		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+		configuration.setAllowedHeaders(Arrays.asList("*"));
+		configuration.setExposedHeaders(Arrays.asList("Set-Cookie", "Authorization"));
+		configuration.setMaxAge(3000L);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/security/config/WebConfig.java
+++ b/src/main/java/com/dnd/gongmuin/security/config/WebConfig.java
@@ -7,6 +7,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+	// Spring MVC cors 설정
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")

--- a/src/main/java/com/dnd/gongmuin/security/exception/JwtErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/security/exception/JwtErrorCode.java
@@ -1,4 +1,4 @@
-package com.dnd.gongmuin.security.jwt.exception;
+package com.dnd.gongmuin.security.exception;
 
 import com.dnd.gongmuin.common.exception.ErrorCode;
 

--- a/src/main/java/com/dnd/gongmuin/security/exception/SecurityErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/security/exception/SecurityErrorCode.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum SecurityErrorCode implements ErrorCode {
-	UNAUTHORIZED("비인가 사용자 요청입니다.", "SECURITY_001");
+	UNAUTHORIZED_USER("비인가 사용자 요청입니다.", "SECURITY_001");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/security/exception/SecurityErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/security/exception/SecurityErrorCode.java
@@ -1,0 +1,15 @@
+package com.dnd.gongmuin.security.exception;
+
+import com.dnd.gongmuin.common.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SecurityErrorCode implements ErrorCode {
+	UNAUTHORIZED("비인가 사용자 요청입니다.", "SECURITY_001");
+
+	private final String message;
+	private final String code;
+}

--- a/src/main/java/com/dnd/gongmuin/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/dnd/gongmuin/security/handler/CustomAuthenticationEntryPoint.java
@@ -26,8 +26,8 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 		response.setContentType("application/json");
 		response.setCharacterEncoding("UTF-8");
 
-		ErrorResponse errorResponse = new ErrorResponse(SecurityErrorCode.UNAUTHORIZED.getMessage(),
-			SecurityErrorCode.UNAUTHORIZED.getCode());
+		ErrorResponse errorResponse = new ErrorResponse(SecurityErrorCode.UNAUTHORIZED_USER.getMessage(),
+			SecurityErrorCode.UNAUTHORIZED_USER.getCode());
 
 		ObjectMapper mapper = new ObjectMapper();
 		String jsonResponse = mapper.writeValueAsString(errorResponse);

--- a/src/main/java/com/dnd/gongmuin/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/dnd/gongmuin/security/handler/CustomAuthenticationEntryPoint.java
@@ -5,6 +5,10 @@ import java.io.IOException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
+import com.dnd.gongmuin.common.exception.ErrorResponse;
+import com.dnd.gongmuin.security.exception.SecurityErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -15,7 +19,19 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException authException) throws IOException, ServletException {
-		log.error("비인가 사용자 요청으로 인가예외 발생", authException);
-		response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증에 실패하였습니다.");
+
+		log.error("비인가 사용자 요청 -> 예외 발생", authException.getStackTrace());
+
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);  // 401 Unauthorized
+		response.setContentType("application/json");
+		response.setCharacterEncoding("UTF-8");
+
+		ErrorResponse errorResponse = new ErrorResponse(SecurityErrorCode.UNAUTHORIZED.getMessage(),
+			SecurityErrorCode.UNAUTHORIZED.getCode());
+
+		ObjectMapper mapper = new ObjectMapper();
+		String jsonResponse = mapper.writeValueAsString(errorResponse);
+
+		response.getWriter().write(jsonResponse);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/security/jwt/exception/JwtErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/exception/JwtErrorCode.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum JwtErrorCode implements ErrorCode {
 
-	MALFORMED_TOKEN("알맞지 않은 형식의 토큰입니다..", "JWT_001"),
+	MALFORMED_TOKEN("알맞지 않은 형식의 토큰입니다.", "JWT_001"),
 	INVALID_TOKEN("유효하지 않은 토큰입니다.", "JWT_002");
 
 	private final String message;

--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenExceptionFilter.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenExceptionFilter.java
@@ -1,18 +1,20 @@
 package com.dnd.gongmuin.security.jwt.util;
 
-import static org.springframework.http.HttpStatus.*;
-
 import java.io.IOException;
 
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.dnd.gongmuin.common.exception.ErrorResponse;
 import com.dnd.gongmuin.common.exception.runtime.CustomJwtException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class TokenExceptionFilter extends OncePerRequestFilter {
 
 	@Override
@@ -21,7 +23,19 @@ public class TokenExceptionFilter extends OncePerRequestFilter {
 		try {
 			filterChain.doFilter(request, response);
 		} catch (CustomJwtException e) {
-			response.sendError(NOT_FOUND.value(), e.getMessage());
+
+			log.error("JWT 검증 실패로 인한 예외 발생", e.getStackTrace());
+
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);  // 401 Unauthorized
+			response.setContentType("application/json");
+			response.setCharacterEncoding("UTF-8");
+
+			ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getCode());
+
+			ObjectMapper mapper = new ObjectMapper();
+			String jsonResponse = mapper.writeValueAsString(errorResponse);
+
+			response.getWriter().write(jsonResponse);
 		}
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenProvider.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenProvider.java
@@ -23,7 +23,7 @@ import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.exception.MemberErrorCode;
 import com.dnd.gongmuin.member.repository.MemberRepository;
 import com.dnd.gongmuin.redis.util.RedisUtil;
-import com.dnd.gongmuin.security.jwt.exception.JwtErrorCode;
+import com.dnd.gongmuin.security.exception.JwtErrorCode;
 import com.dnd.gongmuin.security.oauth2.CustomOauth2User;
 
 import io.jsonwebtoken.Claims;


### PR DESCRIPTION
### 관련 이슈
- close #33 

### 📑 작업 상세 내용
- security config 인가 허용 API 제거
- seucirty 예외 처리 클래스 로직 변경
  - 인증 리소스 접근에 대한 비인가 요청 예외처리 CustomAuthenticationEntryPoint.class 로직 수정
  - JWT 검증 시 발생하는 예외 처리 필터 TokenAuthenticationFilter.class 로직 수정
- CORS 커스텀 적용을 위한 CORS disable -> able
- SecurityErrorCode 생성 
- JwtErroCode 파일 위치 변경
  - security.jwt.exception -> security.exception

### 💫 작업 요약
- security config 인가 허용 API 제거
- seucirty 예외 처리 클래스 로직 변경
- CORS 커스텀 적용을 위한 CORS disable -> able


### 🔍 중점적으로 리뷰 할 부분
-  
