### PR TITLE
[feat #117] 회원 탈퇴 API

### DIFF
--- a/src/main/java/com/dnd/gongmuin/answer/domain/Answer.java
+++ b/src/main/java/com/dnd/gongmuin/answer/domain/Answer.java
@@ -61,4 +61,7 @@ public class Answer extends TimeBaseEntity {
 		this.isChosen = true;
 	}
 
+	public void updateMember(Member anonymous) {
+		this.member = anonymous;
+	}
 }

--- a/src/main/java/com/dnd/gongmuin/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/dnd/gongmuin/answer/repository/AnswerRepository.java
@@ -1,13 +1,18 @@
 package com.dnd.gongmuin.answer.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.dnd.gongmuin.answer.domain.Answer;
+import com.dnd.gongmuin.member.domain.Member;
 
 @Repository
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
 	Slice<Answer> findByQuestionPostId(Long questionPostId);
+
+	List<Answer> findAllByMember(Member member);
 }

--- a/src/main/java/com/dnd/gongmuin/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/dnd/gongmuin/answer/repository/AnswerRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.dnd.gongmuin.answer.domain.Answer;
@@ -15,4 +17,8 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 	Slice<Answer> findByQuestionPostId(Long questionPostId);
 
 	List<Answer> findAllByMember(Member member);
+
+	@Modifying(flushAutomatically = true, clearAutomatically = true)
+	@Query("UPDATE Answer a SET a.member = :anonymous WHERE a.member.id = :memberId")
+	public void updateAnswers(Long memberId, Member anonymous);
 }

--- a/src/main/java/com/dnd/gongmuin/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/dnd/gongmuin/answer/repository/AnswerRepository.java
@@ -1,24 +1,22 @@
 package com.dnd.gongmuin.answer.repository;
 
+import com.dnd.gongmuin.answer.domain.Answer;
+import com.dnd.gongmuin.member.domain.Member;
 import java.util.List;
-
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import com.dnd.gongmuin.answer.domain.Answer;
-import com.dnd.gongmuin.member.domain.Member;
-
 @Repository
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
-	Slice<Answer> findByQuestionPostId(Long questionPostId);
+    Slice<Answer> findByQuestionPostId(Long questionPostId);
 
-	List<Answer> findAllByMember(Member member);
+    List<Answer> findAllByMember(Member member);
 
-	@Modifying(flushAutomatically = true, clearAutomatically = true)
-	@Query("UPDATE Answer a SET a.member = :anonymous WHERE a.member.id = :memberId")
-	public void updateAnswers(Long memberId, Member anonymous);
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("UPDATE Answer a SET a.member = :anonymous WHERE a.member.id = :memberId")
+    public void updateAnswersMember(Long memberId, Member member);
 }

--- a/src/main/java/com/dnd/gongmuin/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/dnd/gongmuin/answer/repository/AnswerRepository.java
@@ -17,6 +17,6 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
     List<Answer> findAllByMember(Member member);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("UPDATE Answer a SET a.member = :anonymous WHERE a.member.id = :memberId")
+    @Query("UPDATE Answer a SET a.member = :member WHERE a.member.id = :memberId")
     public void updateAnswersMember(Long memberId, Member member);
 }

--- a/src/main/java/com/dnd/gongmuin/auth/controller/AuthController.java
+++ b/src/main/java/com/dnd/gongmuin/auth/controller/AuthController.java
@@ -11,8 +11,8 @@ import com.dnd.gongmuin.auth.dto.request.AdditionalInfoRequest;
 import com.dnd.gongmuin.auth.dto.request.TempSignInRequest;
 import com.dnd.gongmuin.auth.dto.request.TempSignUpRequest;
 import com.dnd.gongmuin.auth.dto.request.ValidateNickNameRequest;
+import com.dnd.gongmuin.auth.dto.response.DeleteMemberResponse;
 import com.dnd.gongmuin.auth.dto.response.LogoutResponse;
-import com.dnd.gongmuin.auth.dto.response.MemberDeletionResponse;
 import com.dnd.gongmuin.auth.dto.response.ReissueResponse;
 import com.dnd.gongmuin.auth.dto.response.SignUpResponse;
 import com.dnd.gongmuin.auth.dto.response.TempSignResponse;
@@ -98,12 +98,12 @@ public class AuthController {
 	@Operation(summary = "회원탈퇴 API", description = "회원 탈퇴한다.")
 	@ApiResponse(useReturnTypeSchema = true)
 	@PostMapping("/delete")
-	public ResponseEntity<MemberDeletionResponse> deleteMember(
+	public ResponseEntity<DeleteMemberResponse> deleteMember(
 		HttpServletRequest request
 	) {
-		MemberDeletionResponse memberDeletionResponse = authService.deleteMember(request);
+		DeleteMemberResponse deleteMemberResponse = authService.deleteMember(request);
 
-		return ResponseEntity.ok(memberDeletionResponse);
+		return ResponseEntity.ok(deleteMemberResponse);
 	}
 }
 

--- a/src/main/java/com/dnd/gongmuin/auth/controller/AuthController.java
+++ b/src/main/java/com/dnd/gongmuin/auth/controller/AuthController.java
@@ -12,6 +12,7 @@ import com.dnd.gongmuin.auth.dto.request.TempSignInRequest;
 import com.dnd.gongmuin.auth.dto.request.TempSignUpRequest;
 import com.dnd.gongmuin.auth.dto.request.ValidateNickNameRequest;
 import com.dnd.gongmuin.auth.dto.response.LogoutResponse;
+import com.dnd.gongmuin.auth.dto.response.MemberDeletionResponse;
 import com.dnd.gongmuin.auth.dto.response.ReissueResponse;
 import com.dnd.gongmuin.auth.dto.response.SignUpResponse;
 import com.dnd.gongmuin.auth.dto.response.TempSignResponse;
@@ -92,6 +93,17 @@ public class AuthController {
 		ReissueResponse reissueResponse = authService.reissue(request, response);
 
 		return ResponseEntity.ok(reissueResponse);
+	}
+
+	@Operation(summary = "회원탈퇴 API", description = "회원 탈퇴한다.")
+	@ApiResponse(useReturnTypeSchema = true)
+	@PostMapping("/delete")
+	public ResponseEntity<MemberDeletionResponse> deleteMember(
+		HttpServletRequest request
+	) {
+		MemberDeletionResponse memberDeletionResponse = authService.deleteMember(request);
+
+		return ResponseEntity.ok(memberDeletionResponse);
 	}
 }
 

--- a/src/main/java/com/dnd/gongmuin/auth/dto/response/DeleteMemberResponse.java
+++ b/src/main/java/com/dnd/gongmuin/auth/dto/response/DeleteMemberResponse.java
@@ -1,6 +1,6 @@
 package com.dnd.gongmuin.auth.dto.response;
 
