### PR TITLE
[fix #75, #77] : 잘못된 인가 허용처리 수정, 마이페이지 게시글 목록 조회 응답 DTO 필드 네이밍 변경

### DIFF
--- a/src/main/java/com/dnd/gongmuin/member/dto/response/AnsweredQuestionPostsByMemberResponse.java
+++ b/src/main/java/com/dnd/gongmuin/member/dto/response/AnsweredQuestionPostsByMemberResponse.java
@@ -10,13 +10,13 @@ public record AnsweredQuestionPostsByMemberResponse(
 	String content,
 	String jobGroup,
 	int reward,
-	String questionPostUpdatedAt,
+	String questionPostCreatedAt,
 	boolean isChosen,
 	int savedTotalCount,
 	int recommendTotalCount,
 	Long answerId,
 	String answerContent,
-	String answerUpdatedAt
+	String answerCreatedAt
 ) {
 
 	@QueryProjection
@@ -31,13 +31,13 @@ public record AnsweredQuestionPostsByMemberResponse(
 			questionPost.getContent(),
 			questionPost.getJobGroup().getLabel(),
 			questionPost.getReward(),
-			questionPost.getUpdatedAt().toString(),
+			questionPost.getCreatedAt().toString(),
 			questionPost.getIsChosen(),
 			savedTotalCount,
 			recommendTotalCount,
 			answer.getId(),
 			answer.getContent(),
-			answer.getUpdatedAt().toString()
+			answer.getCreatedAt().toString()
 		);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/member/dto/response/BookmarksByMemberResponse.java
+++ b/src/main/java/com/dnd/gongmuin/member/dto/response/BookmarksByMemberResponse.java
@@ -9,7 +9,7 @@ public record BookmarksByMemberResponse(
 	String content,
 	String jobGroup,
 	int reward,
-	String updatedAt,
+	String createdAt,
 	boolean isChosen,
 	int savedTotalCount,
 	int recommendTotalCount
@@ -26,7 +26,7 @@ public record BookmarksByMemberResponse(
 			questionPost.getContent(),
 			questionPost.getJobGroup().getLabel(),
 			questionPost.getReward(),
-			questionPost.getUpdatedAt().toString(),
+			questionPost.getCreatedAt().toString(),
 			questionPost.getIsChosen(),
 			savedTotalCount,
 			recommendTotalCount

--- a/src/main/java/com/dnd/gongmuin/member/dto/response/QuestionPostsByMemberResponse.java
+++ b/src/main/java/com/dnd/gongmuin/member/dto/response/QuestionPostsByMemberResponse.java
@@ -9,7 +9,7 @@ public record QuestionPostsByMemberResponse(
 	String content,
 	String jobGroup,
 	int reward,
-	String updatedAt,
+	String createdAt,
 	boolean isChosen,
 	int savedTotalCount,
 	int recommendTotalCount
@@ -27,7 +27,7 @@ public record QuestionPostsByMemberResponse(
 			questionPost.getContent(),
 			questionPost.getJobGroup().getLabel(),
 			questionPost.getReward(),
-			questionPost.getUpdatedAt().toString(),
+			questionPost.getCreatedAt().toString(),
 			questionPost.getIsChosen(),
 			savedTotalCount,
 			recommendTotalCount

--- a/src/main/java/com/dnd/gongmuin/member/repository/MemberCustomImpl.java
+++ b/src/main/java/com/dnd/gongmuin/member/repository/MemberCustomImpl.java
@@ -81,9 +81,9 @@ public class MemberCustomImpl implements MemberCustom {
 						.from(aw2)
 						.where(aw2.questionPostId.eq(qp.id)
 							.and(aw2.member.eq(member))
-							.and(aw2.updatedAt.eq(
+							.and(aw2.createdAt.eq(
 								JPAExpressions
-									.select(aw2.updatedAt.max())
+									.select(aw2.createdAt.max())
 									.from(aw2)
 									.where(aw2.questionPostId.eq(qp.id)
 										.and(aw2.member.eq(member)))
@@ -134,7 +134,6 @@ public class MemberCustomImpl implements MemberCustom {
 		return new SliceImpl<>(content, pageable, hasNext);
 	}
 
-	// .on(qp.id.eq(ir.questionPostId).and(ir.type.eq(InteractionType.SAVED)))
 	private <T> boolean hasNext(int pageSize, List<T> content) {
 		if (content.size() <= pageSize) {
 			return false;

--- a/src/main/java/com/dnd/gongmuin/security/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/gongmuin/security/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests(
 				(auth) -> auth
 					.requestMatchers("/").permitAll()
-					.requestMatchers("/api/auth/reissue/token", "/api/auth/check-nickname").permitAll()
+					.requestMatchers("/api/auth/reissue/token").permitAll()
 					.requestMatchers(
 						"/api/auth/member",
 						"/api/auth/check-nickname",

--- a/src/test/java/com/dnd/gongmuin/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/member/repository/MemberRepositoryTest.java
@@ -339,7 +339,7 @@ class MemberRepositoryTest extends DataJpaTestSupport {
 				.containsExactly(
 					answer2.getId()
 				),
-			() -> assertThat(postsByMember).extracting(AnsweredQuestionPostsByMemberResponse::answerUpdatedAt)
+			() -> assertThat(postsByMember).extracting(AnsweredQuestionPostsByMemberResponse::answerCreatedAt)
 				.containsExactly(
 					answer2.getUpdatedAt().toString()
 				),


### PR DESCRIPTION
### 관련 이슈
- close #75 #77 

### 📑 작업 상세 내용
- 특정 URL 잘못된 인가 처리가 이루어짐을 수정
  - "/api/auth/check-nickname" : permitAll() -> hasAnyAuthority("ROLE_GUEST", "ROLE_USER")
- 마이페이지 게시물 목록 조회 응답 DTO 필드 네이밍 변경
  - updatedAt -> createdAt 
- 답변 단 질문 목록 조회 시 답변 내용을 updatedAt -> createdAt 정렬 순으로 가져오도록 변경

### 💫 작업 요약
- 특정 URL이 제대로 된 인가처리가 되도록 수정

### 🔍 중점적으로 리뷰 할 부분
- merge와 push 순서가 꼬여서 한 곳에 다 들어가게 되었습니다 죄송합니다ㅜㅜ
