### PR TITLE
[refactor #65] 소셜로그인 완료 후 리다이렉션 변경

### DIFF
--- a/src/main/java/com/dnd/gongmuin/security/handler/CustomOauth2SuccessHandler.java
+++ b/src/main/java/com/dnd/gongmuin/security/handler/CustomOauth2SuccessHandler.java
@@ -3,6 +3,7 @@ package com.dnd.gongmuin.security.handler;
 import java.io.IOException;
 import java.util.Date;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -29,6 +30,10 @@ public class CustomOauth2SuccessHandler implements AuthenticationSuccessHandler 
 	private final MemberRepository memberRepository;
 	private final TokenProvider tokenProvider;
 	private final CookieUtil cookieUtil;
+	@Value("${direct.sign-up}")
+	private String REDIRECTION_SIGNUP;
+	@Value("${direct.home}")
+	private String REDIRECTION_HOME;
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -46,9 +51,9 @@ public class CustomOauth2SuccessHandler implements AuthenticationSuccessHandler 
 		response.addCookie(cookieUtil.createCookie(token));
 
 		if (!isAuthStatusOld(findmember) && isRoleGuest(findmember.getRole())) {
-			response.sendRedirect("http://localhost:3000/signup");
+			response.sendRedirect(REDIRECTION_SIGNUP);
 		} else {
-			response.sendRedirect("http://localhost:3000/home");
+			response.sendRedirect(REDIRECTION_HOME);
 		}
 	}
 


### PR DESCRIPTION
**###** 관련 이슈
- close #65 

### 📑 작업 상세 내용
- 소셜로그인 완료 후 리다이렉션 변경
  - 무중단 변경을 위해 yml-@value 로 리다이렉션을 변경가능토록 수정

### 💫 작업 요약
- 소셜로그인 완료 후 리다이렉션 변경

### 🔍 중점적으로 리뷰 할 부분
-  yml 노션/git secret 인코딩 업데이트했습니다!