-public record MemberDeletionResponse(
+public record DeleteMemberResponse(
 
 	Long memberId
 ) {

--- a/src/main/java/com/dnd/gongmuin/auth/dto/response/MemberDeletionResponse.java
+++ b/src/main/java/com/dnd/gongmuin/auth/dto/response/MemberDeletionResponse.java
@@ -1,0 +1,7 @@
+package com.dnd.gongmuin.auth.dto.response;
+
+public record MemberDeletionResponse(
+
+	Long memberId
+) {
+}

--- a/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
@@ -2,14 +2,12 @@ package com.dnd.gongmuin.auth.service;
 
 import java.time.Duration;
 import java.util.Date;
-import java.util.List;
 import java.util.Objects;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.dnd.gongmuin.answer.domain.Answer;
 import com.dnd.gongmuin.answer.repository.AnswerRepository;
 import com.dnd.gongmuin.auth.dto.request.AdditionalInfoRequest;
 import com.dnd.gongmuin.auth.dto.request.TempSignInRequest;
@@ -32,7 +30,6 @@ import com.dnd.gongmuin.member.exception.MemberErrorCode;
 import com.dnd.gongmuin.member.repository.MemberRepository;
 import com.dnd.gongmuin.notification.repository.NotificationRepository;
 import com.dnd.gongmuin.post_interaction.repository.InteractionRepository;
-import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 import com.dnd.gongmuin.redis.util.RedisUtil;
 import com.dnd.gongmuin.security.jwt.util.CookieUtil;
@@ -249,12 +246,8 @@ public class AuthService {
 		Member anonymous = memberRepository.findByRole(ANONYMOUS)
 			.orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
 
-		List<QuestionPost> posts = questionPostRepository.findAllByMember(member);
-		posts.forEach(post -> post.updateMember(anonymous));
-
-		List<Answer> answers = answerRepository.findAllByMember(member);
-		answers.forEach(answer -> answer.updateMember(anonymous));
-
+		questionPostRepository.updateQuestionPosts(member.getId(), anonymous);
+		answerRepository.updateAnswers(member.getId(), anonymous);
 	}
 
 }

--- a/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
@@ -12,8 +12,8 @@ import com.dnd.gongmuin.auth.dto.request.AdditionalInfoRequest;
 import com.dnd.gongmuin.auth.dto.request.TempSignInRequest;
 import com.dnd.gongmuin.auth.dto.request.TempSignUpRequest;
 import com.dnd.gongmuin.auth.dto.request.ValidateNickNameRequest;
+import com.dnd.gongmuin.auth.dto.response.DeleteMemberResponse;
 import com.dnd.gongmuin.auth.dto.response.LogoutResponse;
-import com.dnd.gongmuin.auth.dto.response.MemberDeletionResponse;
 import com.dnd.gongmuin.auth.dto.response.ReissueResponse;
 import com.dnd.gongmuin.auth.dto.response.SignUpResponse;
 import com.dnd.gongmuin.auth.dto.response.TempSignResponse;
@@ -186,7 +186,7 @@ public class AuthService {
 	}
 
 	@Transactional
-	public MemberDeletionResponse deleteMember(HttpServletRequest request) {
+	public DeleteMemberResponse deleteMember(HttpServletRequest request) {
 		String accessToken = cookieUtil.getCookieValue(request);
 
 		if (!tokenProvider.validateToken(accessToken, new Date())) {
@@ -220,6 +220,6 @@ public class AuthService {
 		if (redisUtil.getValues("AT(oauth):" + member.getSocialEmail()) != null) {
 			redisUtil.deleteValues("AT(oauth):" + member.getSocialEmail());
 		}
-		return new MemberDeletionResponse(member.getId());
+		return new DeleteMemberResponse(member.getId());
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
@@ -1,13 +1,5 @@
 package com.dnd.gongmuin.auth.service;
 
-import java.time.Duration;
-import java.util.Date;
-import java.util.Objects;
-
-import org.springframework.security.core.Authentication;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.dnd.gongmuin.answer.repository.AnswerRepository;
 import com.dnd.gongmuin.auth.dto.request.AdditionalInfoRequest;
 import com.dnd.gongmuin.auth.dto.request.TempSignInRequest;
@@ -37,217 +29,222 @@ import com.dnd.gongmuin.security.jwt.util.TokenProvider;
 import com.dnd.gongmuin.security.oauth2.AuthInfo;
 import com.dnd.gongmuin.security.oauth2.CustomOauth2User;
 import com.dnd.gongmuin.security.service.OAuth2UnlinkService;
-
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import java.util.Date;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
-	private static final String LOGOUT = "logout";
-	private static final String DELETE = "delete";
-	private static final String ANONYMOUS = "ROLE_ANONYMOUS";
-	private final TokenProvider tokenProvider;
-	private final MemberRepository memberRepository;
-	private final CookieUtil cookieUtil;
-	private final RedisUtil redisUtil;
-	private final OAuth2UnlinkService oAuth2UnlinkService;
-	private final CreditHistoryRepository creditHistoryRepository;
-	private final QuestionPostRepository questionPostRepository;
-	private final AnswerRepository answerRepository;
-	private final InteractionRepository interactionRepository;
-	private final NotificationRepository notificationRepository;
+    private static final String LOGOUT = "logout";
+    private static final String DELETE = "delete";
+    private static final String ANONYMOUS = "ROLE_ANONYMOUS";
+    private final TokenProvider tokenProvider;
+    private final MemberRepository memberRepository;
+    private final CookieUtil cookieUtil;
+    private final RedisUtil redisUtil;
+    private final OAuth2UnlinkService oAuth2UnlinkService;
+    private final CreditHistoryRepository creditHistoryRepository;
+    private final QuestionPostRepository questionPostRepository;
+    private final AnswerRepository answerRepository;
+    private final InteractionRepository interactionRepository;
+    private final NotificationRepository notificationRepository;
 
-	@Transactional
-	public TempSignResponse tempSignUp(TempSignUpRequest tempSignUpRequest, HttpServletResponse response) {
-		Date now = new Date();
-		Member member = Member.of(
-			tempSignUpRequest.socialName(),
-			"kakao/" + tempSignUpRequest.socialEmail(),
-			10000,
-			"ROLE_GUEST"
-		);
+    @Transactional
+    public TempSignResponse tempSignUp(TempSignUpRequest tempSignUpRequest, HttpServletResponse response) {
+        Date now = new Date();
+        Member member = Member.of(
+                tempSignUpRequest.socialName(),
+                "kakao/" + tempSignUpRequest.socialEmail(),
+                10000,
+                "ROLE_GUEST"
+        );
 
-		if (memberRepository.existsBySocialEmail(member.getSocialEmail())) {
-			throw new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER);
-		}
+        if (memberRepository.existsBySocialEmail(member.getSocialEmail())) {
+            throw new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER);
+        }
 
-		memberRepository.save(member);
+        memberRepository.save(member);
 
-		AuthInfo authInfo = AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole());
-		CustomOauth2User customOauth2User = new CustomOauth2User(authInfo);
+        AuthInfo authInfo = AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole());
+        CustomOauth2User customOauth2User = new CustomOauth2User(authInfo);
 
-		tokenProvider.generateRefreshToken(customOauth2User, now);
-		String accessToken = tokenProvider.generateAccessToken(customOauth2User, now);
-		response.addCookie(cookieUtil.createCookie(accessToken));
+        tokenProvider.generateRefreshToken(customOauth2User, now);
+        String accessToken = tokenProvider.generateAccessToken(customOauth2User, now);
+        response.addCookie(cookieUtil.createCookie(accessToken));
 
-		return new TempSignResponse(true);
-	}
+        return new TempSignResponse(true);
+    }
 
-	@Transactional
-	public TempSignResponse tempSignIn(TempSignInRequest tempSignInRequest, HttpServletResponse response) {
-		Date now = new Date();
+    @Transactional
+    public TempSignResponse tempSignIn(TempSignInRequest tempSignInRequest, HttpServletResponse response) {
+        Date now = new Date();
 
-		String prefixSocialEmail = "kakao/" + tempSignInRequest.socialEmail();
+        String prefixSocialEmail = "kakao/" + tempSignInRequest.socialEmail();
 
-		Member member = memberRepository.findBySocialEmail(prefixSocialEmail)
-			.orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
+        Member member = memberRepository.findBySocialEmail(prefixSocialEmail)
+                .orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
 
-		AuthInfo authInfo = AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole());
-		CustomOauth2User customOauth2User = new CustomOauth2User(authInfo);
+        AuthInfo authInfo = AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole());
+        CustomOauth2User customOauth2User = new CustomOauth2User(authInfo);
 
-		tokenProvider.generateRefreshToken(customOauth2User, now);
-		String accessToken = tokenProvider.generateAccessToken(customOauth2User, now);
-		response.addCookie(cookieUtil.createCookie(accessToken));
+        tokenProvider.generateRefreshToken(customOauth2User, now);
+        String accessToken = tokenProvider.generateAccessToken(customOauth2User, now);
+        response.addCookie(cookieUtil.createCookie(accessToken));
 
-		return new TempSignResponse(true);
-	}
+        return new TempSignResponse(true);
+    }
 
-	@Transactional(readOnly = true)
-	public ValidateNickNameResponse isDuplicatedNickname(ValidateNickNameRequest request) {
-		boolean isDuplicated = memberRepository.existsByNickname(request.nickname());
+    @Transactional(readOnly = true)
+    public ValidateNickNameResponse isDuplicatedNickname(ValidateNickNameRequest request) {
+        boolean isDuplicated = memberRepository.existsByNickname(request.nickname());
 
-		return new ValidateNickNameResponse(isDuplicated);
-	}
+        return new ValidateNickNameResponse(isDuplicated);
+    }
 
