### PR TITLE
[feat #80] 프로필 조회 응답 DTO 필드 추가

### DIFF
--- a/src/main/java/com/dnd/gongmuin/member/domain/Member.java
+++ b/src/main/java/com/dnd/gongmuin/member/domain/Member.java
@@ -46,7 +46,7 @@ public class Member extends TimeBaseEntity {
 	private int credit;
 	@Column(name = "role", nullable = false)
 	private String role;
-  @Column(name = "profile_image_no", nullable = false)
+	@Column(name = "profile_image_no", nullable = false)
 	private final int profileImageNo = setRandomNumber();
 
 	@Builder(access = PRIVATE)

--- a/src/main/java/com/dnd/gongmuin/member/dto/MemberMapper.java
+++ b/src/main/java/com/dnd/gongmuin/member/dto/MemberMapper.java
@@ -11,10 +11,12 @@ public class MemberMapper {
 
 	public static MemberProfileResponse toMemberProfileResponse(Member member) {
 		return new MemberProfileResponse(
+			member.getId(),
 			member.getNickname(),
 			member.getJobGroup().getLabel(),
 			member.getJobCategory().getLabel(),
-			member.getCredit()
+			member.getCredit(),
+			member.getProfileImageNo()
 		);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/dnd/gongmuin/member/dto/response/MemberProfileResponse.java
@@ -1,9 +1,11 @@
 package com.dnd.gongmuin.member.dto.response;
 
 public record MemberProfileResponse(
+	Long memberId,
 	String nickname,
 	String jobGroup,
 	String jobCategory,
-	int credit
+	int credit,
+	int profileImageNo
 ) {
 }

--- a/src/test/java/com/dnd/gongmuin/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/member/controller/MemberControllerTest.java
@@ -73,9 +73,11 @@ class MemberControllerTest extends ApiTestSupport {
 				.cookie(accessToken)
 			)
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("nickname").value("김회원"))
-			.andExpect(jsonPath("jobGroup").value("공업"))
-			.andExpect(jsonPath("jobCategory").value("기계"))
+			.andExpect(jsonPath("memberId").value(loginMember.getId()))
+			.andExpect(jsonPath("nickname").value(loginMember.getNickname()))
+			.andExpect(jsonPath("jobGroup").value(loginMember.getJobGroup().getLabel()))
+			.andExpect(jsonPath("jobCategory").value(loginMember.getJobCategory().getLabel()))
+			.andExpect(jsonPath("profileImageNo").value(loginMember.getProfileImageNo()))
 			.andExpect(jsonPath("credit").value(10000));
 	}
 

--- a/src/test/java/com/dnd/gongmuin/member/service/MemberServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/member/service/MemberServiceTest.java
@@ -87,10 +87,12 @@ class MemberServiceTest {
 
 		// then
 		assertAll(
+			() -> assertThat(memberProfile.memberId()).isEqualTo(member.getId()),
 			() -> assertThat(memberProfile.nickname()).isEqualTo(member.getNickname()),
 			() -> assertThat(memberProfile.jobGroup()).isEqualTo(member.getJobGroup().getLabel()),
 			() -> assertThat(memberProfile.jobCategory()).isEqualTo(member.getJobCategory().getLabel()),
-			() -> assertThat(memberProfile.credit()).isEqualTo(member.getCredit())
+			() -> assertThat(memberProfile.credit()).isEqualTo(member.getCredit()),
+			() -> assertThat(memberProfile.profileImageNo()).isEqualTo(member.getProfileImageNo())
 		);
 	}
 


### PR DESCRIPTION
### 관련 이슈
- close #80 

### 📑 작업 상세 내용
- 프로필 조회 응답 DTO 필드 추가
  -  memberId 필드 추가
  -  profileImageNo 필드 추가

### 💫 작업 요약
-  프로필 조회 응답 DTO 필드 추가

### 🔍 중점적으로 리뷰 할 부분
- 
