### PR TITLE
[feat #82] 유저 정보 API

### DIFF
--- a/src/main/java/com/dnd/gongmuin/member/controller/MemberController.java
+++ b/src/main/java/com/dnd/gongmuin/member/controller/MemberController.java
@@ -16,6 +16,7 @@ import com.dnd.gongmuin.member.dto.request.UpdateMemberProfileRequest;
 import com.dnd.gongmuin.member.dto.response.AnsweredQuestionPostsResponse;
 import com.dnd.gongmuin.member.dto.response.BookmarksResponse;
 import com.dnd.gongmuin.member.dto.response.CreditHistoryResponse;
+import com.dnd.gongmuin.member.dto.response.MemberInformationResponse;
 import com.dnd.gongmuin.member.dto.response.MemberProfileResponse;
 import com.dnd.gongmuin.member.dto.response.QuestionPostsResponse;
 import com.dnd.gongmuin.member.service.MemberService;
@@ -102,4 +103,12 @@ public class MemberController {
 		return ResponseEntity.ok(response);
 	}
 
+	@Operation(summary = "회원 정보 전체 조회 API", description = "회원 정보를 전체 조회한다.")
+	@ApiResponse(useReturnTypeSchema = true)
+	@GetMapping("/information")
+	public ResponseEntity<MemberInformationResponse> getMemberInformation(@AuthenticationPrincipal Member member) {
+		MemberInformationResponse response = memberService.getMemberInformation(member);
+
+		return ResponseEntity.ok(response);
+	}
 }

--- a/src/main/java/com/dnd/gongmuin/member/dto/MemberMapper.java
+++ b/src/main/java/com/dnd/gongmuin/member/dto/MemberMapper.java
@@ -1,6 +1,7 @@
 package com.dnd.gongmuin.member.dto;
 
 import com.dnd.gongmuin.member.domain.Member;
+import com.dnd.gongmuin.member.dto.response.MemberInformationResponse;
 import com.dnd.gongmuin.member.dto.response.MemberProfileResponse;
 
 import lombok.AccessLevel;
@@ -13,6 +14,20 @@ public class MemberMapper {
 		return new MemberProfileResponse(
 			member.getId(),
 			member.getNickname(),
+			member.getJobGroup().getLabel(),
+			member.getJobCategory().getLabel(),
+			member.getCredit(),
+			member.getProfileImageNo()
+		);
+	}
+
+	public static MemberInformationResponse toMemberInformationResponse(Member member) {
+		return new MemberInformationResponse(
+			member.getId(),
+			member.getNickname(),
+			member.getSocialName(),
+			member.getOfficialEmail(),
+			member.getSocialEmail(),
 			member.getJobGroup().getLabel(),
 			member.getJobCategory().getLabel(),
 			member.getCredit(),

--- a/src/main/java/com/dnd/gongmuin/member/dto/response/MemberInformationResponse.java
+++ b/src/main/java/com/dnd/gongmuin/member/dto/response/MemberInformationResponse.java
@@ -1,0 +1,14 @@
+package com.dnd.gongmuin.member.dto.response;
+
+public record MemberInformationResponse(
+	Long memberId,
+	String nickname,
+	String socialName,
+	String officialEmail,
+	String socialEmail,
+	String jobGroup,
+	String jobCategory,
+	int credit,
+	int profileImageNo
+) {
+}

--- a/src/main/java/com/dnd/gongmuin/member/service/MemberService.java
+++ b/src/main/java/com/dnd/gongmuin/member/service/MemberService.java
@@ -18,6 +18,7 @@ import com.dnd.gongmuin.member.dto.request.UpdateMemberProfileRequest;
 import com.dnd.gongmuin.member.dto.response.AnsweredQuestionPostsResponse;
 import com.dnd.gongmuin.member.dto.response.BookmarksResponse;
 import com.dnd.gongmuin.member.dto.response.CreditHistoryResponse;
+import com.dnd.gongmuin.member.dto.response.MemberInformationResponse;
 import com.dnd.gongmuin.member.dto.response.MemberProfileResponse;
 import com.dnd.gongmuin.member.dto.response.QuestionPostsResponse;
 import com.dnd.gongmuin.member.exception.MemberErrorCode;
@@ -138,5 +139,14 @@ public class MemberService {
 			throw new NotFoundException(MemberErrorCode.QUESTION_POSTS_BY_MEMBER_FAILED);
 		}
 
+	}
+
+	public MemberInformationResponse getMemberInformation(Member member) {
+		try {
+			Member findMember = memberRepository.findByOfficialEmail(member.getOfficialEmail());
+			return MemberMapper.toMemberInformationResponse(findMember);
+		} catch (Exception e) {
+			throw new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER);
+		}
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/member/controller/MemberControllerTest.java
@@ -332,4 +332,23 @@ class MemberControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.content[0].detail").value(ch4.getDetail()))
 			.andExpect(jsonPath("$.content[0].amount").value(ch4.getAmount()));
 	}
