### PR TITLE
[feat #51] 질문 검색 결과에 북마크 수, 추천 수 추가

### DIFF
--- a/src/main/java/com/dnd/gongmuin/post_interaction/controller/InteractionController.java
+++ b/src/main/java/com/dnd/gongmuin/post_interaction/controller/InteractionController.java
@@ -12,14 +12,18 @@ import com.dnd.gongmuin.post_interaction.domain.InteractionType;
 import com.dnd.gongmuin.post_interaction.dto.InteractionResponse;
 import com.dnd.gongmuin.post_interaction.service.InteractionService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "상호작용 API")
 @RestController
 @RequiredArgsConstructor
 public class InteractionController {
 
 	private final InteractionService interactionService;
 
+	@Operation(summary = "상호작용 등록 API", description = "게시글을 추천하거나 북마크한다.")
 	@PostMapping("/api/question-posts/{questionPostId}/activated")
 	public ResponseEntity<InteractionResponse> activateInteraction(
 		@PathVariable("questionPostId") Long questionPostId,
@@ -34,6 +38,7 @@ public class InteractionController {
 		return ResponseEntity.ok(response);
 	}
 
+	@Operation(summary = "상호작용 등록 API", description = "게시글을 추천하거나 북마크 취소한다.")
 	@PostMapping("/api/question-posts/{questionPostId}/inactivated")
 	public ResponseEntity<InteractionResponse> inactivateInteraction(
 		@PathVariable("questionPostId") Long questionPostId,

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
@@ -44,8 +44,8 @@ public class QuestionPostMapper {
 				member.getNickname(),
 				member.getJobGroup().getLabel()
 			),
-			recommendCount,
 			savedCount,
+			recommendCount,
 			questionPost.getCreatedAt().toString()
 		);
 	}

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
@@ -9,7 +9,6 @@ import com.dnd.gongmuin.question_post.domain.QuestionPostImage;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
-import com.dnd.gongmuin.question_post.dto.response.QuestionPostSimpleResponse;
 import com.dnd.gongmuin.question_post.dto.response.RegisterQuestionPostResponse;
 
 import lombok.AccessLevel;
@@ -69,18 +68,6 @@ public class QuestionPostMapper {
 				member.getJobGroup().getLabel()
 			),
 			questionPost.getCreatedAt().toString()
-		);
-	}
-
-	public static QuestionPostSimpleResponse toQuestionPostSimpleResponse(QuestionPost questionPost) {
-		return new QuestionPostSimpleResponse(
-			questionPost.getId(),
-			questionPost.getTitle(),
-			questionPost.getContent(),
-			questionPost.getJobGroup().getLabel(),
-			questionPost.getReward(),
-			questionPost.getCreatedAt().toString(),
-			questionPost.getIsChosen()
 		);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostDetailResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostDetailResponse.java
@@ -10,8 +10,8 @@ public record QuestionPostDetailResponse(
 	int reward,
 	String targetJobGroup,
 	MemberInfo memberInfo,
-	int recommendCount,
 	int savedCount,
+	int recommendCount,
 	String createdAt
 ) {
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostSimpleResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostSimpleResponse.java
@@ -1,6 +1,5 @@
 package com.dnd.gongmuin.question_post.dto.response;
 
-import com.dnd.gongmuin.post_interaction.domain.InteractionCount;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.querydsl.core.annotations.QueryProjection;
 
@@ -19,8 +18,8 @@ public record QuestionPostSimpleResponse(
 	@QueryProjection
 	public QuestionPostSimpleResponse(
 		QuestionPost questionPost,
-		InteractionCount savedCount,
-		InteractionCount recommendCount
+		int savedCount,
+		int recommendCount
 	) {
 		this(
 			questionPost.getId(),
@@ -30,12 +29,8 @@ public record QuestionPostSimpleResponse(
 			questionPost.getReward(),
 			questionPost.getCreatedAt().toString(),
 			questionPost.getIsChosen(),
-			getCount(savedCount),
-			getCount(recommendCount)
+			savedCount,
+			recommendCount
 		);
-	}
-
-	private static int getCount(InteractionCount interactionCount) {
-		return interactionCount != null ? interactionCount.getCount() : 0;
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostSimpleResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostSimpleResponse.java
@@ -1,5 +1,9 @@
 package com.dnd.gongmuin.question_post.dto.response;
 
+import com.dnd.gongmuin.post_interaction.domain.InteractionCount;
+import com.dnd.gongmuin.question_post.domain.QuestionPost;
+import com.querydsl.core.annotations.QueryProjection;
+
 public record QuestionPostSimpleResponse(
 	Long questionPostId,
 	String title,
@@ -7,7 +11,31 @@ public record QuestionPostSimpleResponse(
 	String jobGroup,
 	int reward,
 	String createdAt,
-	boolean isChosen
-	// TODO: 8/11/24 북마크 수, 추천수 추가
+	boolean isChosen,
+	int savedCount,
+	int recommendCount
 ) {
+
+	@QueryProjection
+	public QuestionPostSimpleResponse(
+		QuestionPost questionPost,
+		InteractionCount savedCount,
+		InteractionCount recommendCount
+	) {
+		this(
+			questionPost.getId(),
+			questionPost.getTitle(),
+			questionPost.getContent(),
+			questionPost.getJobGroup().getLabel(),
+			questionPost.getReward(),
+			questionPost.getCreatedAt().toString(),
+			questionPost.getIsChosen(),
+			getCount(savedCount),
+			getCount(recommendCount)
+		);
+	}
+
+	private static int getCount(InteractionCount interactionCount) {
+		return interactionCount != null ? interactionCount.getCount() : 0;
+	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepository.java
@@ -3,9 +3,9 @@ package com.dnd.gongmuin.question_post.repository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.dto.request.QuestionPostSearchCondition;
+import com.dnd.gongmuin.question_post.dto.response.QuestionPostSimpleResponse;
 
 public interface QuestionPostQueryRepository {
-	Slice<QuestionPost> searchQuestionPosts(QuestionPostSearchCondition condition, Pageable pageable);
+	Slice<QuestionPostSimpleResponse> searchQuestionPosts(QuestionPostSearchCondition condition, Pageable pageable);
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepository.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 
-public interface QuestionPostRepository extends JpaRepository<QuestionPost, Long> {
+public interface QuestionPostRepository extends JpaRepository<QuestionPost, Long>, QuestionPostQueryRepository {
 	boolean existsById(Long id);
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -22,7 +22,6 @@ import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostSimpleResponse;
 import com.dnd.gongmuin.question_post.dto.response.RegisterQuestionPostResponse;
 import com.dnd.gongmuin.question_post.exception.QuestionPostErrorCode;
-import com.dnd.gongmuin.question_post.repository.QuestionPostQueryRepository;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -32,7 +31,6 @@ import lombok.RequiredArgsConstructor;
 public class QuestionPostService {
 
 	private final QuestionPostRepository questionPostRepository;
-	private final QuestionPostQueryRepository questionPostQueryRepository;
 
 	private final InteractionCountRepository interactionCountRepository;
 
@@ -66,7 +64,7 @@ public class QuestionPostService {
 		QuestionPostSearchCondition condition,
 		Pageable pageable
 	) {
-		Slice<QuestionPostSimpleResponse> responsePage = questionPostQueryRepository
+		Slice<QuestionPostSimpleResponse> responsePage = questionPostRepository
 			.searchQuestionPosts(condition, pageable)
 			.map(QuestionPostMapper::toQuestionPostSimpleResponse);
 		return PageMapper.toPageResponse(responsePage);

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -65,8 +65,7 @@ public class QuestionPostService {
 		Pageable pageable
 	) {
 		Slice<QuestionPostSimpleResponse> responsePage = questionPostRepository
-			.searchQuestionPosts(condition, pageable)
-			.map(QuestionPostMapper::toQuestionPostSimpleResponse);
+			.searchQuestionPosts(condition, pageable);
 		return PageMapper.toPageResponse(responsePage);
 	}
 

--- a/src/test/java/com/dnd/gongmuin/common/fixture/InteractionCountFixture.java
+++ b/src/test/java/com/dnd/gongmuin/common/fixture/InteractionCountFixture.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 public class InteractionCountFixture {
 
 	public static InteractionCount interactionCount(
+		Long id,
 		InteractionType type,
 		Long questionPostId
 	) {
@@ -19,7 +20,17 @@ public class InteractionCountFixture {
 			type,
 			questionPostId
 		);
-		ReflectionTestUtils.setField(interactionCount, "id", 1L);
+		ReflectionTestUtils.setField(interactionCount, "id", id);
 		return interactionCount;
+	}
+
+	public static InteractionCount interactionCount(
+		InteractionType type,
+		Long questionPostId
+	) {
+		return InteractionCount.of(
+			type,
+			questionPostId
+		);
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/common/fixture/InteractionFixture.java
+++ b/src/test/java/com/dnd/gongmuin/common/fixture/InteractionFixture.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 public class InteractionFixture {
 
 	public static Interaction interaction(
+		Long id,
 		InteractionType type,
 		Long memberId,
 		Long questionPostId
@@ -21,7 +22,19 @@ public class InteractionFixture {
 			memberId,
 			questionPostId
 		);
-		ReflectionTestUtils.setField(interaction, "id", 1L);
+		ReflectionTestUtils.setField(interaction, "id",id);
 		return interaction;
+	}
+
+	public static Interaction interaction(
+		InteractionType type,
+		Long memberId,
+		Long questionPostId
+	) {
+		return Interaction.of(
+			type,
+			memberId,
+			questionPostId
+		);
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/common/fixture/InteractionFixture.java
+++ b/src/test/java/com/dnd/gongmuin/common/fixture/InteractionFixture.java
@@ -22,7 +22,7 @@ public class InteractionFixture {
 			memberId,
 			questionPostId
 		);
-		ReflectionTestUtils.setField(interaction, "id",id);
+		ReflectionTestUtils.setField(interaction, "id", id);
 		return interaction;
 	}
 

--- a/src/test/java/com/dnd/gongmuin/post_interaction/service/InteractionServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/post_interaction/service/InteractionServiceTest.java
@@ -114,9 +114,9 @@ class InteractionServiceTest {
 		//given
 		InteractionType type = InteractionType.RECOMMEND;
 		QuestionPost questionPost = QuestionPostFixture.questionPost(1L, questioner);
-		Interaction interaction = InteractionFixture.interaction(type, interactor.getId(),
+		Interaction interaction = InteractionFixture.interaction(1L, type, interactor.getId(),
 			questionPost.getId());
-		InteractionCount interactionCount = InteractionCountFixture.interactionCount(type,
+		InteractionCount interactionCount = InteractionCountFixture.interactionCount(1L, type,
 			interactor.getId());
 		interaction.updateIsInteracted(false);
 		interactionCount.decreaseCount();
@@ -150,9 +150,9 @@ class InteractionServiceTest {
 		//given
 		InteractionType type = InteractionType.RECOMMEND;
 		QuestionPost questionPost = QuestionPostFixture.questionPost(1L, questioner);
-		Interaction interaction = InteractionFixture.interaction(type, interactor.getId(),
+		Interaction interaction = InteractionFixture.interaction(1L, type, interactor.getId(),
 			questionPost.getId());
-		InteractionCount interactionCount = InteractionCountFixture.interactionCount(type,
+		InteractionCount interactionCount = InteractionCountFixture.interactionCount(1L, type,
 			interactor.getId());
 
 		given(interactionRepository.findByQuestionPostIdAndMemberIdAndType(

--- a/src/test/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepositoryTest.java
@@ -21,7 +21,7 @@ import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.dto.request.QuestionPostSearchCondition;
 
 @DisplayName("[질문글 동적 쿼리 테스트]")
-class QuestionPostQueryRepositoryImplTest extends DataJpaTestSupport {
+class QuestionPostRepositoryTest extends DataJpaTestSupport {
 
 	private final PageRequest pageRequest = PageRequest.of(0, 10);
 	private Member member;
@@ -31,9 +31,6 @@ class QuestionPostQueryRepositoryImplTest extends DataJpaTestSupport {
 
 	@Autowired
 	private QuestionPostRepository questionPostRepository;
-
-	@Autowired
-	private QuestionPostQueryRepository questionPostQueryRepository;
 
 	@BeforeEach
 	void setup() {
@@ -56,7 +53,7 @@ class QuestionPostQueryRepositoryImplTest extends DataJpaTestSupport {
 		);
 
 		//when
-		List<QuestionPost> questionPosts = questionPostQueryRepository
+		List<QuestionPost> questionPosts = questionPostRepository
 			.searchQuestionPosts(condition, pageRequest)
 			.getContent();
 
@@ -84,7 +81,7 @@ class QuestionPostQueryRepositoryImplTest extends DataJpaTestSupport {
 		);
 
 		//when
-		List<QuestionPost> questionPosts = questionPostQueryRepository
+		List<QuestionPost> questionPosts = questionPostRepository
 			.searchQuestionPosts(condition, pageRequest)
 			.getContent();
 
@@ -112,7 +109,7 @@ class QuestionPostQueryRepositoryImplTest extends DataJpaTestSupport {
 		);
 
 		//when
-		List<QuestionPost> questionPosts = questionPostQueryRepository
+		List<QuestionPost> questionPosts = questionPostRepository
 			.searchQuestionPosts(condition, pageRequest)
 			.getContent();
 

--- a/src/test/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepositoryTest.java
@@ -12,14 +12,25 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.dnd.gongmuin.common.fixture.InteractionCountFixture;
+import com.dnd.gongmuin.common.fixture.InteractionFixture;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
 import com.dnd.gongmuin.common.fixture.QuestionPostFixture;
 import com.dnd.gongmuin.common.support.DataJpaTestSupport;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.repository.MemberRepository;
+import com.dnd.gongmuin.post_interaction.domain.Interaction;
+import com.dnd.gongmuin.post_interaction.domain.InteractionCount;
+import com.dnd.gongmuin.post_interaction.domain.InteractionType;
+import com.dnd.gongmuin.post_interaction.repository.InteractionCountRepository;
+import com.dnd.gongmuin.post_interaction.repository.InteractionRepository;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.dto.request.QuestionPostSearchCondition;
+import com.dnd.gongmuin.question_post.dto.response.QuestionPostSimpleResponse;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @DisplayName("[질문글 동적 쿼리 테스트]")
 class QuestionPostRepositoryTest extends DataJpaTestSupport {
 
@@ -32,12 +43,18 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 	@Autowired
 	private QuestionPostRepository questionPostRepository;
 
+	@Autowired
+	private InteractionRepository interactionRepository;
+
+	@Autowired
+	private InteractionCountRepository interactionCountRepository;
+
 	@BeforeEach
 	void setup() {
 		member = memberRepository.save(MemberFixture.member());
 	}
 
-	@DisplayName("검색어로 필터링할 수 있다")
+	@DisplayName("검색어로 필터링할 수 있다.")
 	@Test
 	void question_post_search_filter() {
 		//given
@@ -53,18 +70,19 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 		);
 
 		//when
-		List<QuestionPost> questionPosts = questionPostRepository
+		List<QuestionPostSimpleResponse> responses = questionPostRepository
 			.searchQuestionPosts(condition, pageRequest)
 			.getContent();
 
 		//then
 		Assertions.assertAll(
-			() -> assertThat(questionPosts).hasSize(2),
-			() -> assertThat(questionPosts).containsExactly(questionPost1, questionPost2)
+			() -> assertThat(responses).hasSize(2),
+			() -> assertThat(responses.get(0).questionPostId()).isEqualTo(questionPost1.getId()),
+			() -> assertThat(responses.get(1).questionPostId()).isEqualTo(questionPost2.getId())
 		);
 	}
 
-	@DisplayName("[직군으로 질문글을 필터링할 수 있다.]")
+	@DisplayName("직군으로 질문글을 필터링할 수 있다.")
 	@Test
 	void question_post_jobgroup_filter() {
 		//given
@@ -81,18 +99,19 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 		);
 
 		//when
-		List<QuestionPost> questionPosts = questionPostRepository
+		List<QuestionPostSimpleResponse> responses = questionPostRepository
 			.searchQuestionPosts(condition, pageRequest)
 			.getContent();
 
 		//then
 		Assertions.assertAll(
-			() -> assertThat(questionPosts).hasSize(2),
-			() -> assertThat(questionPosts).containsExactly(questionPost1, questionPost2)
+			() -> assertThat(responses).hasSize(2),
+			() -> assertThat(responses.get(0).questionPostId()).isEqualTo(questionPost1.getId()),
+			() -> assertThat(responses.get(1).questionPostId()).isEqualTo(questionPost2.getId())
 		);
 	}
 
-	@DisplayName("[채택 여부로 질문글을 필터링할 수 있다.]")
+	@DisplayName("채택 여부로 질문글을 필터링할 수 있다.")
 	@Test
 	void question_post_ischosen_filter() {
 		//given
@@ -109,15 +128,54 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 		);
 
 		//when
-		List<QuestionPost> questionPosts = questionPostRepository
+		List<QuestionPostSimpleResponse> responses = questionPostRepository
 			.searchQuestionPosts(condition, pageRequest)
 			.getContent();
 
 		//then
 		Assertions.assertAll(
-			() -> assertThat(questionPosts).hasSize(1),
-			() -> assertThat(questionPosts).containsExactly(questionPost1)
+			() -> assertThat(responses).hasSize(1),
+			() -> assertThat(responses.get(0).questionPostId()).isEqualTo(questionPost1.getId())
 		);
+	}
+
+	@DisplayName("추천수, 저장수를 함께 조회할 수 있다.")
+	@Test
+	void question_post_join_interactionCount() {
+		//given
+		QuestionPost questionPost = QuestionPostFixture.questionPost(member);
+		questionPostRepository.save(questionPost);
+
+		QuestionPostSearchCondition condition = new QuestionPostSearchCondition(
+			null,
+			null,
+			null
+		);
+
+		interactPost(questionPost.getId(), InteractionType.SAVED);
+		interactPost(questionPost.getId(), InteractionType.RECOMMEND);
+
+		//when
+		List<QuestionPostSimpleResponse> responses = questionPostRepository
+			.searchQuestionPosts(condition, pageRequest)
+			.getContent();
+		System.out.println(responses);
+		//then
+		Assertions.assertAll(
+			() -> assertThat(responses).hasSize(1),
+			() -> assertThat(responses.get(0).questionPostId()).isEqualTo(questionPost.getId()),
+			() -> assertThat(responses.get(0).savedCount()).isEqualTo(1),
+			() -> assertThat(responses.get(0).recommendCount()).isEqualTo(1)
+		);
+	}
+
+	private void interactPost(Long questionPostId, InteractionType type){
+		Interaction interaction =
+			InteractionFixture.interaction(type, 2L, questionPostId);
+		interactionRepository.save(interaction);
+		InteractionCount interactionCount =
+			InteractionCountFixture.interactionCount(type, questionPostId);
+		interactionCountRepository.save(interactionCount);
 	}
 
 }

--- a/src/test/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepositoryTest.java
@@ -169,7 +169,7 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 		);
 	}
 
-	private void interactPost(Long questionPostId, InteractionType type){
+	private void interactPost(Long questionPostId, InteractionType type) {
 		Interaction interaction =
 			InteractionFixture.interaction(type, 2L, questionPostId);
 		interactionRepository.save(interaction);


### PR DESCRIPTION
### 관련 이슈
- close #51 

### 📑 작업 상세 내용
- 의존관계 변경 (queryRepository 의존하도록)
- queryProjection 사용해 dto 조회
- 조인 잘되는지 repository에서 테스트

### 💫 작업 요약
- dto로 querydsl 조회

### 🔍 중점적으로 리뷰 할 부분
- 북마크, 추천 수를 객체가 아닌 필드로 추출해서 dto에 매핑했습니다
  - coalesce를 사용하면 null일 때 0을 반환할 수 있더라고요!
