### PR TITLE
[fix #88] security-jwt hotfix

### DIFF
--- a/src/main/java/com/dnd/gongmuin/auth/controller/AuthController.java
+++ b/src/main/java/com/dnd/gongmuin/auth/controller/AuthController.java
@@ -14,6 +14,7 @@ import com.dnd.gongmuin.auth.dto.request.ValidateNickNameRequest;
 import com.dnd.gongmuin.auth.dto.response.LogoutResponse;
 import com.dnd.gongmuin.auth.dto.response.ReissueResponse;
 import com.dnd.gongmuin.auth.dto.response.SignUpResponse;
+import com.dnd.gongmuin.auth.dto.response.TempSignResponse;
 import com.dnd.gongmuin.auth.dto.response.ValidateNickNameResponse;
 import com.dnd.gongmuin.auth.service.AuthService;
 import com.dnd.gongmuin.member.domain.Member;
@@ -37,23 +38,23 @@ public class AuthController {
 	@Operation(summary = "임시 회원가입(토큰 발급) API", description = "임시 회원가입 후 토큰을 발급한다.")
 	@ApiResponse(useReturnTypeSchema = true)
 	@PostMapping("/temp-signup")
-	public ResponseEntity<String> tempSignUp(
+	public ResponseEntity<TempSignResponse> tempSignUp(
 		@RequestBody @Valid TempSignUpRequest request,
 		HttpServletResponse response) {
 
-		authService.tempSignUp(request, response);
-		return ResponseEntity.ok("성공");
+		TempSignResponse tempSignResponse = authService.tempSignUp(request, response);
+		return ResponseEntity.ok(tempSignResponse);
 	}
 
 	@Operation(summary = "임시 로그인(토큰 발급) API", description = "임시 로그인 후 토큰을 발급한다.")
 	@ApiResponse(useReturnTypeSchema = true)
 	@PostMapping("/temp-signin")
-	public ResponseEntity<String> tempSignIn(
+	public ResponseEntity<TempSignResponse> tempSignIn(
 		@RequestBody @Valid TempSignInRequest request,
 		HttpServletResponse response) {
 
-		authService.tempSignIn(request, response);
-		return ResponseEntity.ok("성공");
+		TempSignResponse tempSignResponse = authService.tempSignIn(request, response);
+		return ResponseEntity.ok(tempSignResponse);
 	}
 
 	@Operation(summary = "닉네임 중복 검증 API", description = "닉네임 중복을 검증한다.")

--- a/src/main/java/com/dnd/gongmuin/auth/dto/response/TempSignResponse.java
+++ b/src/main/java/com/dnd/gongmuin/auth/dto/response/TempSignResponse.java
@@ -1,0 +1,6 @@
+package com.dnd.gongmuin.auth.dto.response;
+
+public record TempSignResponse(
+	boolean result
+) {
+}

--- a/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
@@ -18,6 +18,7 @@ import com.dnd.gongmuin.auth.dto.request.ValidateNickNameRequest;
 import com.dnd.gongmuin.auth.dto.response.LogoutResponse;
 import com.dnd.gongmuin.auth.dto.response.ReissueResponse;
 import com.dnd.gongmuin.auth.dto.response.SignUpResponse;
+import com.dnd.gongmuin.auth.dto.response.TempSignResponse;
 import com.dnd.gongmuin.auth.dto.response.ValidateNickNameResponse;
 import com.dnd.gongmuin.auth.exception.AuthErrorCode;
 import com.dnd.gongmuin.auth.repository.AuthRepository;
@@ -78,7 +79,7 @@ public class AuthService {
 	}
 
 	@Transactional
-	public void tempSignUp(TempSignUpRequest tempSignUpRequest, HttpServletResponse response) {
+	public TempSignResponse tempSignUp(TempSignUpRequest tempSignUpRequest, HttpServletResponse response) {
 		Date now = new Date();
 		Member member = Member.of(
 			tempSignUpRequest.socialName(),
@@ -100,10 +101,12 @@ public class AuthService {
 		tokenProvider.generateRefreshToken(customOauth2User, now);
 		String accessToken = tokenProvider.generateAccessToken(customOauth2User, now);
 		response.addCookie(cookieUtil.createCookie(accessToken));
+
+		return new TempSignResponse(true);
 	}
 
 	@Transactional
-	public void tempSignIn(TempSignInRequest tempSignInRequest, HttpServletResponse response) {
+	public TempSignResponse tempSignIn(TempSignInRequest tempSignInRequest, HttpServletResponse response) {
 		Date now = new Date();
 
 		String prefixSocialEmail = "kakao/" + tempSignInRequest.socialEmail();
@@ -118,6 +121,8 @@ public class AuthService {
 		tokenProvider.generateRefreshToken(customOauth2User, now);
 		String accessToken = tokenProvider.generateAccessToken(customOauth2User, now);
 		response.addCookie(cookieUtil.createCookie(accessToken));
+
+		return new TempSignResponse(true);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/dnd/gongmuin/credit_history/domain/CreditType.java
+++ b/src/main/java/com/dnd/gongmuin/credit_history/domain/CreditType.java
@@ -24,15 +24,15 @@ public enum CreditType {
 			.orElseThrow(IllegalArgumentException::new);
 	}
 
-	private boolean isEqual(String input) {
-		return input.equals(this.label);
-	}
-
 	public static CreditType fromDetail(String detail) {
 		return Arrays.stream(values())
 			.filter(type -> type.isDetailEqual(detail))
 			.findAny()
 			.orElseThrow(IllegalArgumentException::new);
+	}
+
+	private boolean isEqual(String input) {
+		return input.equals(this.label);
 	}
 
 	private boolean isDetailEqual(String input) {

--- a/src/main/java/com/dnd/gongmuin/member/domain/Member.java
+++ b/src/main/java/com/dnd/gongmuin/member/domain/Member.java
@@ -24,6 +24,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 public class Member extends TimeBaseEntity {
 
+	@Column(name = "profile_image_no", nullable = false)
+	private final int profileImageNo = setRandomNumber();
 	@Id
 	@GeneratedValue(strategy = IDENTITY)
 	@Column(name = "member_id")
@@ -46,8 +48,6 @@ public class Member extends TimeBaseEntity {
 	private int credit;
 	@Column(name = "role", nullable = false)
 	private String role;
-	@Column(name = "profile_image_no", nullable = false)
-	private final int profileImageNo = setRandomNumber();
 
 	@Builder(access = PRIVATE)
 	private Member(String nickname, String socialName, JobGroup jobGroup, JobCategory jobCategory, String socialEmail,

--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/CookieUtil.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/CookieUtil.java
@@ -37,6 +37,9 @@ public class CookieUtil {
 		Cookie cookie = new Cookie("Authorization", null);
 		cookie.setPath("/");
 		cookie.setMaxAge(0);
+		cookie.setHttpOnly(true);
+		cookie.setSecure(true);
+		cookie.setAttribute("SameSite", "None");
 
 		response.addCookie(cookie);
 	}


### PR DESCRIPTION
### 관련 이슈
- close #87 

### 📑 작업 상세 내용
- 임시 로그인/회원가입 응답 인코딩 문제 해결(boolean으로 변경)
- 로그아웃 시 로그아웃 토큰 지정 SameSite-None 추가

### 💫 작업 요약
- 임시 로그인/회원가입 응답 인코딩 문제 해결(boolean으로 변경)
- 로그아웃 시 로그아웃 토큰 지정 SameSite-None 추가

### 🔍 중점적으로 리뷰 할 부분
- https 배포 서버 swagger는 로컬 서버와 쿠키 전달이 되지 않습니다. 이걸 까먹고 있었네요.
  로컬 <-> 로컬, https(배포) <-> https(배포)끼리만 가능합니다
