### PR TITLE
[feat #67] Member에 프로필 이미지 번호 필드 추가

### DIFF
--- a/src/main/java/com/dnd/gongmuin/answer/dto/AnswerMapper.java
+++ b/src/main/java/com/dnd/gongmuin/answer/dto/AnswerMapper.java
@@ -34,7 +34,8 @@ public class AnswerMapper {
 			new MemberInfo(
 				member.getId(),
 				member.getNickname(),
-				member.getJobGroup().getLabel()
+				member.getJobGroup().getLabel(),
+				member.getProfileImageNo()
 			),
 			answer.getCreatedAt().toString()
 		);

--- a/src/main/java/com/dnd/gongmuin/member/domain/Member.java
+++ b/src/main/java/com/dnd/gongmuin/member/domain/Member.java
@@ -4,6 +4,7 @@ import static jakarta.persistence.EnumType.*;
 import static jakarta.persistence.GenerationType.*;
 import static lombok.AccessLevel.*;
 
+import java.util.Random;
 import com.dnd.gongmuin.common.entity.TimeBaseEntity;
 import com.dnd.gongmuin.common.exception.runtime.ValidationException;
 import com.dnd.gongmuin.member.exception.MemberErrorCode;
@@ -21,6 +22,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 public class Member extends TimeBaseEntity {
+
+	private final Random random = new Random();
 
 	@Id
 	@GeneratedValue(strategy = IDENTITY)
@@ -53,7 +56,10 @@ public class Member extends TimeBaseEntity {
 	@Column(name = "role", nullable = false)
 	private String role;
 
-	@Builder
+	@Column(name = "profile_image_no", nullable = false)
+	private final int profileImageNo = setRandomNumber();
+
+	@Builder(access = PRIVATE)
 	private Member(String nickname, String socialName, JobGroup jobGroup, JobCategory jobCategory, String socialEmail,
 		String officialEmail, int credit, String role) {
 		this.nickname = nickname;
@@ -127,4 +133,7 @@ public class Member extends TimeBaseEntity {
 		this.jobCategory = jobCategory;
 	}
 
+	private int setRandomNumber() {
+		return random.nextInt(1, 10);
+	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
@@ -42,7 +42,8 @@ public class QuestionPostMapper {
 			new MemberInfo(
 				member.getId(),
 				member.getNickname(),
-				member.getJobGroup().getLabel()
+				member.getJobGroup().getLabel(),
+				member.getProfileImageNo()
 			),
 			savedCount,
 			recommendCount,
@@ -64,7 +65,8 @@ public class QuestionPostMapper {
 			new MemberInfo(
 				member.getId(),
 				member.getNickname(),
-				member.getJobGroup().getLabel()
+				member.getJobGroup().getLabel(),
+				member.getProfileImageNo()
 			),
 			questionPost.getCreatedAt().toString()
 		);

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/MemberInfo.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/MemberInfo.java
@@ -3,7 +3,7 @@ package com.dnd.gongmuin.question_post.dto.response;
 public record MemberInfo(
 	Long memberId,
 	String nickname,
-	String memberJobGroup
-	// TODO: 추후 프로필 이미지 타입 추가
+	String memberJobGroup,
+	int profileImageNo
 ) {
 }

--- a/src/test/java/com/dnd/gongmuin/question_post/controller/QuestionPostControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/controller/QuestionPostControllerTest.java
@@ -1,5 +1,6 @@
 package com.dnd.gongmuin.question_post.controller;
 
+import static org.hamcrest.Matchers.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -118,9 +119,10 @@ class QuestionPostControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.memberInfo.memberId").value(questionPost.getMember().getId()))
 			.andExpect(jsonPath("$.memberInfo.nickname").value(questionPost.getMember().getNickname()))
 			.andExpect(jsonPath("$.memberInfo.memberJobGroup").value(questionPost.getMember().getJobGroup().getLabel()))
+			.andExpect(jsonPath("$.memberInfo.profileImageNo", is(greaterThanOrEqualTo(1))))
+			.andExpect(jsonPath("$.memberInfo.profileImageNo", is(lessThanOrEqualTo(9))))
 			.andExpect(jsonPath("$.recommendCount").value(0))
-			.andExpect(jsonPath("$.savedCount").value(0)
-			);
+			.andExpect(jsonPath("$.savedCount").value(0));
 	}
 
 	@DisplayName("[질문글을 키워드로 검색할 수 있다.]")


### PR DESCRIPTION
### 관련 이슈
- close #67

### 📑 작업 상세 내용
- member 엔티티에 profileImageNo 추가
  - Random 함수 사용해 1~9 번호 중 랜덤 부여
  - final로 정의하고자 필드 선언 부분에 대입
  - dto 반영 및 통합 테스트에서 검증