-	@Transactional
-	public SignUpResponse signUp(AdditionalInfoRequest request, String email, HttpServletResponse response) {
-		Member foundMember = memberRepository.findBySocialEmail(email)
-			.orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
+    @Transactional
+    public SignUpResponse signUp(AdditionalInfoRequest request, String email, HttpServletResponse response) {
+        Member foundMember = memberRepository.findBySocialEmail(email)
+                .orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
 
-		if (!isOfficialEmail(foundMember)) {
-			throw new NotFoundException(MemberErrorCode.NOT_FOUND_NEW_MEMBER);
-		}
+        if (!isOfficialEmail(foundMember)) {
+            throw new NotFoundException(MemberErrorCode.NOT_FOUND_NEW_MEMBER);
+        }
 
-		updateAdditionalInfo(request, foundMember);
+        updateAdditionalInfo(request, foundMember);
 
-		cookieUtil.deleteCookie(response);
+        cookieUtil.deleteCookie(response);
 
-		return new SignUpResponse(foundMember.getNickname());
-	}
+        return new SignUpResponse(foundMember.getNickname());
+    }
 
-	public LogoutResponse logout(HttpServletRequest request, HttpServletResponse response) {
-		String accessToken = cookieUtil.getCookieValue(request);
+    public LogoutResponse logout(HttpServletRequest request, HttpServletResponse response) {
+        String accessToken = cookieUtil.getCookieValue(request);
 
-		if (!tokenProvider.validateToken(accessToken, new Date())) {
-			throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
-		}
+        if (!tokenProvider.validateToken(accessToken, new Date())) {
+            throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
+        }
 
-		Authentication authentication = tokenProvider.getAuthentication(accessToken);
-		Member member = (Member)authentication.getPrincipal();
+        Authentication authentication = tokenProvider.getAuthentication(accessToken);
+        Member member = (Member) authentication.getPrincipal();
 
-		if (!Objects.isNull(redisUtil.getValues("RT:" + member.getSocialEmail()))) {
-			redisUtil.deleteValues("RT:" + member.getSocialEmail());
-		}
+        if (!Objects.isNull(redisUtil.getValues("RT:" + member.getSocialEmail()))) {
+            redisUtil.deleteValues("RT:" + member.getSocialEmail());
+        }
 
-		Long expiration = tokenProvider.getExpiration(accessToken, new Date());
-		redisUtil.setValues(accessToken, LOGOUT, Duration.ofMillis(expiration));
+        Long expiration = tokenProvider.getExpiration(accessToken, new Date());
+        redisUtil.setValues(accessToken, LOGOUT, Duration.ofMillis(expiration));
 
-		String values = redisUtil.getValues(accessToken);
-		if (!Objects.equals(values, LOGOUT)) {
-			throw new NotFoundException(MemberErrorCode.LOGOUT_FAILED);
-		}
+        String values = redisUtil.getValues(accessToken);
+        if (!Objects.equals(values, LOGOUT)) {
+            throw new NotFoundException(MemberErrorCode.LOGOUT_FAILED);
+        }
 
-		cookieUtil.deleteCookie(response);
+        cookieUtil.deleteCookie(response);
 
-		return new LogoutResponse(true);
-	}
+        return new LogoutResponse(true);
+    }
 
-	public ReissueResponse reissue(HttpServletRequest request, HttpServletResponse response) {
-		String accessToken = cookieUtil.getCookieValue(request);
+    public ReissueResponse reissue(HttpServletRequest request, HttpServletResponse response) {
+        String accessToken = cookieUtil.getCookieValue(request);
 
-		// 로그아웃 토큰 처리
-		if ("logout".equals(redisUtil.getValues(accessToken))) {
-			throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
-		}
+        // 로그아웃 토큰 처리
+        if ("logout".equals(redisUtil.getValues(accessToken))) {
+            throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
+        }
 
-		Authentication authentication = tokenProvider.getAuthentication(accessToken);
-		Member member = (Member)authentication.getPrincipal();
+        Authentication authentication = tokenProvider.getAuthentication(accessToken);
+        Member member = (Member) authentication.getPrincipal();
 
-		String refreshToken = redisUtil.getValues("RT:" + member.getSocialEmail());
+        String refreshToken = redisUtil.getValues("RT:" + member.getSocialEmail());
 
-		// 로그아웃 또는 토큰 만료 경우 처리
-		if ("false".equals(refreshToken)) {
-			throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
-		}
+        // 로그아웃 또는 토큰 만료 경우 처리
+        if ("false".equals(refreshToken)) {
+            throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
+        }
 
-		CustomOauth2User customUser = new CustomOauth2User(
-			AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole()));
-		String reissuedAccessToken = tokenProvider.generateAccessToken(customUser, new Date());
-		tokenProvider.generateRefreshToken(customUser, new Date());
+        CustomOauth2User customUser = new CustomOauth2User(
+                AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole()));
+        String reissuedAccessToken = tokenProvider.generateAccessToken(customUser, new Date());
+        tokenProvider.generateRefreshToken(customUser, new Date());
 
-		response.addCookie(cookieUtil.createCookie(reissuedAccessToken));
+        response.addCookie(cookieUtil.createCookie(reissuedAccessToken));
 
-		return new ReissueResponse(true);
-	}
+        return new ReissueResponse(true);
+    }
 
-	public boolean isOfficialEmail(Member member) {
-		return Objects.isNull(member.getOfficialEmail());
-	}
+    public boolean isOfficialEmail(Member member) {
+        return Objects.isNull(member.getOfficialEmail());
+    }
 
-	private void updateAdditionalInfo(AdditionalInfoRequest request, Member findMember) {
-		findMember.updateAdditionalInfo(
-			request.nickname(),
-			request.officialEmail(),
-			JobGroup.from(request.jobGroup()),
-			JobCategory.from(request.jobCategory())
-		);
-	}
+    private void updateAdditionalInfo(AdditionalInfoRequest request, Member findMember) {
+        findMember.updateAdditionalInfo(
+                request.nickname(),
+                request.officialEmail(),
+                JobGroup.from(request.jobGroup()),
+                JobCategory.from(request.jobCategory())
+        );
+    }
 
-	@Transactional
-	public DeleteMemberResponse deleteMember(HttpServletRequest request) {
-		String accessToken = cookieUtil.getCookieValue(request);
+    @Transactional
+    public DeleteMemberResponse deleteMember(HttpServletRequest request) {
+        String accessToken = cookieUtil.getCookieValue(request);
 
-		if (!tokenProvider.validateToken(accessToken, new Date())) {
-			throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
-		}
+        if (!tokenProvider.validateToken(accessToken, new Date())) {
+            throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
+        }
 
-		Authentication authentication = tokenProvider.getAuthentication(accessToken);
-		Member member = (Member)authentication.getPrincipal();
+        Authentication authentication = tokenProvider.getAuthentication(accessToken);
+        Member member = (Member) authentication.getPrincipal();
 
-		// RefreshToken 삭제
-		if (!Objects.isNull(redisUtil.getValues("RT:" + member.getSocialEmail()))) {
-			redisUtil.deleteValues("RT:" + member.getSocialEmail());
-		}
+        // RefreshToken 삭제
+        if (!Objects.isNull(redisUtil.getValues("RT:" + member.getSocialEmail()))) {
+            redisUtil.deleteValues("RT:" + member.getSocialEmail());
+        }
 
-		// 현재 발급 되어 있는 AccessToken 블랙리스트 등록
-		Long expiration = tokenProvider.getExpiration(accessToken, new Date());
-		redisUtil.setValues(accessToken, DELETE, Duration.ofMillis(expiration));
+        // 현재 발급 되어 있는 AccessToken 블랙리스트 등록
+        Long expiration = tokenProvider.getExpiration(accessToken, new Date());
+        redisUtil.setValues(accessToken, DELETE, Duration.ofMillis(expiration));
 
-		// AccessToken 블랙리스트 등록 여부 검증
-		String values = redisUtil.getValues(accessToken);
-		if (!Objects.equals(values, DELETE)) {
-			throw new NotFoundException(MemberErrorCode.DELETE_FAILED);
-		}
+        // AccessToken 블랙리스트 등록 여부 검증
+        String values = redisUtil.getValues(accessToken);
+        if (!Objects.equals(values, DELETE)) {
+            throw new NotFoundException(MemberErrorCode.DELETE_FAILED);
+        }
 
-		deleteAssociation(member);
-		replaceWithAnonymous(member);
-		memberRepository.delete(member);
+        deleteAssociation(member);
+        replaceWithAnonymous(member);
+        memberRepository.delete(member);
 
-		// oauth2 서비스 연결 끊기
-		oAuth2UnlinkService.unlink(member.getSocialEmail());
+        // oauth2 서비스 연결 끊기
+        oAuth2UnlinkService.unlink(member.getSocialEmail());
 
-		// oauth2 access 토큰 삭제
-		if (redisUtil.getValues("AT(oauth):" + member.getSocialEmail()) != null) {
-			redisUtil.deleteValues("AT(oauth):" + member.getSocialEmail());
-		}
-		return new DeleteMemberResponse(member.getId());
-	}
+        // oauth2 access 토큰 삭제
+        if (redisUtil.getValues("AT(oauth):" + member.getSocialEmail()) != null) {
+            redisUtil.deleteValues("AT(oauth):" + member.getSocialEmail());
+        }
+        return new DeleteMemberResponse(member.getId());
+    }
 
