### PR TITLE
[feat #71] 질문 상세 조회에 상호작용 여부 필드 추가

### DIFF
--- a/src/main/java/com/dnd/gongmuin/member/domain/Member.java
+++ b/src/main/java/com/dnd/gongmuin/member/domain/Member.java
@@ -23,7 +23,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 public class Member extends TimeBaseEntity {
 
-	private final Random random = new Random();
 
 	@Id
 	@GeneratedValue(strategy = IDENTITY)
@@ -134,6 +133,7 @@ public class Member extends TimeBaseEntity {
 	}
 
 	private int setRandomNumber() {
+		Random random = new Random();
 		return random.nextInt(1, 10);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/post_interaction/repository/InteractionRepository.java
+++ b/src/main/java/com/dnd/gongmuin/post_interaction/repository/InteractionRepository.java
@@ -13,6 +13,10 @@ public interface InteractionRepository extends JpaRepository<Interaction, Long> 
 		Long questionPostId, Long memberId, InteractionType type
 	);
 
+	boolean existsByQuestionPostIdAndMemberIdAndTypeAndIsInteractedTrue(
+		Long questionPostId, Long memberId, InteractionType type
+	);
+
 	Optional<Interaction> findByQuestionPostIdAndMemberIdAndType(
 		Long questionPostId, Long memberId, InteractionType type
 	);

--- a/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
@@ -51,9 +51,11 @@ public class QuestionPostController {
 	@ApiResponse(useReturnTypeSchema = true)
 	@GetMapping("/api/question-posts/{questionPostId}")
 	public ResponseEntity<QuestionPostDetailResponse> getQuestionPostById(
-		@PathVariable("questionPostId") Long questionPostId
+		@PathVariable("questionPostId") Long questionPostId,
+		@AuthenticationPrincipal Member member
 	) {
-		QuestionPostDetailResponse response = questionPostService.getQuestionPostById(questionPostId);
+		QuestionPostDetailResponse response =
+			questionPostService.getQuestionPostById(questionPostId,member);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
@@ -28,8 +28,10 @@ public class QuestionPostMapper {
 
 	public static QuestionPostDetailResponse toQuestionPostDetailResponse(
 		QuestionPost questionPost,
-		int recommendCount,
-		int savedCount
+		boolean isSaved,
+		boolean isRecommended,
+		int savedCount,
+		int recommendCount
 	) {
 		Member member = questionPost.getMember();
 		return new QuestionPostDetailResponse(
@@ -45,6 +47,8 @@ public class QuestionPostMapper {
 				member.getJobGroup().getLabel(),
 				member.getProfileImageNo()
 			),
+			isSaved,
+			isRecommended,
 			savedCount,
 			recommendCount,
 			questionPost.getCreatedAt().toString()

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostDetailResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostDetailResponse.java
@@ -10,6 +10,8 @@ public record QuestionPostDetailResponse(
 	int reward,
 	String targetJobGroup,
 	MemberInfo memberInfo,
+	boolean isSaved,
+	boolean isRecommended,
 	int savedCount,
 	int recommendCount,
 	String createdAt

--- a/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
@@ -22,6 +22,7 @@ import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.post_interaction.domain.InteractionCount;
 import com.dnd.gongmuin.post_interaction.domain.InteractionType;
 import com.dnd.gongmuin.post_interaction.repository.InteractionCountRepository;
+import com.dnd.gongmuin.post_interaction.repository.InteractionRepository;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.domain.QuestionPostImage;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
@@ -36,13 +37,16 @@ import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 @ExtendWith(MockitoExtension.class)
 class QuestionPostServiceTest {
 
-	private final Member member = MemberFixture.member();
+	private final Member member = MemberFixture.member(1L);
 
 	@Mock
 	private QuestionPostRepository questionPostRepository;
 
 	@Mock
 	private QuestionPostImageRepository questionPostImageRepository;
+
+	@Mock
+	private InteractionRepository interactionRepository;
 
 	@Mock
 	private InteractionCountRepository interactionCountRepository;
@@ -88,19 +92,17 @@ class QuestionPostServiceTest {
 		given(questionPostRepository.findById(questionPostId))
 			.willReturn(Optional.of(questionPost));
 
-		given(interactionCountRepository.findByQuestionPostIdAndType(
-			questionPostId,
-			InteractionType.RECOMMEND
-		)).willReturn(Optional.empty());
+		given(interactionRepository
+			.existsByQuestionPostIdAndMemberIdAndTypeAndIsInteractedTrue(questionPostId, member.getId(), InteractionType.SAVED))
+			.willReturn(false);
 
-		given(interactionCountRepository.findByQuestionPostIdAndType(
-			questionPostId,
-			InteractionType.SAVED
-		)).willReturn(Optional.empty());
+		given(interactionRepository
+			.existsByQuestionPostIdAndMemberIdAndTypeAndIsInteractedTrue(questionPostId, member.getId(), InteractionType.RECOMMEND))
+			.willReturn(false);
 
 		//when
 		QuestionPostDetailResponse response
-			= questionPostService.getQuestionPostById(questionPost.getId());
+			= questionPostService.getQuestionPostById(questionPost.getId(), member);
 
 		//then
 		assertAll(
@@ -136,7 +138,7 @@ class QuestionPostServiceTest {
 
 		//when
 		QuestionPostDetailResponse response
-			= questionPostService.getQuestionPostById(questionPost.getId());
+			= questionPostService.getQuestionPostById(questionPost.getId(), member);
 		//then
 		assertAll(
 			() -> assertThat(response.questionPostId())
@@ -145,6 +147,54 @@ class QuestionPostServiceTest {
 				.isEqualTo(recommendCount.getCount()).isEqualTo(1),
 			() -> assertThat(response.savedCount())
 				.isEqualTo(savedCount.getCount()).isEqualTo(1)
+		);
+	}
+
+	@DisplayName("[질문글 아이디로 질문글을 상세 조회할 수 있다. 나의 추천 이력만 존재]")
+	@Test
+	void getQuestionPostById_my_interaction() {
+		//given
+		Long questionPostId = 1L;
+		QuestionPost questionPost = QuestionPostFixture.questionPost(questionPostId);
+		given(questionPostRepository.findById(questionPostId))
+			.willReturn(Optional.of(questionPost));
+
+		given(interactionRepository
+			.existsByQuestionPostIdAndMemberIdAndTypeAndIsInteractedTrue(questionPostId, member.getId(), InteractionType.SAVED))
+			.willReturn(false);
+		given(interactionRepository
+			.existsByQuestionPostIdAndMemberIdAndTypeAndIsInteractedTrue(questionPostId, member.getId(), InteractionType.RECOMMEND))
+			.willReturn(true);
+
+		InteractionCount recommendCount
+			= InteractionCountFixture.interactionCount(InteractionType.RECOMMEND, questionPostId);
+
+		given(interactionCountRepository.findByQuestionPostIdAndType(
+			questionPostId,
+			InteractionType.SAVED
+		)).willReturn(Optional.empty());
+
+		given(interactionCountRepository.findByQuestionPostIdAndType(
+			questionPostId,
+			InteractionType.RECOMMEND
+		)).willReturn(Optional.of(recommendCount));
+
+		//when
+		QuestionPostDetailResponse response
+			= questionPostService.getQuestionPostById(questionPost.getId(), member);
+
+		//then
+		assertAll(
+			() -> assertThat(response.questionPostId())
+				.isEqualTo(questionPost.getId()),
+			() -> assertThat(response.isSaved())
+				.isFalse(),
+			() -> assertThat(response.isRecommended())
+				.isTrue(),
+			() -> assertThat(response.questionPostId())
+				.isEqualTo(questionPost.getId()),
+			() -> assertThat(response.recommendCount())
+				.isEqualTo(recommendCount.getCount()).isEqualTo(1)
 		);
 	}
 

--- a/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
@@ -193,6 +193,7 @@ class QuestionPostServiceTest {
 				.isTrue(),
 			() -> assertThat(response.questionPostId())
 				.isEqualTo(questionPost.getId()),
+			() -> assertThat(response.savedCount()).isZero(),
 			() -> assertThat(response.recommendCount())
 				.isEqualTo(recommendCount.getCount()).isEqualTo(1)
 		);


### PR DESCRIPTION
### 관련 이슈
- close #71 

### 📑 작업 상세 내용
- 게시물 상세 조회에 추천 여부, 북마크 여부 추가
- 상호작용 여부 조회 쿼리 추가
  - 회원 아이디, 게시물 아이디, 타입, isInteracted=True가 일치하는 컬럼이 있는지 확인
  - 없으면 false 반환 

### 🔍 중점적으로 리뷰 할 부분
- 당근 앱에서는 아래처럼 동작하는데 저희도 이렇게 구현하면 좋을 것 같습니다.
  - 게시글 상세에서만 상호작용 여부 표시/ 추천, 북마크 누를 수 있음
  - 리스트 조회에서는 상호작용 여부 표시x, 숫자만 표현/ 추천, 북마크 누를 수 없음

