### PR TITLE
[feat #56] 질문글 수정 API

### DIFF
--- a/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
@@ -66,6 +66,8 @@ public class QuestionPostController {
 		return ResponseEntity.ok(response);
 	}
 
+	@Operation(summary = "질문글 추천 API", description = "직군에 맞는 질문글을 추천순으로 조회한다.")
+	@ApiResponse(useReturnTypeSchema = true)
 	@GetMapping("/api/question-posts/recommends")
 	public ResponseEntity<PageResponse<RecQuestionPostResponse>> getRecommendQuestionPosts(
 		@AuthenticationPrincipal Member member,

--- a/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -82,10 +83,10 @@ public class QuestionPostController {
 
 	@Operation(summary = "질문글 업데이트 API", description = "질문자가 질문글을 업데이트 한다.")
 	@ApiResponse(useReturnTypeSchema = true)
-	@GetMapping("/api/question-posts/{questionPostId}/edit")
+	@PatchMapping("/api/question-posts/{questionPostId}/edit")
 	public ResponseEntity<UpdateQuestionPostResponse> updateQuestionPosts(
 		@PathVariable("questionPostId") Long questionPostId,
-		UpdateQuestionPostRequest request
+		@Valid @RequestBody UpdateQuestionPostRequest request
 	) {
 		UpdateQuestionPostResponse response
 			= questionPostService.updateQuestionPost(questionPostId, request);

--- a/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
@@ -14,10 +14,12 @@ import com.dnd.gongmuin.common.dto.PageResponse;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.question_post.dto.request.QuestionPostSearchCondition;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
+import com.dnd.gongmuin.question_post.dto.request.UpdateQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostSimpleResponse;
 import com.dnd.gongmuin.question_post.dto.response.RecQuestionPostResponse;
 import com.dnd.gongmuin.question_post.dto.response.RegisterQuestionPostResponse;
+import com.dnd.gongmuin.question_post.dto.response.UpdateQuestionPostResponse;
 import com.dnd.gongmuin.question_post.service.QuestionPostService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -75,6 +77,18 @@ public class QuestionPostController {
 	) {
 		PageResponse<RecQuestionPostResponse> response
 			= questionPostService.getRecommendQuestionPosts(member, pageable);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "질문글 업데이트 API", description = "질문자가 질문글을 업데이트 한다.")
+	@ApiResponse(useReturnTypeSchema = true)
+	@GetMapping("/api/question-posts/{questionPostId}/edit")
+	public ResponseEntity<UpdateQuestionPostResponse> updateQuestionPosts(
+		@PathVariable("questionPostId") Long questionPostId,
+		UpdateQuestionPostRequest request
+	) {
+		UpdateQuestionPostResponse response
+			= questionPostService.updateQuestionPost(questionPostId, request);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
@@ -35,23 +35,30 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuestionPost extends TimeBaseEntity {
 
-	@OneToMany(mappedBy = "questionPost", cascade = CascadeType.ALL)
-	private final List<QuestionPostImage> images = new ArrayList<>();
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "question_post_id", nullable = false)
 	private Long id;
+
 	@Column(name = "title", nullable = false)
 	private String title;
+
 	@Column(name = "content", nullable = false)
 	private String content;
+
 	@Column(name = "reward", nullable = false)
 	private int reward;
+
 	@Enumerated(EnumType.STRING)
 	@Column(name = "job_group", nullable = false)
 	private JobGroup jobGroup;
+
 	@Column(name = "is_chosen", nullable = false)
 	private Boolean isChosen;
+
+	@OneToMany(mappedBy = "questionPost", cascade = CascadeType.ALL)
+	private List<QuestionPostImage> images = new ArrayList<>();
+
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "member_id",
 		nullable = false,
@@ -91,5 +98,21 @@ public class QuestionPost extends TimeBaseEntity {
 			throw new ValidationException(AnswerErrorCode.ALREADY_CHOSEN_ANSWER_EXISTS);
 		this.isChosen = true;
 		answer.updateIsChosen();
+	}
+
+	public void updateQuestionPost(
+		String title, String content, int reward, JobGroup jobGroup
+	) {
+		this.title = title;
+		this.content = content;
+		this.reward = reward;
+		this.jobGroup = jobGroup;
+	}
+
+	public void addPostImages(List<String> imageUrls) {
+		this.images = imageUrls.stream()
+			.map(QuestionPostImage::from)
+			.toList();
+		addImages(images);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
@@ -73,7 +73,7 @@ public class QuestionPost extends TimeBaseEntity {
 		this.reward = reward;
 		this.jobGroup = jobGroup;
 		this.member = member;
-		addImages(images);
+		initPostImages(images);
 	}
 
 	public static QuestionPost of(String title, String content, int reward, JobGroup jobGroup,
@@ -82,11 +82,25 @@ public class QuestionPost extends TimeBaseEntity {
 	}
 
 	//==양방향 편의 메서드==//
-	private void addImages(List<QuestionPostImage> images) {
+	private void initPostImages(List<QuestionPostImage> images) {
 		images.forEach(image -> {
 			this.images.add(image);
 			image.addQuestionPost(this);
 		});
+	}
+
+	public void updatePostImages(List<String> imageUrls) {
+		List<QuestionPostImage> questionPostImages = new ArrayList<>();
+		imageUrls.stream().map(QuestionPostImage::from)
+			.forEach(questionPostImage -> {
+				questionPostImage.addQuestionPost(this);
+				questionPostImages.add(questionPostImage);
+			});
+		this.images = questionPostImages;
+	}
+
+	public void clearPostImages() {
+		this.images.clear();
 	}
 
 	public boolean isQuestioner(Long memberId) {
@@ -107,12 +121,5 @@ public class QuestionPost extends TimeBaseEntity {
 		this.content = content;
 		this.reward = reward;
 		this.jobGroup = jobGroup;
-	}
-
-	public void addPostImages(List<String> imageUrls) {
-		this.images = imageUrls.stream()
-			.map(QuestionPostImage::from)
-			.toList();
-		addImages(images);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
@@ -11,6 +11,7 @@ import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.RegisterQuestionPostResponse;
+import com.dnd.gongmuin.question_post.dto.response.UpdateQuestionPostResponse;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -48,7 +49,7 @@ public class QuestionPostMapper {
 		);
 	}
 
-	public static RegisterQuestionPostResponse toQuestionPostDetailResponse(
+	public static RegisterQuestionPostResponse toRegisterQuestionPostResponse(
 		QuestionPost questionPost
 	) {
 		Member member = questionPost.getMember();
@@ -65,6 +66,19 @@ public class QuestionPostMapper {
 				member.getJobGroup().getLabel()
 			),
 			questionPost.getCreatedAt().toString()
+		);
+	}
+
+	public static UpdateQuestionPostResponse toUpdateQuestionPostResponse(
+		QuestionPost questionPost
+	) {
+		return new UpdateQuestionPostResponse(
+			questionPost.getId(),
+			questionPost.getTitle(),
+			questionPost.getContent(),
+			imagesToUrls(questionPost.getImages()),
+			questionPost.getReward(),
+			questionPost.getJobGroup().getLabel()
 		);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
@@ -1,5 +1,6 @@
 package com.dnd.gongmuin.question_post.dto;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.dnd.gongmuin.member.domain.JobGroup;
@@ -19,9 +20,7 @@ public class QuestionPostMapper {
 
 	public static QuestionPost toQuestionPost(RegisterQuestionPostRequest request, Member member) {
 		JobGroup jobGroup = JobGroup.from(request.targetJobGroup());
-		List<QuestionPostImage> images = request.imageUrls().stream()
-			.map(QuestionPostImage::from)
-			.toList();
+		List<QuestionPostImage> images = urlsToImages(request);
 		return QuestionPost.of(request.title(), request.content(), request.reward(), jobGroup, images, member);
 	}
 
@@ -35,8 +34,7 @@ public class QuestionPostMapper {
 			questionPost.getId(),
 			questionPost.getTitle(),
 			questionPost.getContent(),
-			questionPost.getImages().stream()
-				.map(QuestionPostImage::getImageUrl).toList(),
+			imagesToUrls(questionPost.getImages()),
 			questionPost.getReward(),
 			questionPost.getJobGroup().getLabel(),
 			new MemberInfo(
@@ -58,8 +56,7 @@ public class QuestionPostMapper {
 			questionPost.getId(),
 			questionPost.getTitle(),
 			questionPost.getContent(),
-			questionPost.getImages().stream()
-				.map(QuestionPostImage::getImageUrl).toList(),
+			imagesToUrls(questionPost.getImages()),
 			questionPost.getReward(),
 			questionPost.getJobGroup().getLabel(),
 			new MemberInfo(
@@ -69,5 +66,23 @@ public class QuestionPostMapper {
 			),
 			questionPost.getCreatedAt().toString()
 		);
+	}
+
+	private static List<QuestionPostImage> urlsToImages(RegisterQuestionPostRequest request) {
+		List<QuestionPostImage> images = null;
+		if (request.imageUrls() != null) {
+			images = request.imageUrls().stream()
+				.map(QuestionPostImage::from)
+				.toList();
+		}
+		return images;
+	}
+
+	private static List<String> imagesToUrls(List<QuestionPostImage> images) {
+		if (images == null)
+			return Collections.emptyList();
+		return images.stream()
+			.map(QuestionPostImage::getImageUrl)
+			.toList();
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
@@ -1,5 +1,6 @@
 package com.dnd.gongmuin.question_post.dto;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -83,7 +84,7 @@ public class QuestionPostMapper {
 	}
 
 	private static List<QuestionPostImage> urlsToImages(RegisterQuestionPostRequest request) {
-		List<QuestionPostImage> images = null;
+		List<QuestionPostImage> images = new ArrayList<>();
 		if (request.imageUrls() != null) {
 			images = request.imageUrls().stream()
 				.map(QuestionPostImage::from)

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/request/RegisterQuestionPostRequest.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/request/RegisterQuestionPostRequest.java
@@ -20,15 +20,4 @@ public record RegisterQuestionPostRequest(
 	@NotBlank(message = "직군을 입력해주세요.")
 	String targetJobGroup
 ) {
-	public static RegisterQuestionPostRequest of(
-		String title,
-		String content,
-		List<String> imageUrls,
-		int reward,
-		String targetJobGroup
-	) {
-		return new RegisterQuestionPostRequest(
-			title, content, imageUrls, reward, targetJobGroup
-		);
-	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/request/UpdateQuestionPostRequest.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/request/UpdateQuestionPostRequest.java
@@ -1,0 +1,27 @@
+package com.dnd.gongmuin.question_post.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateQuestionPostRequest(
+
+	@Size(min = 2, max = 20, message = "제목은 2자 이상 20자 이하여야 합니다.")
+	String title,
+
+	@Size(min = 10, max = 200, message = "본문은 10자 이상 200자 이하여야 합니다.")
+	String content,
+
+	List<String> imageUrls,
+
+	@Min(value = 2_000, message = "리워드는 2000 이상이어야 합니다.")
+	@Max(value = 10_000, message = "리워드는 10000 이하여야 합니다.")
+	int reward,
+
+	@NotBlank(message = "직군을 입력해주세요.")
+	String targetJobGroup
+) {
+}

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/ModifyQuestionPostResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/ModifyQuestionPostResponse.java
@@ -1,0 +1,13 @@
+package com.dnd.gongmuin.question_post.dto.response;
+
+import java.util.List;
+
+public record ModifyQuestionPostResponse(
+	Long questionPostId,
+	String title,
+	String content,
+	List<String> imageUrls,
+	int reward,
+	String targetJobGroup
+) {
+}

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/UpdateQuestionPostResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/UpdateQuestionPostResponse.java
@@ -2,7 +2,7 @@ package com.dnd.gongmuin.question_post.dto.response;
 
 import java.util.List;
 
-public record ModifyQuestionPostResponse(
+public record UpdateQuestionPostResponse(
 	Long questionPostId,
 	String title,
 	String content,

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostImageRepository.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostImageRepository.java
@@ -1,0 +1,10 @@
+package com.dnd.gongmuin.question_post.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dnd.gongmuin.question_post.domain.QuestionPost;
+import com.dnd.gongmuin.question_post.domain.QuestionPostImage;
+
+public interface QuestionPostImageRepository extends JpaRepository<QuestionPostImage, Long> {
+	void deleteByQuestionPost(QuestionPost questionPost);
+}

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -41,6 +41,15 @@ public class QuestionPostService {
 	private final InteractionCountRepository interactionCountRepository;
 	private final QuestionPostImageRepository questionPostImageRepository;
 
+	private static void updateQuestionPost(UpdateQuestionPostRequest request, QuestionPost questionPost) {
+		questionPost.updateQuestionPost(
+			request.title(),
+			request.content(),
+			request.reward(),
+			JobGroup.from(request.targetJobGroup())
+		);
+	}
+
 	@Transactional
 	public RegisterQuestionPostResponse registerQuestionPost(
 		RegisterQuestionPostRequest request,
@@ -105,15 +114,6 @@ public class QuestionPostService {
 				questionPost.updatePostImages(imageUrls);
 			}
 		}
-	}
-
-	private static void updateQuestionPost(UpdateQuestionPostRequest request, QuestionPost questionPost) {
-		questionPost.updateQuestionPost(
-			request.title(),
-			request.content(),
-			request.reward(),
-			JobGroup.from(request.targetJobGroup())
-		);
 	}
 
 	private void deleteImages(QuestionPost questionPost) {

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -38,7 +38,6 @@ import lombok.RequiredArgsConstructor;
 public class QuestionPostService {
 
 	private final QuestionPostRepository questionPostRepository;
-
 	private final InteractionCountRepository interactionCountRepository;
 	private final QuestionPostImageRepository questionPostImageRepository;
 
@@ -102,8 +101,8 @@ public class QuestionPostService {
 	private void updateQuestionPostImages(QuestionPost questionPost, List<String> imageUrls) {
 		if (imageUrls != null) { // 수정 사항 존재
 			deleteImages(questionPost); // 기존 이미지 객체 삭제 (새로 비우기 || 수정할 값 존재)
-			if (imageUrls.isEmpty()) { //수정할 값 담아보냄
-				questionPost.addPostImages(imageUrls);
+			if (!imageUrls.isEmpty()) { //수정할 값 담아보냄
+				questionPost.updatePostImages(imageUrls);
 			}
 		}
 	}
@@ -119,6 +118,7 @@ public class QuestionPostService {
 
 	private void deleteImages(QuestionPost questionPost) {
 		questionPostImageRepository.deleteByQuestionPost(questionPost);
+		questionPost.clearPostImages();
 	}
 
 	private int getCountByType(Long questionPostId, InteractionType type) {

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -1,5 +1,7 @@
 package com.dnd.gongmuin.question_post.service;
 
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -9,6 +11,7 @@ import com.dnd.gongmuin.common.dto.PageMapper;
 import com.dnd.gongmuin.common.dto.PageResponse;
 import com.dnd.gongmuin.common.exception.runtime.NotFoundException;
 import com.dnd.gongmuin.common.exception.runtime.ValidationException;
+import com.dnd.gongmuin.member.domain.JobGroup;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.exception.MemberErrorCode;
 import com.dnd.gongmuin.post_interaction.domain.InteractionCount;
@@ -18,11 +21,14 @@ import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.dto.QuestionPostMapper;
 import com.dnd.gongmuin.question_post.dto.request.QuestionPostSearchCondition;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
+import com.dnd.gongmuin.question_post.dto.request.UpdateQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostSimpleResponse;
 import com.dnd.gongmuin.question_post.dto.response.RecQuestionPostResponse;
 import com.dnd.gongmuin.question_post.dto.response.RegisterQuestionPostResponse;
+import com.dnd.gongmuin.question_post.dto.response.UpdateQuestionPostResponse;
 import com.dnd.gongmuin.question_post.exception.QuestionPostErrorCode;
+import com.dnd.gongmuin.question_post.repository.QuestionPostImageRepository;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -34,6 +40,7 @@ public class QuestionPostService {
 	private final QuestionPostRepository questionPostRepository;
 
 	private final InteractionCountRepository interactionCountRepository;
+	private final QuestionPostImageRepository questionPostImageRepository;
 
 	@Transactional
 	public RegisterQuestionPostResponse registerQuestionPost(
@@ -44,7 +51,7 @@ public class QuestionPostService {
 			throw new ValidationException(MemberErrorCode.NOT_ENOUGH_CREDIT);
 		}
 		QuestionPost questionPost = QuestionPostMapper.toQuestionPost(request, member);
-		return QuestionPostMapper.toQuestionPostDetailResponse(
+		return QuestionPostMapper.toRegisterQuestionPostResponse(
 			questionPostRepository.save(questionPost)
 		);
 	}
@@ -78,6 +85,40 @@ public class QuestionPostService {
 		Slice<RecQuestionPostResponse> responsePage
 			= questionPostRepository.getRecommendQuestionPosts(member.getJobGroup(), pageable);
 		return PageMapper.toPageResponse(responsePage);
+	}
+
+	@Transactional
+	public UpdateQuestionPostResponse updateQuestionPost(
+		Long questionPostId,
+		UpdateQuestionPostRequest request
+	) {
+		QuestionPost questionPost = questionPostRepository.findById(questionPostId)
+			.orElseThrow(() -> new NotFoundException(QuestionPostErrorCode.NOT_FOUND_QUESTION_POST));
+		updateQuestionPostImages(questionPost, request.imageUrls());
+		updateQuestionPost(request, questionPost);
+		return QuestionPostMapper.toUpdateQuestionPostResponse(questionPost);
+	}
+
+	private void updateQuestionPostImages(QuestionPost questionPost, List<String> imageUrls) {
+		if (imageUrls != null) { // 수정 사항 존재
+			deleteImages(questionPost); // 기존 이미지 객체 삭제 (새로 비우기 || 수정할 값 존재)
+			if (imageUrls.isEmpty()) { //수정할 값 담아보냄
+				questionPost.addPostImages(imageUrls);
+			}
+		}
+	}
+
+	private static void updateQuestionPost(UpdateQuestionPostRequest request, QuestionPost questionPost) {
+		questionPost.updateQuestionPost(
+			request.title(),
+			request.content(),
+			request.reward(),
+			JobGroup.from(request.targetJobGroup())
+		);
+	}
+
+	private void deleteImages(QuestionPost questionPost) {
+		questionPostImageRepository.deleteByQuestionPost(questionPost);
 	}
 
 	private int getCountByType(Long questionPostId, InteractionType type) {

--- a/src/test/java/com/dnd/gongmuin/common/fixture/QuestionPostFixture.java
+++ b/src/test/java/com/dnd/gongmuin/common/fixture/QuestionPostFixture.java
@@ -19,8 +19,8 @@ public class QuestionPostFixture {
 	public static QuestionPost questionPost(Member member) {
 		return QuestionPost.of(
 			"제목",
-			"내용",
-			1000,
+			"내용내용내용내용내용",
+			2000,
 			JobGroup.from("공업"),
 			List.of(
 				QuestionPostImage.from("image1.jpg"),

--- a/src/test/java/com/dnd/gongmuin/question_post/controller/QuestionPostControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/controller/QuestionPostControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.http.MediaType.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
@@ -18,6 +19,7 @@ import com.dnd.gongmuin.common.fixture.InteractionCountFixture;
 import com.dnd.gongmuin.common.fixture.InteractionFixture;
 import com.dnd.gongmuin.common.fixture.QuestionPostFixture;
 import com.dnd.gongmuin.common.support.ApiTestSupport;
+import com.dnd.gongmuin.member.domain.JobGroup;
 import com.dnd.gongmuin.member.exception.MemberErrorCode;
 import com.dnd.gongmuin.post_interaction.domain.Interaction;
 import com.dnd.gongmuin.post_interaction.domain.InteractionCount;
@@ -26,6 +28,7 @@ import com.dnd.gongmuin.post_interaction.repository.InteractionCountRepository;
 import com.dnd.gongmuin.post_interaction.repository.InteractionRepository;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
+import com.dnd.gongmuin.question_post.dto.request.UpdateQuestionPostRequest;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 
 @DisplayName("[QuestionPost 통합 테스트]")
@@ -208,6 +211,95 @@ class QuestionPostControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.content[0].questionPostId").value(questionPost3.getId()))
 			.andExpect(jsonPath("$.content[1].questionPostId").value(questionPost1.getId()))
 			.andExpect(jsonPath("$.content[2].questionPostId").value(questionPost2.getId()));
+	}
+
+	@DisplayName("[질문글 업데이트해 게시물 정보를 수정할 수 있다..]")
+	@Test
+	void updateQuestionPost() throws Exception {
+		QuestionPost questionPost = questionPostRepository.save(QuestionPostFixture.questionPost(loginMember));
+		UpdateQuestionPostRequest request = new UpdateQuestionPostRequest(
+			questionPost.getTitle(),
+			questionPost.getContent() + "ts",
+			null,
+			questionPost.getReward() + 1000,
+			JobGroup.ADMINISTRATION.getLabel()
+		);
+		mockMvc.perform(patch("/api/question-posts/{questionPostId}/edit", questionPost.getId())
+				.header(AUTHORIZATION, accessToken)
+				.content(toJson(request))
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.title").value(request.title()))
+			.andExpect(jsonPath("$.content").value(request.content()))
+			.andExpect(jsonPath("$.reward").value(request.reward()))
+			.andExpect(jsonPath("$.targetJobGroup").value(request.targetJobGroup()))
+			.andDo(MockMvcResultHandlers.print());
+	}
+
+	@DisplayName("[질문글 업데이트 시 이미지를 업데이트할 수 있다.]")
+	@Test
+	void updateQuestionPost_images() throws Exception {
+		QuestionPost questionPost = questionPostRepository.save(QuestionPostFixture.questionPost(loginMember));
+		List<String> updateImageUrls = List.of("img.url");
+		UpdateQuestionPostRequest request = new UpdateQuestionPostRequest(
+			questionPost.getTitle(),
+			questionPost.getContent(),
+			updateImageUrls,
+			3000,
+			questionPost.getJobGroup().getLabel()
+		);
+		mockMvc.perform(patch("/api/question-posts/{questionPostId}/edit", questionPost.getId())
+				.header(AUTHORIZATION, accessToken)
+				.content(toJson(request))
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.imageUrls[0]").value(updateImageUrls.get(0)))
+			.andExpect(jsonPath("$.imageUrls.length()").value(updateImageUrls.size()))
+			.andDo(MockMvcResultHandlers.print());
+	}
+
+	@DisplayName("[질문글 업데이트 시 이미지 필드가 null이면 변경 사항이 없다.]")
+	@Test
+	void updateQuestionPost_images_null() throws Exception {
+		QuestionPost questionPost = questionPostRepository.save(QuestionPostFixture.questionPost(loginMember));
+		UpdateQuestionPostRequest request = new UpdateQuestionPostRequest(
+			questionPost.getTitle(),
+			questionPost.getContent(),
+			null,
+			3000,
+			questionPost.getJobGroup().getLabel()
+		);
+		mockMvc.perform(patch("/api/question-posts/{questionPostId}/edit", questionPost.getId())
+				.header(AUTHORIZATION, accessToken)
+				.content(toJson(request))
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.imageUrls[0]")
+				.value(questionPost.getImages().get(0).getImageUrl()))
+			.andExpect(jsonPath("$.imageUrls[1]")
+				.value(questionPost.getImages().get(1).getImageUrl()))
+			.andDo(MockMvcResultHandlers.print());
+	}
+
+	@DisplayName("[질문글 업데이트 시 이미지 필드가 빈 리스트이면, 기존 이미지를 모두 지운다]")
+	@Test
+	void updateQuestionPost_images_empty() throws Exception {
+		QuestionPost questionPost = questionPostRepository.save(QuestionPostFixture.questionPost(loginMember));
+		UpdateQuestionPostRequest request = new UpdateQuestionPostRequest(
+			questionPost.getTitle(),
+			questionPost.getContent(),
+			Collections.emptyList(),
+			3000,
+			questionPost.getJobGroup().getLabel()
+		);
+		mockMvc.perform(patch("/api/question-posts/{questionPostId}/edit", questionPost.getId())
+				.header(AUTHORIZATION, accessToken)
+				.content(toJson(request))
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.imageUrls.length()")
+				.value(0))
+			.andDo(MockMvcResultHandlers.print());
 	}
 
 	private void interactPost(Long questionPostId, InteractionType type) {

--- a/src/test/java/com/dnd/gongmuin/question_post/controller/QuestionPostControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/controller/QuestionPostControllerTest.java
@@ -51,7 +51,7 @@ class QuestionPostControllerTest extends ApiTestSupport {
 	@DisplayName("[질문글을 등록할 수 있다.]")
 	@Test
 	void registerQuestionPost() throws Exception {
-		RegisterQuestionPostRequest request = RegisterQuestionPostRequest.of(
+		RegisterQuestionPostRequest request = new RegisterQuestionPostRequest(
 			"제목",
 			"정정기간에 여석이 있을까요?",
 			List.of("image1.jpg", "image2.jpg"),
@@ -82,7 +82,7 @@ class QuestionPostControllerTest extends ApiTestSupport {
 		loginMember.decreaseCredit(5000);
 		memberRepository.save(loginMember); // 크레딧
 
-		RegisterQuestionPostRequest request = RegisterQuestionPostRequest.of(
+		RegisterQuestionPostRequest request = new RegisterQuestionPostRequest(
 			"제목",
 			"정정기간에 여석이 있을까요?",
 			List.of("image1.jpg", "image2.jpg"),

--- a/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
@@ -49,7 +49,7 @@ class QuestionPostServiceTest {
 		//given
 		QuestionPost questionPost = QuestionPostFixture.questionPost(1L);
 		RegisterQuestionPostRequest request =
-			RegisterQuestionPostRequest.of(
+			new RegisterQuestionPostRequest(
 				"제목",
 				"내용",
 				List.of("image1.jpg", "image2.jpg"),

--- a/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
@@ -23,9 +23,13 @@ import com.dnd.gongmuin.post_interaction.domain.InteractionCount;
 import com.dnd.gongmuin.post_interaction.domain.InteractionType;
 import com.dnd.gongmuin.post_interaction.repository.InteractionCountRepository;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
+import com.dnd.gongmuin.question_post.domain.QuestionPostImage;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
+import com.dnd.gongmuin.question_post.dto.request.UpdateQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.RegisterQuestionPostResponse;
+import com.dnd.gongmuin.question_post.dto.response.UpdateQuestionPostResponse;
+import com.dnd.gongmuin.question_post.repository.QuestionPostImageRepository;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 
 @DisplayName("[QuestionPostService 테스트]")
@@ -36,6 +40,9 @@ class QuestionPostServiceTest {
 
 	@Mock
 	private QuestionPostRepository questionPostRepository;
+
+	@Mock
+	private QuestionPostImageRepository questionPostImageRepository;
 
 	@Mock
 	private InteractionCountRepository interactionCountRepository;
@@ -138,6 +145,42 @@ class QuestionPostServiceTest {
 				.isEqualTo(recommendCount.getCount()).isEqualTo(1),
 			() -> assertThat(response.savedCount())
 				.isEqualTo(savedCount.getCount()).isEqualTo(1)
+		);
+	}
+
+	@DisplayName("[질문글 업데이트를 할 수 있다.]")
+	@Test
+	void updateQuestionPost() {
+		//given
+		Long questionPostId = 1L;
+		QuestionPost questionPost = QuestionPostFixture.questionPost(member);
+		UpdateQuestionPostRequest request =
+			new UpdateQuestionPostRequest(
+				questionPost.getTitle() + "ㅇㅇㅇ",
+				questionPost.getContent(),
+				null,
+				questionPost.getReward() * 2,
+				"행정"
+			);
+
+		given(questionPostRepository.findById(questionPostId))
+			.willReturn(Optional.of(questionPost));
+
+		//when
+		UpdateQuestionPostResponse response
+			= questionPostService.updateQuestionPost(questionPostId, request);
+
+		//then
+		assertAll(
+			() -> assertThat(response.title())
+				.isEqualTo(request.title()),
+			() -> assertThat(response.reward())
+				.isEqualTo(request.reward()),
+			() -> assertThat(response.targetJobGroup())
+				.isEqualTo(request.targetJobGroup()),
+			() -> assertThat(response.imageUrls())
+				.isEqualTo(questionPost.getImages().stream()
+					.map(QuestionPostImage::getImageUrl).toList())
 		);
 	}
 }


### PR DESCRIPTION
### 관련 이슈
- close #56 

### 📑 작업 상세 내용
- 질문글 수정 API
- 이미지 업데이트 로직
  - i) 이미지 리스트 null -> 변경 사항 x
  - ii) 이미지 리스트 empty -> 기존 이미지 모두 삭제
  - iii) 이미지 리스트 not empty -> 기존 이미지 모두 삭제 후 리스트 값 넣기
 - 질문글 등록 시 image null로 등록 안되는 에러 
   - QuestionPostMapper에 null 검증 로직 추가 

### 💫 작업 요약
- 질문글 수정 API 설계 및 테스트
- image null로 등록 안되는 오류 해결

### 🔍 중점적으로 리뷰 할 부분
- 이미지 업데이트 서비스 로직