-	private void deleteAssociation(Member member) {
-		creditHistoryRepository.deleteByMember(member);
-		notificationRepository.deleteByMember(member);
-		interactionRepository.deleteByMemberId(member.getId());
-	}
+    private void deleteAssociation(Member member) {
+        creditHistoryRepository.deleteByMember(member);
+        notificationRepository.deleteByMember(member);
+        interactionRepository.deleteByMemberId(member.getId());
+    }
 
-	private void replaceWithAnonymous(Member member) {
-		Member anonymous = memberRepository.findByRole(ANONYMOUS)
-			.orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
+    private void replaceWithAnonymous(Member member) {
+        Member anonymous = memberRepository.findByRole(ANONYMOUS)
+                .orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
 
-		questionPostRepository.updateQuestionPosts(member.getId(), anonymous);
-		answerRepository.updateAnswers(member.getId(), anonymous);
-	}
+        questionPostRepository.updateQuestionPostsMember(member.getId(), anonymous);
+        answerRepository.updateAnswersMember(member.getId(), anonymous);
+    }
 
 }

--- a/src/main/java/com/dnd/gongmuin/common/config/RestTemplateConfig.java
+++ b/src/main/java/com/dnd/gongmuin/common/config/RestTemplateConfig.java
@@ -1,0 +1,21 @@
+package com.dnd.gongmuin.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+	@Bean
+	public RestTemplate restTemplate() {
+		RestTemplate restTemplate = new RestTemplate();
+		SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+		requestFactory.setConnectTimeout(5000);
+		requestFactory.setReadTimeout(5000);
+
+		restTemplate.setRequestFactory(requestFactory);
+
+		return restTemplate;
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/credit_history/repository/CreditHistoryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/credit_history/repository/CreditHistoryRepository.java
@@ -1,10 +1,16 @@
 package com.dnd.gongmuin.credit_history.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.dnd.gongmuin.credit_history.domain.CreditHistory;
+import com.dnd.gongmuin.member.domain.Member;
 
 @Repository
 public interface CreditHistoryRepository extends JpaRepository<CreditHistory, Long> {
+	void deleteByMember(Member member);
+
+	List<CreditHistory> findAllByMember(Member loginMember);
 }

--- a/src/main/java/com/dnd/gongmuin/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/member/exception/MemberErrorCode.java
@@ -16,7 +16,8 @@ public enum MemberErrorCode implements ErrorCode {
 	UPDATE_PROFILE_FAILED("프로필 수정에 실패했습니다.", "MEMBER_005"),
 	QUESTION_POSTS_BY_MEMBER_FAILED("마이페이지 게시글 목록을 불러오는데 실패했습니다", "MEMBER_006"),
 	NOT_FOUND_JOB_GROUP("직군을 올바르게 입력해주세요.", "MEMBER_007"),
-	NOT_FOUND_JOB_CATEGORY("직렬을 올바르게 입력해주세요.", "MEMBER_008");
+	NOT_FOUND_JOB_CATEGORY("직렬을 올바르게 입력해주세요.", "MEMBER_008"),
+	DELETE_FAILED("회원탈퇴를 실패했습니다.", "MEMBER_009");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/member/repository/MemberRepository.java
+++ b/src/main/java/com/dnd/gongmuin/member/repository/MemberRepository.java
@@ -1,21 +1,22 @@
 package com.dnd.gongmuin.member.repository;
 
+import com.dnd.gongmuin.member.domain.Member;
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import com.dnd.gongmuin.member.domain.Member;
-
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustom {
-	Optional<Member> findBySocialEmail(String socialEmail);
+    Optional<Member> findBySocialEmail(String socialEmail);
 
-	boolean existsByNickname(String nickname);
+    boolean existsByNickname(String nickname);
 
-	boolean existsByOfficialEmail(String officialEmail);
+    boolean existsByOfficialEmail(String officialEmail);
 
-	boolean existsBySocialEmail(String socialEmail);
+    boolean existsBySocialEmail(String socialEmail);
 
-	Member findByOfficialEmail(String officialEmail);
+    Member findByOfficialEmail(String officialEmail);
+
+    Optional<Member> findByRole(String role);
+
 }

--- a/src/main/java/com/dnd/gongmuin/member/service/MemberService.java
+++ b/src/main/java/com/dnd/gongmuin/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.dnd.gongmuin.member.service;
 
+import java.time.Duration;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -23,6 +25,7 @@ import com.dnd.gongmuin.member.dto.response.MemberProfileResponse;
 import com.dnd.gongmuin.member.dto.response.QuestionPostsResponse;
 import com.dnd.gongmuin.member.exception.MemberErrorCode;
 import com.dnd.gongmuin.member.repository.MemberRepository;
+import com.dnd.gongmuin.redis.util.RedisUtil;
 import com.dnd.gongmuin.security.oauth2.Oauth2Response;
 
 import lombok.RequiredArgsConstructor;
@@ -31,17 +34,35 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberService {
 
+	private static final long ACCESS_TOKEN_EXPIRATION = 3600 * 1000;
 	private final MemberRepository memberRepository;
+	private final RedisUtil redisUtil;
 
 	public Member saveOrUpdate(Oauth2Response oauth2Response) {
 		Member member = memberRepository.findBySocialEmail(oauth2Response.createSocialEmail())
 			.map(m -> {
 				m.updateSocialEmail(oauth2Response.createSocialEmail());
+				deleteExistingOauthAccessToken(m);
+				saveOauth2AccessToken(oauth2Response, m);
 				return m;
 			})
 			.orElseGet(() -> createMemberFromOauth2Response(oauth2Response));
 
 		return memberRepository.save(member);
+	}
+
+	private void saveOauth2AccessToken(Oauth2Response oauth2Response, Member m) {
+		redisUtil.setValues(
+			"AT(oauth):" + m.getSocialEmail(),
+			oauth2Response.getOauth2AccessToken(),
+			Duration.ofMillis(ACCESS_TOKEN_EXPIRATION)
+		);
+	}
+
+	private void deleteExistingOauthAccessToken(Member m) {
+		if (redisUtil.getValues("AT(oauth2):" + m.getSocialEmail()) != null) {
+			redisUtil.deleteValues("AT(oauth2):" + m.getSocialEmail());
+		}
 	}
 
 	public Provider parseProviderFromSocialEmail(Member member) {
@@ -50,7 +71,9 @@ public class MemberService {
 	}
 
 	private Member createMemberFromOauth2Response(Oauth2Response oauth2Response) {
-		return Member.of(oauth2Response.getName(), oauth2Response.createSocialEmail(), 10000, "ROLE_GUEST");
+		Member member = Member.of(oauth2Response.getName(), oauth2Response.createSocialEmail(), 10000, "ROLE_GUEST");
+		saveOauth2AccessToken(oauth2Response, member);
+		return member;
 	}
 
 	public Member getMemberBySocialEmail(String socialEmail) {

--- a/src/main/java/com/dnd/gongmuin/member/service/MemberService.java
+++ b/src/main/java/com/dnd/gongmuin/member/service/MemberService.java
@@ -42,7 +42,7 @@ public class MemberService {
 		Member member = memberRepository.findBySocialEmail(oauth2Response.createSocialEmail())
 			.map(m -> {
 				m.updateSocialEmail(oauth2Response.createSocialEmail());
-				deleteExistingOauthAccessToken(m);
+				deleteOauthAccessTokenIfExists(m);
 				saveOauth2AccessToken(oauth2Response, m);
 				return m;
 			})
@@ -59,7 +59,7 @@ public class MemberService {
 		);
 	}
 
-	private void deleteExistingOauthAccessToken(Member m) {
+	private void deleteOauthAccessTokenIfExists(Member m) {
 		if (redisUtil.getValues("AT(oauth2):" + m.getSocialEmail()) != null) {
 			redisUtil.deleteValues("AT(oauth2):" + m.getSocialEmail());
 		}

--- a/src/main/java/com/dnd/gongmuin/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/dnd/gongmuin/notification/repository/NotificationRepository.java
@@ -1,10 +1,11 @@
 package com.dnd.gongmuin.notification.repository;
 
+import com.dnd.gongmuin.member.domain.Member;
+import com.dnd.gongmuin.notification.domain.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import com.dnd.gongmuin.notification.domain.Notification;
-
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationCustom {
+    void deleteByMember(Member member);
 }

--- a/src/main/java/com/dnd/gongmuin/post_interaction/repository/InteractionRepository.java
+++ b/src/main/java/com/dnd/gongmuin/post_interaction/repository/InteractionRepository.java
@@ -1,5 +1,6 @@
 package com.dnd.gongmuin.post_interaction.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +19,8 @@ public interface InteractionRepository extends JpaRepository<Interaction, Long> 
 	Optional<Interaction> findByQuestionPostIdAndMemberIdAndType(
 		Long questionPostId, Long memberId, InteractionType type
 	);
+
+	void deleteByMemberId(Long memberId);
+
+	List<Interaction> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
@@ -122,4 +122,8 @@ public class QuestionPost extends TimeBaseEntity {
 		this.reward = reward;
 		this.jobGroup = jobGroup;
 	}
+
+	public void updateMember(Member anonymous) {
+		this.member = anonymous;
+	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepository.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepository.java
@@ -1,11 +1,16 @@
 package com.dnd.gongmuin.question_post.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 
 @Repository
 public interface QuestionPostRepository extends JpaRepository<QuestionPost, Long>, QuestionPostQueryRepository {
 	boolean existsById(Long id);
+
+	List<QuestionPost> findAllByMember(Member member);
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepository.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepository.java
@@ -3,6 +3,8 @@ package com.dnd.gongmuin.question_post.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.dnd.gongmuin.member.domain.Member;
@@ -13,4 +15,8 @@ public interface QuestionPostRepository extends JpaRepository<QuestionPost, Long
 	boolean existsById(Long id);
 
 	List<QuestionPost> findAllByMember(Member member);
+
+	@Modifying(flushAutomatically = true, clearAutomatically = true)
+	@Query("UPDATE QuestionPost q SET q.member = :anonymous WHERE q.member.id = :memberId")
+	public void updateQuestionPosts(Long memberId, Member anonymous);
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepository.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepository.java
@@ -15,6 +15,6 @@ public interface QuestionPostRepository extends JpaRepository<QuestionPost, Long
     List<QuestionPost> findAllByMember(Member member);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("UPDATE QuestionPost q SET q.member = :anonymous WHERE q.member.id = :memberId")
+    @Query("UPDATE QuestionPost q SET q.member = :member WHERE q.member.id = :memberId")
     public void updateQuestionPostsMember(Long memberId, Member member);
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepository.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepository.java
@@ -1,22 +1,20 @@
 package com.dnd.gongmuin.question_post.repository;
 
+import com.dnd.gongmuin.member.domain.Member;
+import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import com.dnd.gongmuin.member.domain.Member;
-import com.dnd.gongmuin.question_post.domain.QuestionPost;
-
 @Repository
 public interface QuestionPostRepository extends JpaRepository<QuestionPost, Long>, QuestionPostQueryRepository {
-	boolean existsById(Long id);
+    boolean existsById(Long id);
 
-	List<QuestionPost> findAllByMember(Member member);
+    List<QuestionPost> findAllByMember(Member member);
 
-	@Modifying(flushAutomatically = true, clearAutomatically = true)
-	@Query("UPDATE QuestionPost q SET q.member = :anonymous WHERE q.member.id = :memberId")
-	public void updateQuestionPosts(Long memberId, Member anonymous);
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("UPDATE QuestionPost q SET q.member = :anonymous WHERE q.member.id = :memberId")
+    public void updateQuestionPostsMember(Long memberId, Member member);
 }

--- a/src/main/java/com/dnd/gongmuin/security/exception/OAuth2ErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/security/exception/OAuth2ErrorCode.java
@@ -1,0 +1,17 @@
+package com.dnd.gongmuin.security.exception;
+
+import com.dnd.gongmuin.common.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuth2ErrorCode implements ErrorCode {
+
+	INVALID_REQUEST("유효하지 않은 탈퇴 요청입니다.", "OAUTH2_001"),
+	EXPIRED_AUTH_TOKEN("만료된 OAuth2 토큰입니다.", "OAUTH2_002"),
+	INTERNAL_SERVER_ERROR("OAuth 서버 에러 발생입니다.", "OAUTH2_003");
+	private final String message;
+	private final String code;
+}

--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenAuthenticationFilter.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenAuthenticationFilter.java
@@ -33,7 +33,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
 		if (tokenProvider.validateToken(accessToken, new Date())) {
 			// accessToken logout 여부 확인
-			if (tokenProvider.verifyLogout(accessToken)) {
+			if (tokenProvider.verifyBlackList(accessToken)) {
 				saveAuthentication(accessToken);
 			}
 		}

--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenProvider.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenProvider.java
@@ -1,10 +1,10 @@
 package com.dnd.gongmuin.security.jwt.util;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import javax.crypto.SecretKey;
@@ -40,6 +40,7 @@ import lombok.RequiredArgsConstructor;
 public class TokenProvider {
 
 	private static final String ROLE_KEY = "ROLE";
+	private static final String[] BLACKLIST = new String[] {"false", "delete"};
 	private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 90L;
 	private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24L;
 	private final MemberRepository memberRepository;
@@ -136,9 +137,9 @@ public class TokenProvider {
 		return (expiration.getTime() - date.getTime());
 	}
 
-	public boolean verifyLogout(String accessToken) {
+	public boolean verifyBlackList(String accessToken) {
 		String value = redisUtil.getValues(accessToken);
-		return Objects.equals("false", value);
+		return Arrays.asList(BLACKLIST).contains(value);
 	}
 
 }

--- a/src/main/java/com/dnd/gongmuin/security/oauth2/KakaoResponse.java
+++ b/src/main/java/com/dnd/gongmuin/security/oauth2/KakaoResponse.java
@@ -8,10 +8,12 @@ public class KakaoResponse implements Oauth2Response {
 
 	private final Map<String, Object> attribute;
 	private final Long id;
+	private final String oauth2AccessToken;
 
-	public KakaoResponse(Map<String, Object> attribute) {
+	public KakaoResponse(Map<String, Object> attribute, String oauth2AccessToken) {
 		this.attribute = (Map<String, Object>)attribute.get("kakao_account");
 		this.id = (Long)attribute.get("id");
+		this.oauth2AccessToken = oauth2AccessToken;
 	}
 
 	@Override
@@ -41,6 +43,11 @@ public class KakaoResponse implements Oauth2Response {
 			this.getProviderId(),
 			this.getEmail()
 		);
+	}
+
+	@Override
+	public String getOauth2AccessToken() {
+		return this.oauth2AccessToken;
 	}
 
 }

--- a/src/main/java/com/dnd/gongmuin/security/oauth2/NaverResponse.java
+++ b/src/main/java/com/dnd/gongmuin/security/oauth2/NaverResponse.java
@@ -7,9 +7,11 @@ import com.dnd.gongmuin.member.domain.Provider;
 public class NaverResponse implements Oauth2Response {
 
 	private final Map<String, Object> attribute;
+	private final String oauth2AccessToken;
 
-	public NaverResponse(Map<String, Object> attribute) {
+	public NaverResponse(Map<String, Object> attribute, String oauth2AccessToken) {
 		this.attribute = (Map<String, Object>)attribute.get("response");
+		this.oauth2AccessToken = oauth2AccessToken;
 	}
 
 	@Override
@@ -39,5 +41,10 @@ public class NaverResponse implements Oauth2Response {
 			this.getProviderId(),
 			this.getEmail()
 		);
+	}
+
+	@Override
+	public String getOauth2AccessToken() {
+		return this.oauth2AccessToken;
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/security/oauth2/Oauth2Response.java
+++ b/src/main/java/com/dnd/gongmuin/security/oauth2/Oauth2Response.java
@@ -11,4 +11,5 @@ public interface Oauth2Response {
 
 	String createSocialEmail();
 
+	String getOauth2AccessToken();
 }

--- a/src/main/java/com/dnd/gongmuin/security/service/CustomOauth2UserService.java
+++ b/src/main/java/com/dnd/gongmuin/security/service/CustomOauth2UserService.java
@@ -34,13 +34,15 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
 	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 		OAuth2User oAuth2User = super.loadUser(userRequest);
 
+		String oauth2AccessToken = userRequest.getAccessToken().getTokenValue();
+
 		String registrationId = userRequest.getClientRegistration().getRegistrationId();
 		Oauth2Response oauth2Response = null;
 
 		if (Objects.equals(registrationId, KAKAO.getLabel())) {
-			oauth2Response = new KakaoResponse(oAuth2User.getAttributes());
+			oauth2Response = new KakaoResponse(oAuth2User.getAttributes(), oauth2AccessToken);
 		} else if (Objects.equals(registrationId, NAVER.getLabel())) {
-			oauth2Response = new NaverResponse(oAuth2User.getAttributes());
+			oauth2Response = new NaverResponse(oAuth2User.getAttributes(), oauth2AccessToken);
 		} else {
 			throw new OAuth2AuthenticationException(
 				new OAuth2Error(UNSUPPORTED_SOCIAL_LOGIN.getCode()),
@@ -57,5 +59,6 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
 		);
 		return new CustomOauth2User(authInfo);
 	}
+
 }
 

--- a/src/main/java/com/dnd/gongmuin/security/service/OAuth2UnlinkService.java
+++ b/src/main/java/com/dnd/gongmuin/security/service/OAuth2UnlinkService.java
@@ -1,0 +1,105 @@
+package com.dnd.gongmuin.security.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.dnd.gongmuin.common.exception.runtime.ValidationException;
+import com.dnd.gongmuin.redis.util.RedisUtil;
+import com.dnd.gongmuin.security.exception.OAuth2ErrorCode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class OAuth2UnlinkService {
+
+	private static final String KAKAO_URL = "https://kapi.kakao.com/v1/user/unlink";
+	private static final String NAVER_URL = "https://nid.naver.com/oauth2.0/token";
+	private final RestTemplate restTemplate;
+	private final RedisUtil redisUtil;
+	@Value("${spring.security.oauth2.client.registration.naver.client-id}")
+	private String NAVER_CLIENT_ID;
+	@Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+	private String NAVER_CLIENT_SECRET;
+
+	public void unlink(String provider) {
+		if (provider.startsWith("kakao")) {
+			kakaoUnlink(provider);
+		} else if (provider.startsWith("naver")) {
+			naverUnlink(provider);
+		} else {
+			throw new ValidationException(OAuth2ErrorCode.INVALID_REQUEST);
+		}
+	}
+
+	public void kakaoUnlink(String provider) {
+		String accessToken = redisUtil.getValues("AT(oauth):" + provider);
+		// oauth2 토큰이 만료 시 재 로그인
+		if (accessToken == null) {
+			throw new ValidationException(OAuth2ErrorCode.EXPIRED_AUTH_TOKEN);
+		}
+		HttpHeaders headers = new HttpHeaders();
+		headers.setBearerAuth(accessToken);
+		HttpEntity<Object> entity = new HttpEntity<>("", headers);
+		ResponseEntity<String> responseEntity = restTemplate.exchange(
+			KAKAO_URL,
+			HttpMethod.POST,
+			entity,
+			String.class
+		);
+
+		if (responseEntity.getBody().isEmpty()) {
+			throw new ValidationException(OAuth2ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	public void naverUnlink(String provider) {
+		String accessToken = redisUtil.getValues("AT(oauth):" + provider);
+
+		// oauth2 토큰이 만료 시 재 로그인
+		if (accessToken == null) {
+			throw new ValidationException(OAuth2ErrorCode.EXPIRED_AUTH_TOKEN);
+		}
+
+		String url = NAVER_URL +
+			"?service_provider=NAVER" +
+			"&grant_type=delete" +
+			"&client_id=" +
+			NAVER_CLIENT_ID +
+			"&client_secret=" +
+			NAVER_CLIENT_SECRET +
+			"&access_token=" +
+			accessToken;
+
+		NaverUnlinkResponse response = restTemplate.getForObject(url, NaverUnlinkResponse.class);
+
+		if (response != null && !"success".equalsIgnoreCase(response.getResult())) {
+			throw new ValidationException(OAuth2ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	/**
+	 * 네이버 응답 데이터
+	 */
+	@Getter
+	public static class NaverUnlinkResponse {
+		private final String accessToken;
+		private final String result;
+
+		@JsonCreator
+		public NaverUnlinkResponse(
+			@JsonProperty("access_token") String accessToken,
+			@JsonProperty("result") String result) {
+			this.accessToken = accessToken;
+			this.result = result;
+		}
+	}
+}

--- a/src/test/java/com/dnd/gongmuin/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/auth/service/AuthServiceTest.java
@@ -243,14 +243,11 @@ class AuthServiceTest {
 		given(redisUtil.getValues(anyString())).willReturn("delete");
 		given(memberRepository.findByRole("ROLE_ANONYMOUS")).willReturn(Optional.of(principal));
 
-		given(questionPostRepository.findAllByMember(principal)).willReturn(mockQuestionPosts);
-		given(answerRepository.findAllByMember(principal)).willReturn(mockAnswers);
-
 		// when
 		authService.deleteMember(mockRequest);
 
 		// then
-		verify(questionPostRepository).findAllByMember(principal);
-		verify(answerRepository).findAllByMember(principal);
+		verify(questionPostRepository).updateQuestionPosts(any(), any());
+		verify(answerRepository).updateAnswers(any(), any());
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/auth/service/AuthServiceTest.java
@@ -1,24 +1,13 @@
 package com.dnd.gongmuin.auth.service;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
-
-import java.time.Duration;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyString;
+import static org.mockito.BDDMockito.doNothing;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.willDoNothing;
 
 import com.dnd.gongmuin.answer.domain.Answer;
 import com.dnd.gongmuin.answer.repository.AnswerRepository;
@@ -44,210 +33,224 @@ import com.dnd.gongmuin.security.jwt.util.CookieUtil;
 import com.dnd.gongmuin.security.jwt.util.TokenProvider;
 import com.dnd.gongmuin.security.oauth2.CustomOauth2User;
 import com.dnd.gongmuin.security.service.OAuth2UnlinkService;
-
 import jakarta.servlet.http.Cookie;
+import java.time.Duration;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
 
-	@Mock
-	private MemberRepository memberRepository;
-	@Mock
-	private OAuth2UnlinkService oAuth2UnlinkService;
-	@Mock
-	private CreditHistoryRepository creditHistoryRepository;
-	@Mock
-	private QuestionPostRepository questionPostRepository;
-	@Mock
-	private AnswerRepository answerRepository;
-	@Mock
-	private InteractionRepository interactionRepository;
-	@Mock
-	private NotificationRepository notificationRepository;
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private OAuth2UnlinkService oAuth2UnlinkService;
+    @Mock
+    private CreditHistoryRepository creditHistoryRepository;
+    @Mock
+    private QuestionPostRepository questionPostRepository;
+    @Mock
+    private AnswerRepository answerRepository;
+    @Mock
+    private InteractionRepository interactionRepository;
+    @Mock
+    private NotificationRepository notificationRepository;
 
-	@Mock
-	private TokenProvider tokenProvider;
+    @Mock
+    private TokenProvider tokenProvider;
 
-	@Mock
-	private RedisUtil redisUtil;
+    @Mock
+    private RedisUtil redisUtil;
 
-	@Mock
-	private CookieUtil cookieUtil;
+    @Mock
+    private CookieUtil cookieUtil;
 
-	@InjectMocks
-	private AuthService authService;
+    @InjectMocks
+    private AuthService authService;
 
-	@DisplayName("공무원 이메일이 존재하는지 체크한다.")
-	@Test
-	void isOfficialEmail() {
-		// given
-		Member kakaoMember = MemberFixture.member();
+    @DisplayName("공무원 이메일이 존재하는지 체크한다.")
+    @Test
+    void isOfficialEmail() {
+        // given
+        Member kakaoMember = MemberFixture.member();
 
-		// when
-		boolean result = authService.isOfficialEmail(kakaoMember);
+        // when
+        boolean result = authService.isOfficialEmail(kakaoMember);
 
-		// then
-		assertThat(result).isFalse();
+        // then
+        assertThat(result).isFalse();
 
-	}
+    }
 
-	@DisplayName("중복 닉네임이 존재하는지 체크한다.")
-	@Test
-	void isDuplicatedNickname() {
-		// given
-		given(memberRepository.existsByNickname("김철수")).willReturn(true);
-		ValidateNickNameRequest request = new ValidateNickNameRequest("김철수");
+    @DisplayName("중복 닉네임이 존재하는지 체크한다.")
+    @Test
+    void isDuplicatedNickname() {
+        // given
+        given(memberRepository.existsByNickname("김철수")).willReturn(true);
+        ValidateNickNameRequest request = new ValidateNickNameRequest("김철수");
 
-		// when
-		ValidateNickNameResponse duplicatedNickname = authService.isDuplicatedNickname(request);
+        // when
+        ValidateNickNameResponse duplicatedNickname = authService.isDuplicatedNickname(request);
 
-		// then
-		assertThat(duplicatedNickname.isDuplicated()).isTrue();
-	}
+        // then
+        assertThat(duplicatedNickname.isDuplicated()).isTrue();
+    }
 
-	@DisplayName("신규 회원은 추가 정보가 업데이트 된다.")
-	@Test
-	void signUp() {
-		// given
-		AdditionalInfoRequest request = new AdditionalInfoRequest("abc123@korea.com", "김신규", "공업", "일반기계");
-		MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+    @DisplayName("신규 회원은 추가 정보가 업데이트 된다.")
+    @Test
+    void signUp() {
+        // given
+        AdditionalInfoRequest request = new AdditionalInfoRequest("abc123@korea.com", "김신규", "공업", "일반기계");
+        MockHttpServletResponse mockResponse = new MockHttpServletResponse();
 
-		Member member1 = MemberFixture.member3();
-		given(memberRepository.findBySocialEmail(member1.getSocialEmail())).willReturn(
-			Optional.of(member1));
+        Member member1 = MemberFixture.member3();
+        given(memberRepository.findBySocialEmail(member1.getSocialEmail())).willReturn(
+                Optional.of(member1));
 
-		// when
-		authService.signUp(request, member1.getSocialEmail(), mockResponse);
+        // when
+        authService.signUp(request, member1.getSocialEmail(), mockResponse);
 
-		// then
-		assertThat(member1).extracting("officialEmail", "nickname", "jobGroup", "jobCategory")
-			.containsExactlyInAnyOrder(
-				"abc123@korea.com",
-				"김신규",
-				JobGroup.ENG,
-				JobCategory.GME
-			);
-	}
+        // then
+        assertThat(member1).extracting("officialEmail", "nickname", "jobGroup", "jobCategory")
+                .containsExactlyInAnyOrder(
+                        "abc123@korea.com",
+                        "김신규",
+                        JobGroup.ENG,
+                        JobCategory.GME
+                );
+    }
 
-	@DisplayName("로그인 회원은 로그아웃 할 수 있다.")
-	@Test
-	void logout() {
-		// given
-		Long fiveMinutes = 300_000L;
+    @DisplayName("로그인 회원은 로그아웃 할 수 있다.")
+    @Test
+    void logout() {
+        // given
+        Long fiveMinutes = 300_000L;
 
-		Member principal = MemberFixture.member();
-		Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "test");
+        Member principal = MemberFixture.member();
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "test");
 
-		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
-		MockHttpServletResponse mockResponse = new MockHttpServletResponse();
-		mockRequest.setCookies(new Cookie("Authorization", "testtesttesttest"));
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+        MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+        mockRequest.setCookies(new Cookie("Authorization", "testtesttesttest"));
 
-		given(cookieUtil.getCookieValue(mockRequest)).willReturn("testtesttesttest");
-		given(tokenProvider.validateToken(anyString(), any(Date.class))).willReturn(true);
-		given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
-		given(tokenProvider.getExpiration(anyString(), any(Date.class))).willReturn(fiveMinutes);
-		given(redisUtil.getValues(anyString())).willReturn("refresh");
-		given(redisUtil.getValues(anyString())).willReturn("logout");
+        given(cookieUtil.getCookieValue(mockRequest)).willReturn("testtesttesttest");
+        given(tokenProvider.validateToken(anyString(), any(Date.class))).willReturn(true);
+        given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
+        given(tokenProvider.getExpiration(anyString(), any(Date.class))).willReturn(fiveMinutes);
+        given(redisUtil.getValues(anyString())).willReturn("refresh");
+        given(redisUtil.getValues(anyString())).willReturn("logout");
 
-		willDoNothing().given(redisUtil).setValues(anyString(), anyString(), any(Duration.class));
+        willDoNothing().given(redisUtil).setValues(anyString(), anyString(), any(Duration.class));
 
-		// when
-		LogoutResponse response = authService.logout(mockRequest, mockResponse);
+        // when
+        LogoutResponse response = authService.logout(mockRequest, mockResponse);
 
-		// then
-		assertThat(response.result()).isTrue();
-		assertThat(mockResponse.getCookies()).isEmpty();
-	}
+        // then
+        assertThat(response.result()).isTrue();
+        assertThat(mockResponse.getCookies()).isEmpty();
+    }
 
-	@DisplayName("refresh 토큰이 만료되지 않았다면 재발급 할 수 있다.")
-	@Test
-	void reissue() {
-		// given
-		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
-		MockHttpServletResponse mockResponse = new MockHttpServletResponse();
-		mockRequest.setCookies(new Cookie("Authorization", "testtesttesttest"));
+    @DisplayName("refresh 토큰이 만료되지 않았다면 재발급 할 수 있다.")
+    @Test
+    void reissue() {
+        // given
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+        MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+        mockRequest.setCookies(new Cookie("Authorization", "testtesttesttest"));
 
-		Member principal = MemberFixture.member();
-		Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "test");
+        Member principal = MemberFixture.member();
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "test");
 
-		given(cookieUtil.getCookieValue(mockRequest)).willReturn("testtesttesttest");
-		given(cookieUtil.createCookie(anyString())).willReturn(new Cookie("Authorization", "reissueToken"));
-		given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
-		given(redisUtil.getValues(anyString())).willReturn("refreshToken");
-		given(tokenProvider.generateAccessToken(any(CustomOauth2User.class), any(Date.class))).willReturn(
-			"reissueToken");
-		given(tokenProvider.generateRefreshToken(any(CustomOauth2User.class), any(Date.class))).willReturn(
-			"reissueToken");
+        given(cookieUtil.getCookieValue(mockRequest)).willReturn("testtesttesttest");
+        given(cookieUtil.createCookie(anyString())).willReturn(new Cookie("Authorization", "reissueToken"));
+        given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
+        given(redisUtil.getValues(anyString())).willReturn("refreshToken");
+        given(tokenProvider.generateAccessToken(any(CustomOauth2User.class), any(Date.class))).willReturn(
+                "reissueToken");
+        given(tokenProvider.generateRefreshToken(any(CustomOauth2User.class), any(Date.class))).willReturn(
+                "reissueToken");
 
-		// when
-		ReissueResponse response = authService.reissue(mockRequest, mockResponse);
-		Cookie[] cookies = mockResponse.getCookies();
+        // when
+        ReissueResponse response = authService.reissue(mockRequest, mockResponse);
+        Cookie[] cookies = mockResponse.getCookies();
 
-		// then
-		Assertions.assertAll(
-			() -> assertThat(response.result()).isTrue(),
-			() -> assertThat(cookies)
-				.hasSize(1)
-				.extracting(Cookie::getName, Cookie::getValue)
-				.containsExactly(tuple("Authorization", "reissueToken"))
-		);
-	}
+        // then
+        Assertions.assertAll(
+                () -> assertThat(response.result()).isTrue(),
+                () -> assertThat(cookies)
+                        .hasSize(1)
+                        .extracting(Cookie::getName, Cookie::getValue)
+                        .containsExactly(tuple("Authorization", "reissueToken"))
+        );
+    }
 
-	@DisplayName("회원 삭제 시 크레딧 내역, 알림, 상호작용은 모두 삭제된다.")
-	@Test
-	void deleteMemberWithAssociatedDatas() {
-		// given
-		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
-		mockRequest.setCookies(new Cookie("Authorization", "testtesttesttest"));
+    @DisplayName("회원 삭제 시 크레딧 내역, 알림, 상호작용은 모두 삭제된다.")
+    @Test
+    void deleteMemberWithAssociatedDatas() {
+        // given
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+        mockRequest.setCookies(new Cookie("Authorization", "testtesttesttest"));
 
-		Member principal = MemberFixture.member(1L);
-		Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "test");
+        Member principal = MemberFixture.member(1L);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "test");
 
-		given(cookieUtil.getCookieValue(mockRequest)).willReturn("testtesttesttest");
-		given(tokenProvider.validateToken(anyString(), any(Date.class))).willReturn(true);
-		given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
-		given(redisUtil.getValues(anyString())).willReturn("delete");
-		given(memberRepository.findByRole("ROLE_ANONYMOUS")).willReturn(Optional.of(principal));
+        given(cookieUtil.getCookieValue(mockRequest)).willReturn("testtesttesttest");
+        given(tokenProvider.validateToken(anyString(), any(Date.class))).willReturn(true);
+        given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
+        given(redisUtil.getValues(anyString())).willReturn("delete");
+        given(memberRepository.findByRole("ROLE_ANONYMOUS")).willReturn(Optional.of(principal));
 
-		doNothing().when(creditHistoryRepository).deleteByMember(principal);
-		doNothing().when(notificationRepository).deleteByMember(principal);
-		doNothing().when(interactionRepository).deleteByMemberId(principal.getId());
-		doNothing().when(memberRepository).delete(principal);
+        doNothing().when(creditHistoryRepository).deleteByMember(principal);
+        doNothing().when(notificationRepository).deleteByMember(principal);
+        doNothing().when(interactionRepository).deleteByMemberId(principal.getId());
+        doNothing().when(memberRepository).delete(principal);
 
-		// when
-		authService.deleteMember(mockRequest);
+        // when
+        authService.deleteMember(mockRequest);
 
-		// then
-		verify(creditHistoryRepository).deleteByMember(principal);
-		verify(notificationRepository).deleteByMember(principal);
-		verify(interactionRepository).deleteByMemberId(principal.getId());
-		verify(memberRepository).delete(principal);
-	}
+        // then
+        verify(creditHistoryRepository).deleteByMember(principal);
+        verify(notificationRepository).deleteByMember(principal);
+        verify(interactionRepository).deleteByMemberId(principal.getId());
+        verify(memberRepository).delete(principal);
+    }
 
-	@DisplayName("회원 삭제 시 연관된 답변과 게시글은 모두 익명 회원 정보로 교체된다.")
-	@Test
-	void deleteMember() {
-		// given
-		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
-		mockRequest.setCookies(new Cookie("Authorization", "testtesttesttest"));
+    @DisplayName("회원 삭제 시 연관된 답변과 게시글은 모두 익명 회원 정보로 교체된다.")
+    @Test
+    void deleteMember() {
+        // given
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+        mockRequest.setCookies(new Cookie("Authorization", "testtesttesttest"));
 
-		Member principal = MemberFixture.member(1L);
-		Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "test");
+        Member principal = MemberFixture.member(1L);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "test");
 
-		List<QuestionPost> mockQuestionPosts = List.of(QuestionPostFixture.questionPost(1L, principal));
-		List<Answer> mockAnswers = List.of(AnswerFixture.answer(1L, principal));
+        List<QuestionPost> mockQuestionPosts = List.of(QuestionPostFixture.questionPost(1L, principal));
+        List<Answer> mockAnswers = List.of(AnswerFixture.answer(1L, principal));
 
-		given(cookieUtil.getCookieValue(mockRequest)).willReturn("testtesttesttest");
-		given(tokenProvider.validateToken(anyString(), any(Date.class))).willReturn(true);
-		given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
-		given(redisUtil.getValues(anyString())).willReturn("delete");
-		given(memberRepository.findByRole("ROLE_ANONYMOUS")).willReturn(Optional.of(principal));
+        given(cookieUtil.getCookieValue(mockRequest)).willReturn("testtesttesttest");
+        given(tokenProvider.validateToken(anyString(), any(Date.class))).willReturn(true);
+        given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
+        given(redisUtil.getValues(anyString())).willReturn("delete");
+        given(memberRepository.findByRole("ROLE_ANONYMOUS")).willReturn(Optional.of(principal));
 
-		// when
-		authService.deleteMember(mockRequest);
+        // when
+        authService.deleteMember(mockRequest);
 
-		// then
-		verify(questionPostRepository).updateQuestionPosts(any(), any());
-		verify(answerRepository).updateAnswers(any(), any());
-	}
+        // then
+        verify(questionPostRepository).updateQuestionPostsMember(any(), any());
+        verify(answerRepository).updateAnswersMember(any(), any());
+    }
 }

--- a/src/test/java/com/dnd/gongmuin/common/fixture/MemberFixture.java
+++ b/src/test/java/com/dnd/gongmuin/common/fixture/MemberFixture.java
@@ -20,7 +20,7 @@ public class MemberFixture {
 			"회원123",
 			JobGroup.ENG,
 			JobCategory.ME,
-			"KAKAO123/gongmuin@daum.net",
+			"kakao123/gongmuin@daum.net",
 			"gongmuin@korea.kr",
 			10000,
 			"ROLE_USER"
@@ -33,7 +33,7 @@ public class MemberFixture {
 			"소셜회원",
 			JobGroup.ENG,
 			JobCategory.ME,
-			"KAKAO123/member2@daum.net",
+			"kakao123/member2@daum.net",
 			"member2@korea.kr",
 			20000,
 			"ROLE_USER"
@@ -43,7 +43,7 @@ public class MemberFixture {
 	public static Member member3() {
 		return Member.of(
 			"소셜회원",
-			"KAKAO123/member2@daum.net",
+			"kakao123/member2@daum.net",
 			20000,
 			"ROLE_GUEST"
 		);
@@ -55,7 +55,7 @@ public class MemberFixture {
 			"소셜회원",
 			JobGroup.AD,
 			JobCategory.ME,
-			"KAKAO1234/member2@daum.net",
+			"kakao1234/member2@daum.net",
 			"member@korea.kr",
 			20000,
 			"ROLE_USER"
@@ -68,7 +68,7 @@ public class MemberFixture {
 			"회원123",
 			JobGroup.ENG,
 			JobCategory.ME,
-			"KAKAO123/gongmuin@daum.net",
+			"kakao123/gongmuin@daum.net",
 			"gongmuin@korea.kr",
 			10000,
 			"ROLE_USER"

--- a/src/test/java/com/dnd/gongmuin/member/service/MemberServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/member/service/MemberServiceTest.java
@@ -71,8 +71,8 @@ class MemberServiceTest {
 		// then
 		assertThat(findMember).extracting("socialName", "socialEmail")
 			.containsExactlyInAnyOrder(
-				"회원123",
-				"KAKAO123/gongmuin@daum.net"
+				member.getSocialName(),
+				member.getSocialEmail()
 			);
 	}
 

--- a/src/test/java/com/dnd/gongmuin/security/jwt/TokenProviderTest.java
+++ b/src/test/java/com/dnd/gongmuin/security/jwt/TokenProviderTest.java
@@ -111,7 +111,7 @@ class TokenProviderTest {
 
 		// then
 		assertThat(authentication.isAuthenticated()).isTrue();
-		assertThat(principal.getSocialEmail()).isEqualTo("KAKAO123/gongmuin@daum.net");
+		assertThat(principal.getSocialEmail()).isEqualTo(member.getSocialEmail());
 	}
 
 	@DisplayName("토큰의 만료일이 현재 시간보다 전이면 만료된 토큰이다.")


### PR DESCRIPTION
### 관련 이슈
- close #117 

### 📑 작업 상세 내용
- 카카오, 네이버 각 연결된 소셜 서비스 연결 끊기
- 서비스 회원 탈퇴(SOFT DELETE) 미구현
  - 추후 논의 필요
- 회원 탈퇴 시 기존 발급 된 AccessToken/RefreshToeken 삭제 및 블랙리스트 추가
### 💫 작업 요약
- 서비스 회원탈퇴(SOFT DELETE)를 제외한 소셜 로그인 회원 탈퇴 로직 구현

### 🔍 중점적으로 리뷰 할 부분
- **여러 논의를 위해서 선제 PR 올립니다..!**
<img width="854" alt="image" src="https://github.com/user-attachments/assets/aefe0d6c-f82d-4a41-932b-a93df3343dac">
- 카카오 개발 문서를 확인하면 회원 탈퇴(연결 끊기) 시 사용자 정보를 복구 불가능한 방법으로 파기해야된다고 합니다? 보관하면 안된다는데 이러면 SOFT DELETE를 하면 안되는것 같기도하네요..
  - 네이버는 아직 문서를 제대로 읽어보지 않아서 잘 모르곘습니다. 추후 확인하고 남기겠습니다.
- 개발 후 카카오 문서를 조금 더 읽어보니 회원 탈퇴 후 이에 대한 응답 값을 카카오 서버 측에 보내주어야 된다는데, 이에 대해 조금 더 확인해보고 진행하겠습니다.

----

## 이후 작업
- 팀 전체 회의 간 SOFT DELETE가 아닌 HARD DELETE 방식으로 변경하기로 결정
- HARD DELETE 방식 구현(단, 공무인의 귀중한 자산인 질문과 답변은 익명(탈퇴자) 회원으로 매핑 변경)