### PR TITLE
[feat #108] 채팅 수락/거절 API

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
@@ -4,12 +4,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dnd.gongmuin.chat.dto.request.CreateChatRoomRequest;
+import com.dnd.gongmuin.chat.dto.response.AcceptChatResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatMessageResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomDetailResponse;
 import com.dnd.gongmuin.chat.service.ChatRoomService;
@@ -46,6 +48,16 @@ public class ChatRoomController {
 		@AuthenticationPrincipal Member member
 	) {
 		ChatRoomDetailResponse response = chatRoomService.createChatRoom(request, member);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "채팅 수락 API", description = "채팅방에서 요청자와의 채팅을 수락한다.")
+	@PatchMapping("/api/chat-rooms/{chatRoomId}/accept")
+	public ResponseEntity<AcceptChatResponse> acceptChat(
+		@PathVariable("chatRoomId") Long chatRoomId,
+		@AuthenticationPrincipal Member member
+	) {
+		AcceptChatResponse response = chatRoomService.acceptChat(chatRoomId, member);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
@@ -14,6 +14,7 @@ import com.dnd.gongmuin.chat.dto.request.CreateChatRoomRequest;
 import com.dnd.gongmuin.chat.dto.response.AcceptChatResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatMessageResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomDetailResponse;
+import com.dnd.gongmuin.chat.dto.response.RejectChatResponse;
 import com.dnd.gongmuin.chat.service.ChatRoomService;
 import com.dnd.gongmuin.common.dto.PageResponse;
 import com.dnd.gongmuin.member.domain.Member;
@@ -58,6 +59,16 @@ public class ChatRoomController {
 		@AuthenticationPrincipal Member member
 	) {
 		AcceptChatResponse response = chatRoomService.acceptChat(chatRoomId, member);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "채팅 거절 API", description = "채팅방에서 요청자와의 채팅을 거절한다.")
+	@PatchMapping("/api/chat-rooms/{chatRoomId}/reject")
+	public ResponseEntity<RejectChatResponse> rejectChat(
+		@PathVariable("chatRoomId") Long chatRoomId,
+		@AuthenticationPrincipal Member member
+	) {
+		RejectChatResponse response = chatRoomService.rejectChat(chatRoomId, member);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/chat/domain/ChatRoom.java
+++ b/src/main/java/com/dnd/gongmuin/chat/domain/ChatRoom.java
@@ -78,4 +78,12 @@ public class ChatRoom extends TimeBaseEntity {
 		status = ChatStatus.ACCEPTED;
 		answerer.increaseCredit(CHAT_REWARD);
 	}
+
+	public void updateStatusRejected() {
+		if (status != ChatStatus.PENDING) {
+			throw new ValidationException(ChatErrorCode.UNABLE_TO_CHANGE_CHAT_STATUS);
+		}
+		status = ChatStatus.REJECTED;
+		inquirer.increaseCredit(CHAT_REWARD);
+	}
 }

--- a/src/main/java/com/dnd/gongmuin/chat/domain/ChatRoom.java
+++ b/src/main/java/com/dnd/gongmuin/chat/domain/ChatRoom.java
@@ -73,7 +73,7 @@ public class ChatRoom extends TimeBaseEntity {
 
 	public void updateStatusAccepted() {
 		if (status != ChatStatus.PENDING) {
-			throw new ValidationException(ChatErrorCode.UNABLE_TO_ACCEPT);
+			throw new ValidationException(ChatErrorCode.UNABLE_TO_CHANGE_CHAT_STATUS);
 		}
 		status = ChatStatus.ACCEPTED;
 		answerer.increaseCredit(CHAT_REWARD);

--- a/src/main/java/com/dnd/gongmuin/chat/domain/ChatRoom.java
+++ b/src/main/java/com/dnd/gongmuin/chat/domain/ChatRoom.java
@@ -28,6 +28,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatRoom extends TimeBaseEntity {
 
+	private static final int CHAT_REWARD = 2000;
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "chat_room_id", nullable = false)
@@ -58,7 +60,7 @@ public class ChatRoom extends TimeBaseEntity {
 		this.inquirer = inquirer;
 		this.answerer = answerer;
 		this.status = ChatStatus.PENDING;
-		inquirer.decreaseCredit(2000);
+		inquirer.decreaseCredit(CHAT_REWARD);
 	}
 
 	public static ChatRoom of(
@@ -74,6 +76,6 @@ public class ChatRoom extends TimeBaseEntity {
 			throw new ValidationException(ChatErrorCode.UNABLE_TO_ACCEPT);
 		}
 		status = ChatStatus.ACCEPTED;
-		answerer.increaseCredit(2000);
+		answerer.increaseCredit(CHAT_REWARD);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/chat/domain/ChatRoom.java
+++ b/src/main/java/com/dnd/gongmuin/chat/domain/ChatRoom.java
@@ -55,7 +55,7 @@ public class ChatRoom extends TimeBaseEntity {
 		this.inquirer = inquirer;
 		this.answerer = answerer;
 		this.isAccepted = false;
-		validateInquirerCredit();
+		inquirer.decreaseCredit(2000);
 	}
 
 	public static ChatRoom of(
@@ -64,11 +64,5 @@ public class ChatRoom extends TimeBaseEntity {
 		Member answerer
 	) {
 		return new ChatRoom(questionPost, inquirer, answerer);
-	}
-
-	private void validateInquirerCredit() {
-		if (inquirer.getCredit() < 2000) {
-			throw new ValidationException(MemberErrorCode.NOT_ENOUGH_CREDIT);
-		}
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/chat/domain/ChatRoom.java
+++ b/src/main/java/com/dnd/gongmuin/chat/domain/ChatRoom.java
@@ -1,6 +1,7 @@
 package com.dnd.gongmuin.chat.domain;
 
 import static jakarta.persistence.ConstraintMode.*;
+import static jakarta.persistence.EnumType.*;
 import static jakarta.persistence.FetchType.*;
 
 import com.dnd.gongmuin.common.entity.TimeBaseEntity;
@@ -11,6 +12,7 @@ import com.dnd.gongmuin.question_post.domain.QuestionPost;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -47,14 +49,15 @@ public class ChatRoom extends TimeBaseEntity {
 		foreignKey = @ForeignKey(NO_CONSTRAINT))
 	private Member answerer;
 
-	@Column(name = "is_accepted", nullable = false)
-	private boolean isAccepted;
+	@Enumerated(STRING)
+	@Column(name = "status", nullable = false)
+	private ChatStatus status;
 
 	private ChatRoom(QuestionPost questionPost, Member inquirer, Member answerer) {
 		this.questionPost = questionPost;
 		this.inquirer = inquirer;
 		this.answerer = answerer;
-		this.isAccepted = false;
+		this.status = ChatStatus.PENDING;
 		inquirer.decreaseCredit(2000);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/chat/domain/ChatRoom.java
+++ b/src/main/java/com/dnd/gongmuin/chat/domain/ChatRoom.java
@@ -4,10 +4,10 @@ import static jakarta.persistence.ConstraintMode.*;
 import static jakarta.persistence.EnumType.*;
 import static jakarta.persistence.FetchType.*;
 
+import com.dnd.gongmuin.chat.exception.ChatErrorCode;
 import com.dnd.gongmuin.common.entity.TimeBaseEntity;
 import com.dnd.gongmuin.common.exception.runtime.ValidationException;
 import com.dnd.gongmuin.member.domain.Member;
-import com.dnd.gongmuin.member.exception.MemberErrorCode;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 
 import jakarta.persistence.Column;
@@ -67,5 +67,13 @@ public class ChatRoom extends TimeBaseEntity {
 		Member answerer
 	) {
 		return new ChatRoom(questionPost, inquirer, answerer);
+	}
+
+	public void updateStatusAccepted() {
+		if (status != ChatStatus.PENDING) {
+			throw new ValidationException(ChatErrorCode.UNABLE_TO_ACCEPT);
+		}
+		status = ChatStatus.ACCEPTED;
+		answerer.increaseCredit(2000);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/chat/domain/ChatStatus.java
+++ b/src/main/java/com/dnd/gongmuin/chat/domain/ChatStatus.java
@@ -9,7 +9,7 @@ public enum ChatStatus {
 
 	PENDING("요청중"),
 	ACCEPTED("수락됨"),
-	DENIED("거절됨");
+	REJECTED("거절됨");
 
 	private final String label;
 }

--- a/src/main/java/com/dnd/gongmuin/chat/domain/ChatStatus.java
+++ b/src/main/java/com/dnd/gongmuin/chat/domain/ChatStatus.java
@@ -1,0 +1,15 @@
+package com.dnd.gongmuin.chat.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatStatus {
+
+	PENDING("요청중"),
+	ACCEPTED("수락됨"),
+	DENIED("거절됨");
+
+	private final String label;
+}

--- a/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
@@ -44,14 +44,14 @@ public class ChatRoomMapper {
 		);
 	}
 
-	public static AcceptChatResponse toAcceptChatResponse(ChatRoom chatRoom){
+	public static AcceptChatResponse toAcceptChatResponse(ChatRoom chatRoom) {
 		return new AcceptChatResponse(
 			chatRoom.getStatus().getLabel(),
 			chatRoom.getAnswerer().getCredit()
 		);
 	}
 
-	public static RejectChatResponse toRejectChatResponse(ChatRoom chatRoom){
+	public static RejectChatResponse toRejectChatResponse(ChatRoom chatRoom) {
 		return new RejectChatResponse(
 			chatRoom.getStatus().getLabel()
 		);

--- a/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
@@ -38,7 +38,8 @@ public class ChatRoomMapper {
 				answerer.getJobGroup().getLabel(),
 				answerer.getProfileImageNo()
 			),
-			chatRoom.isAccepted()
+			chatRoom.getStatus().getLabel()
 		);
 	}
+
 }

--- a/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
@@ -3,6 +3,7 @@ package com.dnd.gongmuin.chat.dto;
 import com.dnd.gongmuin.chat.domain.ChatRoom;
 import com.dnd.gongmuin.chat.dto.response.AcceptChatResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomDetailResponse;
+import com.dnd.gongmuin.chat.dto.response.RejectChatResponse;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
@@ -47,6 +48,12 @@ public class ChatRoomMapper {
 		return new AcceptChatResponse(
 			chatRoom.getStatus().getLabel(),
 			chatRoom.getAnswerer().getCredit()
+		);
+	}
+
+	public static RejectChatResponse toRejectChatResponse(ChatRoom chatRoom){
+		return new RejectChatResponse(
+			chatRoom.getStatus().getLabel()
 		);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
@@ -1,6 +1,7 @@
 package com.dnd.gongmuin.chat.dto;
 
 import com.dnd.gongmuin.chat.domain.ChatRoom;
+import com.dnd.gongmuin.chat.dto.response.AcceptChatResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomDetailResponse;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
@@ -39,6 +40,13 @@ public class ChatRoomMapper {
 				answerer.getProfileImageNo()
 			),
 			chatRoom.getStatus().getLabel()
+		);
+	}
+
+	public static AcceptChatResponse toAcceptChatResponse(ChatRoom chatRoom){
+		return new AcceptChatResponse(
+			chatRoom.getStatus().getLabel(),
+			chatRoom.getAnswerer().getCredit()
 		);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/chat/dto/response/AcceptChatResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/response/AcceptChatResponse.java
@@ -1,0 +1,7 @@
+package com.dnd.gongmuin.chat.dto.response;
+
+public record AcceptChatResponse(
+	String chatStatus,
+	int credit
+) {
+}

--- a/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomDetailResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomDetailResponse.java
@@ -7,6 +7,6 @@ public record ChatRoomDetailResponse(
 	String targetJobGroup,
 	String title,
 	MemberInfo receiverInfo,
-	boolean isAccepted
+	String status
 ) {
 }

--- a/src/main/java/com/dnd/gongmuin/chat/dto/response/RejectChatResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/response/RejectChatResponse.java
@@ -1,0 +1,6 @@
+package com.dnd.gongmuin.chat.dto.response;
+
+public record RejectChatResponse(
+	String chatStatus
+) {
+}

--- a/src/main/java/com/dnd/gongmuin/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/chat/exception/ChatErrorCode.java
@@ -10,7 +10,9 @@ import lombok.RequiredArgsConstructor;
 public enum ChatErrorCode implements ErrorCode {
 
 	INVALID_MESSAGE_TYPE("메시지 타입을 올바르게 입력해주세요.", "CH_001"),
-	NOT_FOUND_CHAT_ROOM("해당 아이디의 채팅방이 존재하지 않습니다.", "CH_002");
+	NOT_FOUND_CHAT_ROOM("해당 아이디의 채팅방이 존재하지 않습니다.", "CH_002"),
+	UNAUTHORIZED_REQUEST("채팅 수락을 하거나 거절할 권한이 없습니다.", "CH_003"),
+	UNABLE_TO_ACCEPT("이미 수락했거나 거절한 요청입니다.", "CH_004");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/chat/exception/ChatErrorCode.java
@@ -12,7 +12,7 @@ public enum ChatErrorCode implements ErrorCode {
 	INVALID_MESSAGE_TYPE("메시지 타입을 올바르게 입력해주세요.", "CH_001"),
 	NOT_FOUND_CHAT_ROOM("해당 아이디의 채팅방이 존재하지 않습니다.", "CH_002"),
 	UNAUTHORIZED_REQUEST("채팅 수락을 하거나 거절할 권한이 없습니다.", "CH_003"),
-	UNABLE_TO_ACCEPT("이미 수락했거나 거절한 요청입니다.", "CH_004");
+	UNABLE_TO_CHANGE_CHAT_STATUS("이미 수락했거나 거절한 요청입니다.", "CH_004");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
@@ -40,6 +40,12 @@ public class ChatRoomService {
 	private final MemberRepository memberRepository;
 	private final QuestionPostRepository questionPostRepository;
 
+	private static void validateIfAnswerer(Member member, ChatRoom chatRoom) {
+		if (!Objects.equals(member.getId(), chatRoom.getAnswerer().getId())) {
+			throw new ValidationException(ChatErrorCode.UNAUTHORIZED_REQUEST);
+		}
+	}
+
 	@Transactional(readOnly = true)
 	public PageResponse<ChatMessageResponse> getChatMessages(Long chatRoomId, Pageable pageable) {
 		Slice<ChatMessageResponse> responsePage = chatMessageRepository
@@ -75,13 +81,7 @@ public class ChatRoomService {
 		return ChatRoomMapper.toRejectChatResponse(chatRoom);
 	}
 
-	private static void validateIfAnswerer(Member member, ChatRoom chatRoom) {
-		if (!Objects.equals(member.getId(), chatRoom.getAnswerer().getId())){
-			throw new ValidationException(ChatErrorCode.UNAUTHORIZED_REQUEST);
-		}
-	}
-
-	private ChatRoom getChatRoomById(Long id){
+	private ChatRoom getChatRoomById(Long id) {
 		return chatRoomRepository.findById(id)
 			.orElseThrow(() -> new NotFoundException(ChatErrorCode.NOT_FOUND_CHAT_ROOM));
 	}

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
@@ -1,5 +1,7 @@
 package com.dnd.gongmuin.chat.service;
 
+import java.util.Objects;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -64,7 +66,7 @@ public class ChatRoomService {
 	}
 
 	private static void validateIfAnswerer(Member member, ChatRoom chatRoom) {
-		if (member != chatRoom.getAnswerer()) {
+		if (!Objects.equals(member.getId(), chatRoom.getAnswerer().getId())){
 			throw new ValidationException(ChatErrorCode.UNAUTHORIZED_REQUEST);
 		}
 	}

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
@@ -14,6 +14,7 @@ import com.dnd.gongmuin.chat.dto.request.CreateChatRoomRequest;
 import com.dnd.gongmuin.chat.dto.response.AcceptChatResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatMessageResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomDetailResponse;
+import com.dnd.gongmuin.chat.dto.response.RejectChatResponse;
 import com.dnd.gongmuin.chat.exception.ChatErrorCode;
 import com.dnd.gongmuin.chat.repository.ChatMessageRepository;
 import com.dnd.gongmuin.chat.repository.ChatRoomRepository;
@@ -63,6 +64,15 @@ public class ChatRoomService {
 		chatRoom.updateStatusAccepted();
 
 		return ChatRoomMapper.toAcceptChatResponse(chatRoom);
+	}
+
+	@Transactional
+	public RejectChatResponse rejectChat(Long chatRoomId, Member member) {
+		ChatRoom chatRoom = getChatRoomById(chatRoomId);
+		validateIfAnswerer(member, chatRoom);
+		chatRoom.updateStatusRejected();
+
+		return ChatRoomMapper.toRejectChatResponse(chatRoom);
 	}
 
 	private static void validateIfAnswerer(Member member, ChatRoom chatRoom) {

--- a/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
@@ -11,9 +11,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.dnd.gongmuin.chat.domain.ChatMessage;
+import com.dnd.gongmuin.chat.domain.ChatRoom;
+import com.dnd.gongmuin.chat.domain.ChatStatus;
 import com.dnd.gongmuin.chat.dto.request.CreateChatRoomRequest;
 import com.dnd.gongmuin.chat.repository.ChatMessageRepository;
+import com.dnd.gongmuin.chat.repository.ChatRoomRepository;
 import com.dnd.gongmuin.common.fixture.ChatMessageFixture;
+import com.dnd.gongmuin.common.fixture.ChatRoomFixture;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
 import com.dnd.gongmuin.common.fixture.QuestionPostFixture;
 import com.dnd.gongmuin.common.support.ApiTestSupport;
@@ -25,6 +29,8 @@ import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 @DisplayName("[ChatMessage 통합 테스트]")
 class ChatRoomControllerTest extends ApiTestSupport {
 
+	private static final int CHAT_REWARD = 2000;
+
 	@Autowired
 	private ChatMessageRepository chatMessageRepository;
 
@@ -33,6 +39,9 @@ class ChatRoomControllerTest extends ApiTestSupport {
 
 	@Autowired
 	private QuestionPostRepository questionPostRepository;
+
+	@Autowired
+	private ChatRoomRepository chatRoomRepository;
 
 	@DisplayName("[채팅방 아이디로 메시지를 조회할 수 있다.]")
 	@Test
@@ -64,4 +73,18 @@ class ChatRoomControllerTest extends ApiTestSupport {
 			.andExpect(status().isOk());
 	}
 
+	@DisplayName("[답변자가 채팅 요청을 수락할 수 있다.]")
+	@Test
+	void acceptChatRoom() throws Exception {
+		Member inquirer = memberRepository.save(MemberFixture.member4());
+		QuestionPost questionPost = questionPostRepository.save(QuestionPostFixture.questionPost(inquirer));
+		ChatRoom chatRoom = chatRoomRepository.save(ChatRoomFixture.chatRoom(questionPost, inquirer, loginMember));
+		int previousAnswererCredit = chatRoom.getAnswerer().getCredit();
+
+		mockMvc.perform(patch("/api/chat-rooms/{chatRoomId}/accept", 1L)
+				.cookie(accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.chatStatus").value(ChatStatus.ACCEPTED.getLabel()))
+			.andExpect(jsonPath("$.credit").value(previousAnswererCredit + CHAT_REWARD));
+	}
 }

--- a/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
@@ -95,4 +95,17 @@ class ChatRoomControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.chatStatus").value(ChatStatus.ACCEPTED.getLabel()))
 			.andExpect(jsonPath("$.credit").value(previousAnswererCredit + CHAT_REWARD));
 	}
+
+	@DisplayName("[답변자가 채팅 요청을 거절할 수 있다.]")
+	@Test
+	void rejectChatRoom() throws Exception {
+		Member inquirer = memberRepository.save(MemberFixture.member4());
+		QuestionPost questionPost = questionPostRepository.save(QuestionPostFixture.questionPost(inquirer));
+		ChatRoom chatRoom = chatRoomRepository.save(ChatRoomFixture.chatRoom(questionPost, inquirer, loginMember));
+
+		mockMvc.perform(patch("/api/chat-rooms/{chatRoomId}/reject", chatRoom.getId())
+				.cookie(accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.chatStatus").value(ChatStatus.REJECTED.getLabel()));
+	}
 }

--- a/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +43,13 @@ class ChatRoomControllerTest extends ApiTestSupport {
 
 	@Autowired
 	private ChatRoomRepository chatRoomRepository;
+
+	@AfterEach
+	void teardown() {
+		memberRepository.deleteAll();
+		questionPostRepository.deleteAll();
+		chatRoomRepository.deleteAll();
+	}
 
 	@DisplayName("[채팅방 아이디로 메시지를 조회할 수 있다.]")
 	@Test

--- a/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
@@ -89,7 +89,7 @@ class ChatRoomControllerTest extends ApiTestSupport {
 		ChatRoom chatRoom = chatRoomRepository.save(ChatRoomFixture.chatRoom(questionPost, inquirer, loginMember));
 		int previousAnswererCredit = chatRoom.getAnswerer().getCredit();
 
-		mockMvc.perform(patch("/api/chat-rooms/{chatRoomId}/accept", 1L)
+		mockMvc.perform(patch("/api/chat-rooms/{chatRoomId}/accept", chatRoom.getId())
 				.cookie(accessToken))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.chatStatus").value(ChatStatus.ACCEPTED.getLabel()))

--- a/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.BDDMockito.*;
 import java.util.List;
 import java.util.Optional;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,9 +42,8 @@ import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 @ExtendWith(MockitoExtension.class)
 class ChatRoomServiceTest {
 
-	private final PageRequest pageRequest = PageRequest.of(0, 5);
 	private static final int CHAT_REWARD = 2000;
-
+	private final PageRequest pageRequest = PageRequest.of(0, 5);
 	@Mock
 	private ChatMessageRepository chatMessageRepository;
 
@@ -135,7 +133,7 @@ class ChatRoomServiceTest {
 	@DisplayName("[답변자가 채팅 요청을 수락할 수 있다.]")
 	@Test
 	void acceptChat() {
-	    //given
+		//given
 		Long chatRoomId = 1L;
 		Member inquirer = MemberFixture.member(1L);
 		Member answerer = MemberFixture.member(2L);
@@ -154,7 +152,7 @@ class ChatRoomServiceTest {
 			() -> assertThat(response.chatStatus())
 				.isEqualTo(ChatStatus.ACCEPTED.getLabel()),
 			() -> assertThat(response.credit())
-				.isEqualTo(previousCredit+CHAT_REWARD)
+				.isEqualTo(previousCredit + CHAT_REWARD)
 		);
 	}
 

--- a/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.*;
 import java.util.List;
 import java.util.Optional;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +25,7 @@ import com.dnd.gongmuin.chat.dto.request.CreateChatRoomRequest;
 import com.dnd.gongmuin.chat.dto.response.AcceptChatResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatMessageResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomDetailResponse;
+import com.dnd.gongmuin.chat.dto.response.RejectChatResponse;
 import com.dnd.gongmuin.chat.repository.ChatMessageRepository;
 import com.dnd.gongmuin.chat.repository.ChatRoomRepository;
 import com.dnd.gongmuin.common.exception.runtime.ValidationException;
@@ -154,5 +156,26 @@ class ChatRoomServiceTest {
 			() -> assertThat(response.credit())
 				.isEqualTo(previousCredit+CHAT_REWARD)
 		);
+	}
+
+	@DisplayName("[답변자가 채팅 요청을 거절할 수 있다.]")
+	@Test
+	void rejectChat() {
+		//given
+		Long chatRoomId = 1L;
+		Member inquirer = MemberFixture.member(1L);
+		Member answerer = MemberFixture.member(2L);
+		QuestionPost questionPost = QuestionPostFixture.questionPost(inquirer);
+		ChatRoom chatRoom = ChatRoomFixture.chatRoom(questionPost, inquirer, answerer);
+
+		given(chatRoomRepository.findById(chatRoomId))
+			.willReturn(Optional.of(chatRoom));
+
+		//when
+		RejectChatResponse response = chatRoomService.rejectChat(chatRoomId, answerer);
+
+		//then
+		assertThat(response.chatStatus())
+			.isEqualTo(ChatStatus.REJECTED.getLabel());
 	}
 }


### PR DESCRIPTION
### 관련 이슈
- close #108 

### 📑 작업 상세 내용
- 채팅 상태 enum 필드 추가
  - `대기`, `수락` -> `대기`, `수락`, `거절` 
- 채팅 수락 API
  - 상태 변경 및 답변자 크레딧 증가
- 채팅 거절 API
  - 상태 변경 및 요청자 크레딧 환불   

### 💫 작업 요약
- 채팅 수락 API
- 채팅 거절 API

### 🔍 중점적으로 리뷰 할 부분
- 기존에는 채팅 요청 시 요청자 보유 크레딧이 2000 넘는지만 체크했습니다.
  - 답변자의 채팅 요청 수락 시점에 2000 크레딧이 없을 경우를 감안하여 
요청 시 2000 크레딧을 소모하고, 거절 당한 경우 2000을 반환받도록 로직을 수정했습니다.