+
+	@DisplayName("로그인 된 사용자 프로필 정보를 조회한다.")
+	@Test
+	void getMemberInformation() throws Exception {
+		// when  // then
+		mockMvc.perform(get("/api/members/information")
+				.cookie(accessToken)
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("memberId").value(loginMember.getId()))
+			.andExpect(jsonPath("nickname").value(loginMember.getNickname()))
+			.andExpect(jsonPath("socialName").value(loginMember.getSocialName()))
+			.andExpect(jsonPath("officialEmail").value(loginMember.getOfficialEmail()))
+			.andExpect(jsonPath("socialEmail").value(loginMember.getSocialEmail()))
+			.andExpect(jsonPath("jobGroup").value(loginMember.getJobGroup().getLabel()))
+			.andExpect(jsonPath("jobCategory").value(loginMember.getJobCategory().getLabel()))
+			.andExpect(jsonPath("profileImageNo").value(loginMember.getProfileImageNo()))
+			.andExpect(jsonPath("credit").value(10000));
+	}
 }

--- a/src/test/java/com/dnd/gongmuin/member/service/MemberServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/member/service/MemberServiceTest.java
@@ -20,6 +20,7 @@ import com.dnd.gongmuin.common.exception.runtime.ValidationException;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.dto.request.UpdateMemberProfileRequest;
+import com.dnd.gongmuin.member.dto.response.MemberInformationResponse;
 import com.dnd.gongmuin.member.dto.response.MemberProfileResponse;
 import com.dnd.gongmuin.member.repository.MemberRepository;
 
@@ -136,6 +137,39 @@ class MemberServiceTest {
 
 		// when  // then
 		assertThrows(ValidationException.class, () -> memberService.updateMemberProfile(request, member));
+	}
 
+	@DisplayName("회원 정보를 전체 조회한다.")
+	@Test
+	void getMemberInformation() {
+		// given
+		Member member = MemberFixture.member();
+		given(memberRepository.findByOfficialEmail(anyString())).willReturn(member);
+
+		// when
+		MemberInformationResponse memberInformation = memberService.getMemberInformation(member);
+
+		// then
+		assertAll(
+			() -> assertThat(memberInformation.memberId()).isEqualTo(member.getId()),
+			() -> assertThat(memberInformation.nickname()).isEqualTo(member.getNickname()),
+			() -> assertThat(memberInformation.socialName()).isEqualTo(member.getSocialName()),
+			() -> assertThat(memberInformation.officialEmail()).isEqualTo(member.getOfficialEmail()),
+			() -> assertThat(memberInformation.socialEmail()).isEqualTo(member.getSocialEmail()),
+			() -> assertThat(memberInformation.jobGroup()).isEqualTo(member.getJobGroup().getLabel()),
+			() -> assertThat(memberInformation.jobCategory()).isEqualTo(member.getJobCategory().getLabel()),
+			() -> assertThat(memberInformation.credit()).isEqualTo(member.getCredit()),
+			() -> assertThat(memberInformation.profileImageNo()).isEqualTo(member.getProfileImageNo())
+		);
+	}
+
+	@DisplayName("회원 정보를 전체 조회 시 회원을 찾을 수 없으면 예외가 발생한다.")
+	@Test
+	void getMemberInformationThrowException() {
+		// given
+		Member member = MemberFixture.member();
+
+		// when  // then
+		assertThrows(NotFoundException.class, () -> memberService.getMemberInformation(member));
 	}
 }


### PR DESCRIPTION
### 관련 이슈
- close #82 

### 📑 작업 상세 내용
- 회원 정보(전체) 조회 API 개발

### 💫 작업 요약
- 회원 정보(전체) 조회 API 개발


### 🔍 중점적으로 리뷰 할 부분
- 프로필 조회 API와 유사하지만 응답 DTO가 달라 분리하여 개발했습니다.
