### PR TITLE
[feat #113] 네이버 소셜로그인 로직

### DIFF
--- a/src/main/java/com/dnd/gongmuin/security/oauth2/KakaoResponse.java
+++ b/src/main/java/com/dnd/gongmuin/security/oauth2/KakaoResponse.java
@@ -16,7 +16,7 @@ public class KakaoResponse implements Oauth2Response {
 
 	@Override
 	public String getProvider() {
-		return Provider.NAVER.getLabel();
+		return Provider.KAKAO.getLabel();
 	}
 
 	@Override

--- a/src/main/java/com/dnd/gongmuin/security/oauth2/NaverResponse.java
+++ b/src/main/java/com/dnd/gongmuin/security/oauth2/NaverResponse.java
@@ -1,0 +1,43 @@
+package com.dnd.gongmuin.security.oauth2;
+
+import java.util.Map;
+
+import com.dnd.gongmuin.member.domain.Provider;
+
+public class NaverResponse implements Oauth2Response {
+
+	private final Map<String, Object> attribute;
+
+	public NaverResponse(Map<String, Object> attribute) {
+		this.attribute = (Map<String, Object>)attribute.get("response");
+	}
+
+	@Override
+	public String getProvider() {
+		return Provider.NAVER.getLabel();
+	}
+
+	@Override
+	public String getProviderId() {
+		return this.attribute.get("id").toString();
+	}
+
+	@Override
+	public String getEmail() {
+		return this.attribute.get("email").toString();
+	}
+
+	@Override
+	public String getName() {
+		return this.attribute.get("name").toString();
+	}
+
+	@Override
+	public String createSocialEmail() {
+		return String.format("%s%s/%s",
+			this.getProvider(),
+			this.getProviderId(),
+			this.getEmail()
+		);
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/security/service/CustomOauth2UserService.java
+++ b/src/main/java/com/dnd/gongmuin/security/service/CustomOauth2UserService.java
@@ -1,6 +1,7 @@
 package com.dnd.gongmuin.security.service;
 
 import static com.dnd.gongmuin.auth.exception.AuthErrorCode.*;
+import static com.dnd.gongmuin.member.domain.Provider.*;
 
 import java.util.Objects;
 
@@ -17,6 +18,7 @@ import com.dnd.gongmuin.member.service.MemberService;
 import com.dnd.gongmuin.security.oauth2.AuthInfo;
 import com.dnd.gongmuin.security.oauth2.CustomOauth2User;
 import com.dnd.gongmuin.security.oauth2.KakaoResponse;
+import com.dnd.gongmuin.security.oauth2.NaverResponse;
 import com.dnd.gongmuin.security.oauth2.Oauth2Response;
 
 import lombok.RequiredArgsConstructor;
@@ -35,8 +37,10 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
 		String registrationId = userRequest.getClientRegistration().getRegistrationId();
 		Oauth2Response oauth2Response = null;
 
-		if (Objects.equals(registrationId, "kakao")) {
+		if (Objects.equals(registrationId, KAKAO.getLabel())) {
 			oauth2Response = new KakaoResponse(oAuth2User.getAttributes());
+		} else if (Objects.equals(registrationId, NAVER.getLabel())) {
+			oauth2Response = new NaverResponse(oAuth2User.getAttributes());
 		} else {
 			throw new OAuth2AuthenticationException(
 				new OAuth2Error(UNSUPPORTED_SOCIAL_LOGIN.getCode()),


### PR DESCRIPTION
### 관련 이슈
- close #113 

### 📑 작업 상세 내용
-  Naver Oauth 객체(NaverResponse) 추가
-  Kakao Oauth 객체(KakaoResponse) getProvider() 시 "kakao"가 아닌 "naver" 가져오는 오류 수정
- Oauth 인증 객체 로직 변경
  -  Kakao 인증 객체가 아니라면 에러 던지기 -> `Kakao || Naver` 인증 객체가 아니라면 에러 던지기
- Secret YML 변경

### 💫 작업 요약
- 네이버 소셜로그인 로직 추가
