### PR TITLE
[feat #45] 게시글 상세 조회 응답 필드 추가

### DIFF
--- a/src/main/java/com/dnd/gongmuin/post_interaction/domain/InteractionCount.java
+++ b/src/main/java/com/dnd/gongmuin/post_interaction/domain/InteractionCount.java
@@ -26,15 +26,15 @@ public class InteractionCount extends TimeBaseEntity {
 	@Column(name = "question_post_id")
 	private Long questionPostId;
 
-	@Column(name = "total_count", nullable = false)
-	private int totalCount;
+	@Column(name = "count", nullable = false)
+	private int count;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "type")
 	private InteractionType type;
 
 	private InteractionCount(InteractionType type, Long questionPostId) {
-		this.totalCount = 1;
+		this.count = 1;
 		this.type = type;
 		this.questionPostId = questionPostId;
 	}
@@ -43,11 +43,11 @@ public class InteractionCount extends TimeBaseEntity {
 		return new InteractionCount(type, questionPostId);
 	}
 
-	public int increaseTotalCount() {
-		return ++totalCount;
+	public int increaseCount() {
+		return ++count;
 	}
 
-	public int decreaseTotalCount() {
-		return --totalCount;
+	public int decreaseCount() {
+		return --count;
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/post_interaction/service/InteractionService.java
+++ b/src/main/java/com/dnd/gongmuin/post_interaction/service/InteractionService.java
@@ -33,16 +33,16 @@ public class InteractionService {
 		Long memberId,
 		InteractionType type // 북마크, 추천
 	) {
-		int totalCount;
+		int count;
 		if (!interactionRepository.existsByQuestionPostIdAndMemberIdAndType // 상호 작용 존재x -> 저장
 			(questionPostId, memberId, type)
 		) {
-			totalCount = createInteraction(questionPostId, memberId, type);
+			count = createInteraction(questionPostId, memberId, type);
 		} else { // 존재 -> 값 업데이트
-			totalCount = updateInteractionAndCount(questionPostId, memberId, type, true);
+			count = updateInteractionAndCount(questionPostId, memberId, type, true);
 		}
 		return InteractionMapper.toPostInteractionResponse(
-			totalCount, type
+			count, type
 		);
 	}
 
@@ -52,9 +52,9 @@ public class InteractionService {
 		Long memberId,
 		InteractionType type
 	) {
-		int totalCount = updateInteractionAndCount(questionPostId, memberId, type, false);
+		int count = updateInteractionAndCount(questionPostId, memberId, type, false);
 		return InteractionMapper.toPostInteractionResponse(
-			totalCount, type
+			count, type
 		);
 	}
 
@@ -73,7 +73,7 @@ public class InteractionService {
 				() -> interactionCountRepository
 					.save(InteractionMapper.toPostInteractionCount(questionPostId, type)) // 생성 시 count 1로 초기화
 			)
-			.getTotalCount();
+			.getCount();
 	}
 
 	private void validateIfPostExistsAndNotQuestioner(
@@ -93,18 +93,18 @@ public class InteractionService {
 		InteractionType type,
 		boolean isActivate
 	) {
-		int totalCount;
+		int count;
 		Interaction interaction = getPostInteraction(questionPostId, memberId, type);
 		InteractionCount interactionCount = getPostInteractionCount(questionPostId, type);
 
 		if (isActivate) { //활성화
 			interaction.updateIsInteractedTrue();
-			totalCount = interactionCount.increaseTotalCount();
+			count = interactionCount.increaseCount();
 		} else { // 비활성화
 			interaction.updateIsInteractedFalse();
-			totalCount = interactionCount.decreaseTotalCount();
+			count = interactionCount.decreaseCount();
 		}
-		return totalCount;
+		return count;
 	}
 
 	private Interaction getPostInteraction(Long questionPostId, Long memberId, InteractionType type) {

--- a/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
@@ -17,6 +17,7 @@ import com.dnd.gongmuin.question_post.dto.request.QuestionPostSearchCondition;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostSimpleResponse;
+import com.dnd.gongmuin.question_post.dto.response.RegisterQuestionPostResponse;
 import com.dnd.gongmuin.question_post.service.QuestionPostService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,11 +37,11 @@ public class QuestionPostController {
 	@Operation(summary = "질문글 등록 API", description = "질문글을 등록한다")
 	@ApiResponse(useReturnTypeSchema = true)
 	@PostMapping
-	public ResponseEntity<QuestionPostDetailResponse> registerQuestionPost(
+	public ResponseEntity<RegisterQuestionPostResponse> registerQuestionPost(
 		@Valid @RequestBody RegisterQuestionPostRequest request,
 		@AuthenticationPrincipal Member member
 	) {
-		QuestionPostDetailResponse response = questionPostService.registerQuestionPost(request, member);
+		RegisterQuestionPostResponse response = questionPostService.registerQuestionPost(request, member);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
@@ -26,7 +26,7 @@ public class QuestionPostMapper {
 		return QuestionPost.of(request.title(), request.content(), request.reward(), jobGroup, images, member);
 	}
 
-	public static QuestionPostDetailResponse toRegisterQuestionPostResponse(
+	public static QuestionPostDetailResponse toQuestionPostDetailResponse(
 		QuestionPost questionPost,
 		int recommendCount,
 		int savedCount
@@ -51,7 +51,7 @@ public class QuestionPostMapper {
 		);
 	}
 
-	public static RegisterQuestionPostResponse toRegisterQuestionPostResponse(
+	public static RegisterQuestionPostResponse toQuestionPostDetailResponse(
 		QuestionPost questionPost
 	) {
 		Member member = questionPost.getMember();

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
@@ -10,6 +10,7 @@ import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostSimpleResponse;
+import com.dnd.gongmuin.question_post.dto.response.RegisterQuestionPostResponse;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -25,9 +26,36 @@ public class QuestionPostMapper {
 		return QuestionPost.of(request.title(), request.content(), request.reward(), jobGroup, images, member);
 	}
 
-	public static QuestionPostDetailResponse toQuestionPostDetailResponse(QuestionPost questionPost) {
+	public static QuestionPostDetailResponse toRegisterQuestionPostResponse(
+		QuestionPost questionPost,
+		int recommendCount,
+		int savedCount
+	) {
 		Member member = questionPost.getMember();
 		return new QuestionPostDetailResponse(
+			questionPost.getId(),
+			questionPost.getTitle(),
+			questionPost.getContent(),
+			questionPost.getImages().stream()
+				.map(QuestionPostImage::getImageUrl).toList(),
+			questionPost.getReward(),
+			questionPost.getJobGroup().getLabel(),
+			new MemberInfo(
+				member.getId(),
+				member.getNickname(),
+				member.getJobGroup().getLabel()
+			),
+			recommendCount,
+			savedCount,
+			questionPost.getCreatedAt().toString()
+		);
+	}
+
+	public static RegisterQuestionPostResponse toRegisterQuestionPostResponse(
+		QuestionPost questionPost
+	) {
+		Member member = questionPost.getMember();
+		return new RegisterQuestionPostResponse(
 			questionPost.getId(),
 			questionPost.getTitle(),
 			questionPost.getContent(),

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostDetailResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostDetailResponse.java
@@ -10,6 +10,8 @@ public record QuestionPostDetailResponse(
 	int reward,
 	String targetJobGroup,
 	MemberInfo memberInfo,
+	int recommendCount,
+	int savedCount,
 	String createdAt
 ) {
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/RegisterQuestionPostResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/RegisterQuestionPostResponse.java
@@ -2,7 +2,7 @@ package com.dnd.gongmuin.question_post.dto.response;
 
 import java.util.List;
 
-public record RegisterQuestionPostResponse (
+public record RegisterQuestionPostResponse(
 	Long questionPostId,
 	String title,
 	String content,
@@ -11,5 +11,5 @@ public record RegisterQuestionPostResponse (
 	String targetJobGroup,
 	MemberInfo memberInfo,
 	String createdAt
-){
+) {
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/RegisterQuestionPostResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/RegisterQuestionPostResponse.java
@@ -1,0 +1,15 @@
+package com.dnd.gongmuin.question_post.dto.response;
+
+import java.util.List;
+
+public record RegisterQuestionPostResponse (
+	Long questionPostId,
+	String title,
+	String content,
+	List<String> imageUrls,
+	int reward,
+	String targetJobGroup,
+	MemberInfo memberInfo,
+	String createdAt
+){
+}

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -56,8 +56,8 @@ public class QuestionPostService {
 			.orElseThrow(() -> new NotFoundException(QuestionPostErrorCode.NOT_FOUND_QUESTION_POST));
 		return QuestionPostMapper.toQuestionPostDetailResponse(
 			questionPost,
-			getTotalCountByType(questionPostId, InteractionType.RECOMMEND),
-			getTotalCountByType(questionPostId, InteractionType.SAVED)
+			getCountByType(questionPostId, InteractionType.RECOMMEND),
+			getCountByType(questionPostId, InteractionType.SAVED)
 		);
 	}
 
@@ -72,10 +72,10 @@ public class QuestionPostService {
 		return PageMapper.toPageResponse(responsePage);
 	}
 
-	private int getTotalCountByType(Long questionPostId, InteractionType type) {
+	private int getCountByType(Long questionPostId, InteractionType type) {
 		return interactionCountRepository
 			.findByQuestionPostIdAndType(questionPostId, type)
-			.map(InteractionCount::getTotalCount)
+			.map(InteractionCount::getCount)
 			.orElse(0);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -45,7 +45,7 @@ public class QuestionPostService {
 			throw new ValidationException(MemberErrorCode.NOT_ENOUGH_CREDIT);
 		}
 		QuestionPost questionPost = QuestionPostMapper.toQuestionPost(request, member);
-		return QuestionPostMapper.toRegisterQuestionPostResponse(
+		return QuestionPostMapper.toQuestionPostDetailResponse(
 			questionPostRepository.save(questionPost)
 		);
 	}
@@ -54,10 +54,10 @@ public class QuestionPostService {
 	public QuestionPostDetailResponse getQuestionPostById(Long questionPostId) {
 		QuestionPost questionPost = questionPostRepository.findById(questionPostId)
 			.orElseThrow(() -> new NotFoundException(QuestionPostErrorCode.NOT_FOUND_QUESTION_POST));
-		return QuestionPostMapper.toRegisterQuestionPostResponse(
+		return QuestionPostMapper.toQuestionPostDetailResponse(
 			questionPost,
-			getCountByType(questionPostId, InteractionType.RECOMMEND),
-			getCountByType(questionPostId, InteractionType.SAVED)
+			getTotalCountByType(questionPostId, InteractionType.RECOMMEND),
+			getTotalCountByType(questionPostId, InteractionType.SAVED)
 		);
 	}
 
@@ -72,7 +72,7 @@ public class QuestionPostService {
 		return PageMapper.toPageResponse(responsePage);
 	}
 
-	private int getCountByType(Long questionPostId, InteractionType type) {
+	private int getTotalCountByType(Long questionPostId, InteractionType type) {
 		return interactionCountRepository
 			.findByQuestionPostIdAndType(questionPostId, type)
 			.map(InteractionCount::getTotalCount)

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -72,7 +72,7 @@ public class QuestionPostService {
 		return PageMapper.toPageResponse(responsePage);
 	}
 
-	private int getCountByType(Long questionPostId, InteractionType type){
+	private int getCountByType(Long questionPostId, InteractionType type) {
 		return interactionCountRepository
 			.findByQuestionPostIdAndType(questionPostId, type)
 			.map(InteractionCount::getTotalCount)

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -11,12 +11,16 @@ import com.dnd.gongmuin.common.exception.runtime.NotFoundException;
 import com.dnd.gongmuin.common.exception.runtime.ValidationException;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.exception.MemberErrorCode;
+import com.dnd.gongmuin.post_interaction.domain.InteractionCount;
+import com.dnd.gongmuin.post_interaction.domain.InteractionType;
+import com.dnd.gongmuin.post_interaction.repository.InteractionCountRepository;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.dto.QuestionPostMapper;
 import com.dnd.gongmuin.question_post.dto.request.QuestionPostSearchCondition;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostSimpleResponse;
+import com.dnd.gongmuin.question_post.dto.response.RegisterQuestionPostResponse;
 import com.dnd.gongmuin.question_post.exception.QuestionPostErrorCode;
 import com.dnd.gongmuin.question_post.repository.QuestionPostQueryRepository;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
@@ -30,20 +34,31 @@ public class QuestionPostService {
 	private final QuestionPostRepository questionPostRepository;
 	private final QuestionPostQueryRepository questionPostQueryRepository;
 
+	private final InteractionCountRepository interactionCountRepository;
+
 	@Transactional
-	public QuestionPostDetailResponse registerQuestionPost(RegisterQuestionPostRequest request, Member member) {
+	public RegisterQuestionPostResponse registerQuestionPost(
+		RegisterQuestionPostRequest request,
+		Member member
+	) {
 		if (member.getCredit() < request.reward()) {
 			throw new ValidationException(MemberErrorCode.NOT_ENOUGH_CREDIT);
 		}
 		QuestionPost questionPost = QuestionPostMapper.toQuestionPost(request, member);
-		return QuestionPostMapper.toQuestionPostDetailResponse(questionPostRepository.save(questionPost));
+		return QuestionPostMapper.toRegisterQuestionPostResponse(
+			questionPostRepository.save(questionPost)
+		);
 	}
 
 	@Transactional(readOnly = true)
 	public QuestionPostDetailResponse getQuestionPostById(Long questionPostId) {
 		QuestionPost questionPost = questionPostRepository.findById(questionPostId)
 			.orElseThrow(() -> new NotFoundException(QuestionPostErrorCode.NOT_FOUND_QUESTION_POST));
-		return QuestionPostMapper.toQuestionPostDetailResponse(questionPost);
+		return QuestionPostMapper.toRegisterQuestionPostResponse(
+			questionPost,
+			getCountByType(questionPostId, InteractionType.RECOMMEND),
+			getCountByType(questionPostId, InteractionType.SAVED)
+		);
 	}
 
 	@Transactional(readOnly = true)
@@ -55,5 +70,12 @@ public class QuestionPostService {
 			.searchQuestionPosts(condition, pageable)
 			.map(QuestionPostMapper::toQuestionPostSimpleResponse);
 		return PageMapper.toPageResponse(responsePage);
+	}
+
+	private int getCountByType(Long questionPostId, InteractionType type){
+		return interactionCountRepository
+			.findByQuestionPostIdAndType(questionPostId, type)
+			.map(InteractionCount::getTotalCount)
+			.orElse(0);
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/common/fixture/InteractionCountFixture.java
+++ b/src/test/java/com/dnd/gongmuin/common/fixture/InteractionCountFixture.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class InteractionCountFixture {
 
-	public static InteractionCount postInteractionCount(
+	public static InteractionCount interactionCount(
 		InteractionType type,
 		Long questionPostId
 	) {

--- a/src/test/java/com/dnd/gongmuin/common/fixture/InteractionFixture.java
+++ b/src/test/java/com/dnd/gongmuin/common/fixture/InteractionFixture.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class InteractionFixture {
 
-	public static Interaction postInteraction(
+	public static Interaction interaction(
 		InteractionType type,
 		Long memberId,
 		Long questionPostId

--- a/src/test/java/com/dnd/gongmuin/post_interaction/controller/InteractionControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/post_interaction/controller/InteractionControllerTest.java
@@ -63,10 +63,10 @@ class InteractionControllerTest extends ApiTestSupport {
 		QuestionPost questionPost = questionPostRepository.save(
 			QuestionPostFixture.questionPost(questioner)
 		);
-		interactionRepository.save(InteractionFixture.postInteraction(InteractionType.RECOMMEND,
+		interactionRepository.save(InteractionFixture.interaction(InteractionType.RECOMMEND,
 			loginMember.getId(), questionPost.getId()));
 		interactionCountRepository.save(
-			InteractionCountFixture.postInteractionCount(InteractionType.RECOMMEND, questionPost.getId())
+			InteractionCountFixture.interactionCount(InteractionType.RECOMMEND, questionPost.getId())
 		);
 
 		mockMvc.perform(post("/api/question-posts/{questionPostId}/inactivated", questionPost.getId())
@@ -84,10 +84,10 @@ class InteractionControllerTest extends ApiTestSupport {
 		QuestionPost questionPost = questionPostRepository.save(
 			QuestionPostFixture.questionPost(questioner)
 		);
-		interactionRepository.save(InteractionFixture.postInteraction(InteractionType.RECOMMEND,
+		interactionRepository.save(InteractionFixture.interaction(InteractionType.RECOMMEND,
 			loginMember.getId(), questionPost.getId()));
 		interactionCountRepository.save(
-			InteractionCountFixture.postInteractionCount(InteractionType.RECOMMEND, questionPost.getId())
+			InteractionCountFixture.interactionCount(InteractionType.RECOMMEND, questionPost.getId())
 		);
 
 		mockMvc.perform(post("/api/question-posts/{questionPostId}/inactivated", questionPost.getId())

--- a/src/test/java/com/dnd/gongmuin/post_interaction/service/InteractionServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/post_interaction/service/InteractionServiceTest.java
@@ -119,7 +119,7 @@ class InteractionServiceTest {
 		InteractionCount interactionCount = InteractionCountFixture.interactionCount(type,
 			interactor.getId());
 		interaction.updateIsInteractedFalse();
-		interactionCount.decreaseTotalCount();
+		interactionCount.decreaseCount();
 
 		given(interactionRepository.existsByQuestionPostIdAndMemberIdAndType(
 			questionPost.getId(), interactor.getId(), type

--- a/src/test/java/com/dnd/gongmuin/post_interaction/service/InteractionServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/post_interaction/service/InteractionServiceTest.java
@@ -114,9 +114,9 @@ class InteractionServiceTest {
 		//given
 		InteractionType type = InteractionType.RECOMMEND;
 		QuestionPost questionPost = QuestionPostFixture.questionPost(1L, questioner);
-		Interaction interaction = InteractionFixture.postInteraction(type, interactor.getId(),
+		Interaction interaction = InteractionFixture.interaction(type, interactor.getId(),
 			questionPost.getId());
-		InteractionCount interactionCount = InteractionCountFixture.postInteractionCount(type,
+		InteractionCount interactionCount = InteractionCountFixture.interactionCount(type,
 			interactor.getId());
 		interaction.updateIsInteractedFalse();
 		interactionCount.decreaseTotalCount();
@@ -150,9 +150,9 @@ class InteractionServiceTest {
 		//given
 		InteractionType type = InteractionType.RECOMMEND;
 		QuestionPost questionPost = QuestionPostFixture.questionPost(1L, questioner);
-		Interaction interaction = InteractionFixture.postInteraction(type, interactor.getId(),
+		Interaction interaction = InteractionFixture.interaction(type, interactor.getId(),
 			questionPost.getId());
-		InteractionCount interactionCount = InteractionCountFixture.postInteractionCount(type,
+		InteractionCount interactionCount = InteractionCountFixture.interactionCount(type,
 			interactor.getId());
 
 		given(interactionRepository.findByQuestionPostIdAndMemberIdAndType(

--- a/src/test/java/com/dnd/gongmuin/question_post/controller/QuestionPostControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/controller/QuestionPostControllerTest.java
@@ -100,7 +100,9 @@ class QuestionPostControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.targetJobGroup").value(questionPost.getJobGroup().getLabel()))
 			.andExpect(jsonPath("$.memberInfo.memberId").value(questionPost.getMember().getId()))
 			.andExpect(jsonPath("$.memberInfo.nickname").value(questionPost.getMember().getNickname()))
-			.andExpect(jsonPath("$.memberInfo.memberJobGroup").value(questionPost.getMember().getJobGroup().getLabel())
+			.andExpect(jsonPath("$.memberInfo.memberJobGroup").value(questionPost.getMember().getJobGroup().getLabel()))
+			.andExpect(jsonPath("$.recommendCount").value(0))
+			.andExpect(jsonPath("$.savedCount").value(0)
 			);
 	}
 

--- a/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
@@ -135,9 +135,9 @@ class QuestionPostServiceTest {
 			() -> assertThat(response.questionPostId())
 				.isEqualTo(questionPost.getId()),
 			() -> assertThat(response.recommendCount())
-				.isEqualTo(recommendCount.getTotalCount()).isEqualTo(1),
+				.isEqualTo(recommendCount.getCount()).isEqualTo(1),
 			() -> assertThat(response.savedCount())
-				.isEqualTo(savedCount.getTotalCount()).isEqualTo(1)
+				.isEqualTo(savedCount.getCount()).isEqualTo(1)
 		);
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
@@ -15,12 +15,17 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.dnd.gongmuin.common.fixture.InteractionCountFixture;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
 import com.dnd.gongmuin.common.fixture.QuestionPostFixture;
 import com.dnd.gongmuin.member.domain.Member;
+import com.dnd.gongmuin.post_interaction.domain.InteractionCount;
+import com.dnd.gongmuin.post_interaction.domain.InteractionType;
+import com.dnd.gongmuin.post_interaction.repository.InteractionCountRepository;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
+import com.dnd.gongmuin.question_post.dto.response.RegisterQuestionPostResponse;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 
 @DisplayName("[QuestionPostService 테스트]")
@@ -31,6 +36,9 @@ class QuestionPostServiceTest {
 
 	@Mock
 	private QuestionPostRepository questionPostRepository;
+
+	@Mock
+	private InteractionCountRepository interactionCountRepository;
 
 	@InjectMocks
 	private QuestionPostService questionPostService;
@@ -53,7 +61,7 @@ class QuestionPostServiceTest {
 			.willReturn(questionPost);
 
 		//when
-		QuestionPostDetailResponse response = questionPostService.registerQuestionPost(request, member);
+		RegisterQuestionPostResponse response = questionPostService.registerQuestionPost(request, member);
 
 		//then
 		assertAll(
@@ -64,18 +72,72 @@ class QuestionPostServiceTest {
 		);
 	}
 
-	@DisplayName("[질문글 아이디로 질문글을 상세 조회할 수 있다.]")
+	@DisplayName("[질문글 아이디로 질문글을 상세 조회할 수 있다. 상호작용 이력 존재x]")
 	@Test
-	void getQuestionPostById() {
+	void getQuestionPostById_noInteraction() {
 		//given
-		QuestionPost questionPost = QuestionPostFixture.questionPost(1L);
-		given(questionPostRepository.findById(1L))
+		Long questionPostId = 1L;
+		QuestionPost questionPost = QuestionPostFixture.questionPost(questionPostId);
+		given(questionPostRepository.findById(questionPostId))
 			.willReturn(Optional.of(questionPost));
+
+		given(interactionCountRepository.findByQuestionPostIdAndType(
+			questionPostId,
+			InteractionType.RECOMMEND
+		)).willReturn(Optional.empty());
+
+		given(interactionCountRepository.findByQuestionPostIdAndType(
+			questionPostId,
+			InteractionType.SAVED
+		)).willReturn(Optional.empty());
+
 		//when
-		QuestionPostDetailResponse response = questionPostService.getQuestionPostById(questionPost.getId());
+		QuestionPostDetailResponse response
+			= questionPostService.getQuestionPostById(questionPost.getId());
 
 		//then
-		assertThat(response.questionPostId()).isEqualTo(questionPost.getId());
+		assertAll(
+			() -> assertThat(response.questionPostId()).isEqualTo(questionPost.getId()),
+			() -> assertThat(response.recommendCount()).isZero(),
+			() -> assertThat(response.savedCount()).isZero()
+		);
 	}
 
+	@DisplayName("[질문글 아이디로 질문글을 상세 조회할 수 있다. 상호작용 이력 존재]")
+	@Test
+	void getQuestionPostById_interaction() {
+		//given
+		Long questionPostId = 1L;
+		QuestionPost questionPost = QuestionPostFixture.questionPost(questionPostId);
+		given(questionPostRepository.findById(questionPostId))
+			.willReturn(Optional.of(questionPost));
+
+		InteractionCount recommendCount
+			= InteractionCountFixture.interactionCount(InteractionType.RECOMMEND, questionPostId);
+		InteractionCount savedCount
+			= InteractionCountFixture.interactionCount(InteractionType.SAVED, questionPostId);
+
+		given(interactionCountRepository.findByQuestionPostIdAndType(
+			questionPostId,
+			InteractionType.RECOMMEND
+		)).willReturn(Optional.of(recommendCount));
+
+		given(interactionCountRepository.findByQuestionPostIdAndType(
+			questionPostId,
+			InteractionType.SAVED
+		)).willReturn(Optional.of(savedCount));
+
+		//when
+		QuestionPostDetailResponse response
+			= questionPostService.getQuestionPostById(questionPost.getId());
+		//then
+		assertAll(
+			() -> assertThat(response.questionPostId())
+				.isEqualTo(questionPost.getId()),
+			() -> assertThat(response.recommendCount())
+				.isEqualTo(recommendCount.getTotalCount()).isEqualTo(1),
+			() -> assertThat(response.savedCount())
+				.isEqualTo(savedCount.getTotalCount()).isEqualTo(1)
+		);
+	}
 }


### PR DESCRIPTION
### 관련 이슈
- close #45 

### 📑 작업 상세 내용
- 질문글 등록 API, 상세 조회 API 모두 detailResponse를 썼는데 dto를 하나 추가하여 API 별로 분리
- service 내에 게시글 수 조회 로직 추가
  -  조회 o -> getTotalCount()
  - 조회 x -> 0 반환

### 💫 작업 요약
- detailResponse에 추천수, 북마크수 필드 추가