### PR TITLE
[feat #42] 스크랩 목록 조회 API

### DIFF
--- a/src/main/java/com/dnd/gongmuin/member/controller/MemberController.java
+++ b/src/main/java/com/dnd/gongmuin/member/controller/MemberController.java
@@ -13,6 +13,7 @@ import com.dnd.gongmuin.common.dto.PageResponse;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.dto.request.UpdateMemberProfileRequest;
 import com.dnd.gongmuin.member.dto.response.AnsweredQuestionPostsByMemberResponse;
+import com.dnd.gongmuin.member.dto.response.BookmarksByMemberResponse;
 import com.dnd.gongmuin.member.dto.response.MemberProfileResponse;
 import com.dnd.gongmuin.member.dto.response.QuestionPostsByMemberResponse;
 import com.dnd.gongmuin.member.service.MemberService;
@@ -70,6 +71,18 @@ public class MemberController {
 		Pageable pageable) {
 		PageResponse<AnsweredQuestionPostsByMemberResponse> response =
 			memberService.getAnsweredQuestionPostsByMember(member, pageable);
+
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "스크랩 질문 전체 조회 API", description = "스크랩한 질문을 전체 조회한다.")
+	@ApiResponse(useReturnTypeSchema = true)
+	@GetMapping("/post-interaction/bookmarks")
+	public ResponseEntity<PageResponse<BookmarksByMemberResponse>> getBookmarksByMember(
+		@AuthenticationPrincipal Member member,
+		Pageable pageable) {
+		PageResponse<BookmarksByMemberResponse> response =
+			memberService.getBookmarksByMember(member, pageable);
 
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/com/dnd/gongmuin/member/controller/MemberController.java
+++ b/src/main/java/com/dnd/gongmuin/member/controller/MemberController.java
@@ -65,7 +65,7 @@ public class MemberController {
 
 	@Operation(summary = "댓글 단 질문 전체 조회 API", description = "댓글 단 질문을 전체 조회한다.")
 	@ApiResponse(useReturnTypeSchema = true)
-	@GetMapping("/answer-posts")
+	@GetMapping("/question-posts/answers")
 	public ResponseEntity<PageResponse<AnsweredQuestionPostsByMemberResponse>> getAnsweredQuestionPostsByMember(
 		@AuthenticationPrincipal Member member,
 		Pageable pageable) {
@@ -77,7 +77,7 @@ public class MemberController {
 
 	@Operation(summary = "스크랩 질문 전체 조회 API", description = "스크랩한 질문을 전체 조회한다.")
 	@ApiResponse(useReturnTypeSchema = true)
-	@GetMapping("/post-interaction/bookmarks")
+	@GetMapping("/question-posts/bookmarks")
 	public ResponseEntity<PageResponse<BookmarksByMemberResponse>> getBookmarksByMember(
 		@AuthenticationPrincipal Member member,
 		Pageable pageable) {

--- a/src/main/java/com/dnd/gongmuin/member/dto/response/AnsweredQuestionPostsByMemberResponse.java
+++ b/src/main/java/com/dnd/gongmuin/member/dto/response/AnsweredQuestionPostsByMemberResponse.java
@@ -1,7 +1,6 @@
 package com.dnd.gongmuin.member.dto.response;
 
 import com.dnd.gongmuin.answer.domain.Answer;
-import com.dnd.gongmuin.post_interaction.domain.InteractionCount;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.querydsl.core.annotations.QueryProjection;
 
@@ -23,8 +22,8 @@ public record AnsweredQuestionPostsByMemberResponse(
 	@QueryProjection
 	public AnsweredQuestionPostsByMemberResponse(
 		QuestionPost questionPost,
-		InteractionCount savedCount,
-		InteractionCount recommendCount,
+		int savedTotalCount,
+		int recommendTotalCount,
 		Answer answer) {
 		this(
 			questionPost.getId(),
@@ -34,15 +33,11 @@ public record AnsweredQuestionPostsByMemberResponse(
 			questionPost.getReward(),
 			questionPost.getUpdatedAt().toString(),
 			questionPost.getIsChosen(),
-			extractTotalCount(savedCount),
-			extractTotalCount(recommendCount),
+			savedTotalCount,
+			recommendTotalCount,
 			answer.getId(),
 			answer.getContent(),
 			answer.getUpdatedAt().toString()
 		);
-	}
-
-	private static int extractTotalCount(InteractionCount interactionCount) {
-		return interactionCount != null ? interactionCount.getCount() : 0;
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/member/dto/response/BookmarksByMemberResponse.java
+++ b/src/main/java/com/dnd/gongmuin/member/dto/response/BookmarksByMemberResponse.java
@@ -1,0 +1,40 @@
+package com.dnd.gongmuin.member.dto.response;
+
+import com.dnd.gongmuin.post_interaction.domain.InteractionCount;
+import com.dnd.gongmuin.question_post.domain.QuestionPost;
+import com.querydsl.core.annotations.QueryProjection;
+
+public record BookmarksByMemberResponse(
+	Long questionPostId,
+	String title,
+	String content,
+	String jobGroup,
+	int reward,
+	String updatedAt,
+	boolean isChosen,
+	int savedTotalCount,
+	int recommendTotalCount
+) {
+	@QueryProjection
+	public BookmarksByMemberResponse(
+		QuestionPost questionPost,
+		InteractionCount savedCount,
+		InteractionCount recommendCount
+	) {
+		this(
+			questionPost.getId(),
+			questionPost.getTitle(),
+			questionPost.getContent(),
+			questionPost.getJobGroup().getLabel(),
+			questionPost.getReward(),
+			questionPost.getUpdatedAt().toString(),
+			questionPost.getIsChosen(),
+			extractTotalCount(savedCount),
+			extractTotalCount(recommendCount)
+		);
+	}
+
+	private static int extractTotalCount(InteractionCount interactionCount) {
+		return interactionCount != null ? interactionCount.getCount() : 0;
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/member/dto/response/BookmarksByMemberResponse.java
+++ b/src/main/java/com/dnd/gongmuin/member/dto/response/BookmarksByMemberResponse.java
@@ -1,6 +1,5 @@
 package com.dnd.gongmuin.member.dto.response;
 
-import com.dnd.gongmuin.post_interaction.domain.InteractionCount;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.querydsl.core.annotations.QueryProjection;
 
@@ -18,8 +17,8 @@ public record BookmarksByMemberResponse(
 	@QueryProjection
 	public BookmarksByMemberResponse(
 		QuestionPost questionPost,
-		InteractionCount savedCount,
-		InteractionCount recommendCount
+		int savedTotalCount,
+		int recommendTotalCount
 	) {
 		this(
 			questionPost.getId(),
@@ -29,12 +28,8 @@ public record BookmarksByMemberResponse(
 			questionPost.getReward(),
 			questionPost.getUpdatedAt().toString(),
 			questionPost.getIsChosen(),
-			extractTotalCount(savedCount),
-			extractTotalCount(recommendCount)
+			savedTotalCount,
+			recommendTotalCount
 		);
-	}
-
-	private static int extractTotalCount(InteractionCount interactionCount) {
-		return interactionCount != null ? interactionCount.getCount() : 0;
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/member/dto/response/QuestionPostsByMemberResponse.java
+++ b/src/main/java/com/dnd/gongmuin/member/dto/response/QuestionPostsByMemberResponse.java
@@ -1,6 +1,5 @@
 package com.dnd.gongmuin.member.dto.response;
 
-import com.dnd.gongmuin.post_interaction.domain.InteractionCount;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.querydsl.core.annotations.QueryProjection;
 
@@ -19,8 +18,8 @@ public record QuestionPostsByMemberResponse(
 	@QueryProjection
 	public QuestionPostsByMemberResponse(
 		QuestionPost questionPost,
-		InteractionCount savedCount,
-		InteractionCount recommendCount
+		int savedTotalCount,
+		int recommendTotalCount
 	) {
 		this(
 			questionPost.getId(),
@@ -30,13 +29,8 @@ public record QuestionPostsByMemberResponse(
 			questionPost.getReward(),
 			questionPost.getUpdatedAt().toString(),
 			questionPost.getIsChosen(),
-			extractTotalCount(savedCount),
-			extractTotalCount(recommendCount)
+			savedTotalCount,
+			recommendTotalCount
 		);
 	}
-
-	private static int extractTotalCount(InteractionCount interactionCount) {
-		return interactionCount != null ? interactionCount.getCount() : 0;
-	}
-
 }

--- a/src/main/java/com/dnd/gongmuin/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/member/exception/MemberErrorCode.java
@@ -14,9 +14,7 @@ public enum MemberErrorCode implements ErrorCode {
 	LOGOUT_FAILED("로그아웃을 실패했습니다.", "MEMBER_003"),
 	NOT_ENOUGH_CREDIT("보유한 크레딧이 부족합니다.", "MEMBER_004"),
 	UPDATE_PROFILE_FAILED("프로필 수정에 실패했습니다.", "MEMBER_005"),
-	QUESTION_POSTS_BY_MEMBER_FAILED("작성한 게시글 목록을 찾는 도중 실패했습니다.", "MEMBER_006"),
-	ANSWERED_QUESTION_POSTS_BY_MEMBER_FAILED("댓글 단 게시글 목록을 찾는 도중 실패했습니다.", "MEMBER_007"),
-	BOOKMARK_QUESTION_POSTS_BY_MEMBER_FAILED("스크랩 한 게시글 목록을 찾는 도중 실패했씁니다.", "MEMBER_008");
+	QUESTION_POSTS_BY_MEMBER_FAILED("마이페이지 게시글 목록을 불러오는데 실패했습니다", "MEMBER_006");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/member/exception/MemberErrorCode.java
@@ -15,7 +15,8 @@ public enum MemberErrorCode implements ErrorCode {
 	NOT_ENOUGH_CREDIT("보유한 크레딧이 부족합니다.", "MEMBER_004"),
 	UPDATE_PROFILE_FAILED("프로필 수정에 실패했습니다.", "MEMBER_005"),
 	QUESTION_POSTS_BY_MEMBER_FAILED("작성한 게시글 목록을 찾는 도중 실패했습니다.", "MEMBER_006"),
-	ANSWERED_QUESTION_POSTS_BY_MEMBER_FAILED("댓글 단 게시글 목록을 찾는 도중 실패했습니다.", "MEMBER_007");
+	ANSWERED_QUESTION_POSTS_BY_MEMBER_FAILED("댓글 단 게시글 목록을 찾는 도중 실패했습니다.", "MEMBER_007"),
+	BOOKMARK_QUESTION_POSTS_BY_MEMBER_FAILED("스크랩 한 게시글 목록을 찾는 도중 실패했씁니다.", "MEMBER_008");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/member/repository/MemberCustom.java
+++ b/src/main/java/com/dnd/gongmuin/member/repository/MemberCustom.java
@@ -5,10 +5,13 @@ import org.springframework.data.domain.Slice;
 
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.dto.response.AnsweredQuestionPostsByMemberResponse;
+import com.dnd.gongmuin.member.dto.response.BookmarksByMemberResponse;
 import com.dnd.gongmuin.member.dto.response.QuestionPostsByMemberResponse;
 
 public interface MemberCustom {
 	Slice<QuestionPostsByMemberResponse> getQuestionPostsByMember(Member member, Pageable pageable);
 
 	Slice<AnsweredQuestionPostsByMemberResponse> getAnsweredQuestionPostsByMember(Member member, Pageable pageable);
+
+	Slice<BookmarksByMemberResponse> getBookmarksByMember(Member member, Pageable pageable);
 }

--- a/src/main/java/com/dnd/gongmuin/member/repository/MemberCustomImpl.java
+++ b/src/main/java/com/dnd/gongmuin/member/repository/MemberCustomImpl.java
@@ -35,7 +35,11 @@ public class MemberCustomImpl implements MemberCustom {
 		QInteractionCount recommend = new QInteractionCount("RECOMMEND");
 
 		List<QuestionPostsByMemberResponse> content = queryFactory
-			.select(new QQuestionPostsByMemberResponse(qp, saved, recommend))
+			.select(new QQuestionPostsByMemberResponse(
+				qp,
+				saved.count.coalesce(0).as("savedTotalCount"),
+				recommend.count.coalesce(0).as("recommendTotalCount")
+			))
 			.from(qp)
 			.leftJoin(saved)
 			.on(qp.id.eq(saved.questionPostId).and(saved.type.eq(InteractionType.SAVED)))
@@ -63,7 +67,12 @@ public class MemberCustomImpl implements MemberCustom {
 
 		List<AnsweredQuestionPostsByMemberResponse> content =
 			queryFactory
-				.select(new QAnsweredQuestionPostsByMemberResponse(qp, saved, recommend, aw1))
+				.select(new QAnsweredQuestionPostsByMemberResponse(
+					qp,
+					saved.count.coalesce(0).as("savedTotalCount"),
+					recommend.count.coalesce(0).as("recommendTotalCount"),
+					aw1
+				))
 				.from(qp)
 				.join(aw1)
 				.on(aw1.id.eq(
@@ -102,7 +111,11 @@ public class MemberCustomImpl implements MemberCustom {
 		QInteractionCount recommend = new QInteractionCount("RECOMMEND");
 
 		List<BookmarksByMemberResponse> content = queryFactory
-			.select(new QBookmarksByMemberResponse(qp, saved, recommend))
+			.select(new QBookmarksByMemberResponse(
+				qp,
+				saved.count.coalesce(0).as("savedTotalCount"),
+				recommend.count.coalesce(0).as("recommendTotalCount")
+			))
 			.from(qp)
 			.join(ir)
 			.on(qp.id.eq(ir.questionPostId).and(ir.type.eq(InteractionType.SAVED)))

--- a/src/main/java/com/dnd/gongmuin/member/repository/MemberCustomImpl.java
+++ b/src/main/java/com/dnd/gongmuin/member/repository/MemberCustomImpl.java
@@ -42,7 +42,7 @@ public class MemberCustomImpl implements MemberCustom {
 			.leftJoin(recommend)
 			.on(qp.id.eq(recommend.questionPostId).and(recommend.type.eq(InteractionType.RECOMMEND)))
 			.where(qp.member.eq(member))
-			.orderBy(qp.updatedAt.desc())
+			.orderBy(qp.createdAt.desc())
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize() + 1L)
 			.fetch();
@@ -84,7 +84,7 @@ public class MemberCustomImpl implements MemberCustom {
 				.on(qp.id.eq(saved.questionPostId).and(saved.type.eq(InteractionType.SAVED)))
 				.leftJoin(recommend)
 				.on(qp.id.eq(recommend.questionPostId).and(recommend.type.eq(InteractionType.RECOMMEND)))
-				.orderBy(qp.updatedAt.desc())
+				.orderBy(qp.createdAt.desc())
 				.offset(pageable.getOffset())
 				.limit(pageable.getPageSize() + 1L)
 				.fetch();
@@ -111,7 +111,7 @@ public class MemberCustomImpl implements MemberCustom {
 			.leftJoin(recommend)
 			.on(qp.id.eq(recommend.questionPostId).and(recommend.type.eq(InteractionType.RECOMMEND)))
 			.where(ir.memberId.eq(member.getId()))
-			.orderBy(qp.updatedAt.desc())
+			.orderBy(qp.createdAt.desc())
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize() + 1L)
 			.fetch();

--- a/src/main/java/com/dnd/gongmuin/member/service/MemberService.java
+++ b/src/main/java/com/dnd/gongmuin/member/service/MemberService.java
@@ -217,7 +217,7 @@ public class MemberService {
 
 			return PageMapper.toPageResponse(responsePage);
 		} catch (Exception e) {
-			throw new NotFoundException(MemberErrorCode.ANSWERED_QUESTION_POSTS_BY_MEMBER_FAILED);
+			throw new NotFoundException(MemberErrorCode.QUESTION_POSTS_BY_MEMBER_FAILED);
 		}
 	}
 
@@ -229,7 +229,7 @@ public class MemberService {
 
 			return PageMapper.toPageResponse(responsePage);
 		} catch (Exception e) {
-			throw new NotFoundException(MemberErrorCode.BOOKMARK_QUESTION_POSTS_BY_MEMBER_FAILED);
+			throw new NotFoundException(MemberErrorCode.QUESTION_POSTS_BY_MEMBER_FAILED);
 		}
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/member/service/MemberService.java
+++ b/src/main/java/com/dnd/gongmuin/member/service/MemberService.java
@@ -226,7 +226,7 @@ public class MemberService {
 		try {
 			Slice<BookmarksByMemberResponse> responsePage =
 				memberRepository.getBookmarksByMember(member, pageable);
-			
+
 			return PageMapper.toPageResponse(responsePage);
 		} catch (Exception e) {
 			throw new NotFoundException(MemberErrorCode.BOOKMARK_QUESTION_POSTS_BY_MEMBER_FAILED);

--- a/src/main/java/com/dnd/gongmuin/member/service/MemberService.java
+++ b/src/main/java/com/dnd/gongmuin/member/service/MemberService.java
@@ -26,6 +26,7 @@ import com.dnd.gongmuin.member.dto.request.ReissueRequest;
 import com.dnd.gongmuin.member.dto.request.UpdateMemberProfileRequest;
 import com.dnd.gongmuin.member.dto.request.ValidateNickNameRequest;
 import com.dnd.gongmuin.member.dto.response.AnsweredQuestionPostsByMemberResponse;
+import com.dnd.gongmuin.member.dto.response.BookmarksByMemberResponse;
 import com.dnd.gongmuin.member.dto.response.LogoutResponse;
 import com.dnd.gongmuin.member.dto.response.MemberProfileResponse;
 import com.dnd.gongmuin.member.dto.response.QuestionPostsByMemberResponse;
@@ -217,6 +218,18 @@ public class MemberService {
 			return PageMapper.toPageResponse(responsePage);
 		} catch (Exception e) {
 			throw new NotFoundException(MemberErrorCode.ANSWERED_QUESTION_POSTS_BY_MEMBER_FAILED);
+		}
+	}
+
+	public PageResponse<BookmarksByMemberResponse> getBookmarksByMember(
+		Member member, Pageable pageable) {
+		try {
+			Slice<BookmarksByMemberResponse> responsePage =
+				memberRepository.getBookmarksByMember(member, pageable);
+			
+			return PageMapper.toPageResponse(responsePage);
+		} catch (Exception e) {
+			throw new NotFoundException(MemberErrorCode.BOOKMARK_QUESTION_POSTS_BY_MEMBER_FAILED);
 		}
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/common/fixture/InteractionFixture.java
+++ b/src/test/java/com/dnd/gongmuin/common/fixture/InteractionFixture.java
@@ -24,4 +24,17 @@ public class InteractionFixture {
 		ReflectionTestUtils.setField(interaction, "id", 1L);
 		return interaction;
 	}
+
+	public static Interaction interaction2(
+		InteractionType type,
+		Long memberId,
+		Long questionPostId
+	) {
+		Interaction interaction = Interaction.of(
+			type,
+			memberId,
+			questionPostId
+		);
+		return interaction;
+	}
 }

--- a/src/test/java/com/dnd/gongmuin/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/member/controller/MemberControllerTest.java
@@ -158,7 +158,7 @@ class MemberControllerTest extends ApiTestSupport {
 		answerRepository.save(answer2);
 
 		// when  // then
-		mockMvc.perform(get("/api/members/answer-posts")
+		mockMvc.perform(get("/api/members/question-posts/answers")
 				.header(AUTHORIZATION, accessToken)
 			)
 			.andExpect(status().isOk())
@@ -193,7 +193,7 @@ class MemberControllerTest extends ApiTestSupport {
 		interactionRepository.saveAll(List.of(interaction1, interaction2, interaction3, interaction4));
 
 		// when  // then
-		mockMvc.perform(get("/api/members/post-interaction/bookmarks")
+		mockMvc.perform(get("/api/members/question-posts/bookmarks")
 				.header(AUTHORIZATION, accessToken)
 			)
 			.andExpect(status().isOk())


### PR DESCRIPTION
### 관련 이슈
- close #42 

### 📑 작업 상세 내용
- 스크랩 목록 조회 API
  - QueryDSL 스크랩 목록 조회 작성
  - Repository/Controller Test 작성
- MemberRepository 테스트 내 검증 시 하드 코딩 부분 수정

### 💫 작업 요약
- 스크랩 목록 조회 API

### 🔍 중점적으로 리뷰 할 부분
- 스크랩 목록 조회 시 게시물 업데이트 기준으로 가져왔는데, 스크랩 기준으로 할까요?
- 내가 쓴 글 전체 조회 API와 응답 DTO가 동일한데, 재사용하려다가 따로 나눴습니다.
  - 스크랩 목록 조회 응답 DTO 필드로 더 필요한게 있는지 확인 부탁드립니다! 
