### PR TITLE
[chore #63] Jacoco 세팅하기

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: 빌드
         run: ./gradlew build
 
-      - name: Jacoco 테스트 결과 출력
+      - name: Jacoco Test Coverage Report 코멘트에 등록
         id: jacoco
         uses: madrapps/jacoco-report@v1.6.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: madrapps/jacoco-report@v1.6.1
         with:
           title: Code Coverage
-          paths: ${{ github.workspace }}/**/build/reports/jacocoReport/test/jacocoTestReport.xml
+          paths: ${{ github.workspace }}/build/jacocoReport/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 60
           min-coverage-changed-files: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,26 +19,22 @@ jobs:
       - name: Check the timezone
         run: date
 
-      # 자바 버전 설정
-      - name: Set up JDK 17
+      - name: 자바 버전 17 설정
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
 
-      # test 경로 application.yml 파일 생성
-      - name: Generate application.yml
+      - name: test 경로 application.yml 파일 생성
         run: |
           mkdir -p ./src/test/resources
           echo "${{ secrets.TEST_APPLICATION_YML }}" > ./src/test/resources/application.yml
 
-      # gradle 권한 부여
-      - name: Grant execute permission for gradlew
+      - name: gradle 권한 부여
         run: chmod +x ./gradlew
         shell: bash
 
-      # 빌드 시 캐시 적용
-      - name: Gradle Caching
+      - name: 빌드 시 캐시 적용
         uses: actions/cache@v3
         with:
           path: |
@@ -48,19 +44,27 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # 빌드
-      - name: Build with Gradle
+      - name: 빌드
         run: ./gradlew build
 
-      # 테스트 결과 PR 코멘트에 등록
-      - name: Register the test results as PR comments
+      - name: Jacoco 테스트 결과 출력
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.6.1
+        with:
+          title: Code Coverage
+          paths: ${{ github.workspace }}/**/build/reports/jacocoReport/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 60
+          min-coverage-changed-files: 60
+          update-comment: true
+
+      - name: 테스트 결과 PR 코멘트에 등록
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           files: '**/build/test-results/test/TEST-*.xml'
 
-      # 테스트 실패시 코드 라인에 대한 체크 추가
-      - name: If test fail, add check comment on failed code line
+      - name: 테스트 실패시 코드 라인에 대한 체크 추가
         uses: mikepenz/action-junit-report@v3
         if: always()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,8 @@ jobs:
           title: Code Coverage
           paths: ${{ github.workspace }}/build/jacocoReport/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 60
-          min-coverage-changed-files: 60
+          min-coverage-overall: 65
+          min-coverage-changed-files: 65
           update-comment: true
 
       - name: 테스트 결과 PR 코멘트에 등록

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'LINE'
                 value = 'COVERERDRATIO'
-                minimum = 0.7
+                minimum = 0.65
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'LINE'
                 value = 'COVERERDRATIO'
-                minimum = 0.75
+                minimum = 0.7
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.8'
     id 'io.spring.dependency-management' version '1.1.6'
+    id 'jacoco'
 }
 
 group = 'com.dnd'
@@ -21,6 +22,67 @@ configurations {
 
 repositories {
     mavenCentral()
+}
+
+test {
+    useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+    reportsDirectory = layout.buildDirectory.dir('jacocoReport')
+}
+
+def QDomains = []
+
+for (qPattern in '**/QA'..'**/QZ') {
+    QDomains.add(qPattern + '*')
+}
+
+jacocoTestReport {
+    dependsOn test
+
+    classDirectories.setFrom(files(classDirectories.files.collect {
+        fileTree(dir: it, excludes: [
+                '**/*Application*',
+                '**/exception/**',
+                '**/config/**',
+                '**/dto/**',
+                '**/s3/**'
+        ] + QDomains)
+    }))
+
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+        csv.required.set(true)
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = 'CLASS'
+
+            limit {
+                counter = 'LINE'
+                value = 'COVERERDRATIO'
+                minimum = 0.75
+            }
+        }
+
+        rule {
+            excludes = [
+                    '**/*Application*',
+                    '**/exception/**',
+                    '**/config/**',
+                    '**/dto/**',
+                    '**/s3/**'
+            ] + QDomains
+        }
+    }
 }
 
 dependencies {
@@ -66,7 +128,7 @@ dependencies {
 
     // mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
-    
+
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,8 @@ jacocoTestReport {
                 '**/exception/**',
                 '**/config/**',
                 '**/dto/**',
-                '**/s3/**'
+                '**/s3/**',
+                '**/security/**'
         ] + QDomains)
     }))
 
@@ -79,7 +80,8 @@ jacocoTestCoverageVerification {
                     '**/exception/**',
                     '**/config/**',
                     '**/dto/**',
-                    '**/s3/**'
+                    '**/s3/**',
+                    '**/security/**'
             ] + QDomains
         }
     }

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
### 관련 이슈
- close #63 

### 📑 작업 상세 내용
- Jacoco 의존성 추가
- Jacoco 설정
  - 65% 커버리지 충족 못 시킬 경우 빌드 실패시키기
    - Application, exception, config, dto, s3, Q파일 제외하고 측정
- CI 시 Jacoco 테스트 커버리지 결과 등록하도록 CI 스크립트 수정

