### PR TITLE
[feat #119] 채팅방 상세조회 API

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
@@ -52,6 +52,16 @@ public class ChatRoomController {
 		return ResponseEntity.ok(response);
 	}
 
+	@Operation(summary = "채팅방 조회 API", description = "채팅방 아이디로 채팅방을 조회한다.")
+	@GetMapping("/api/chat-rooms/{chatRoomId}")
+	public ResponseEntity<ChatRoomDetailResponse> createChatRoom(
+		@PathVariable("chatRoomId") Long chatRoomId,
+		@AuthenticationPrincipal Member member
+	) {
+		ChatRoomDetailResponse response = chatRoomService.getChatRoomById(chatRoomId, member);
+		return ResponseEntity.ok(response);
+	}
+
 	@Operation(summary = "채팅 수락 API", description = "채팅방에서 요청자와의 채팅을 수락한다.")
 	@PatchMapping("/api/chat-rooms/{chatRoomId}/accept")
 	public ResponseEntity<AcceptChatResponse> acceptChat(

--- a/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
@@ -26,19 +26,21 @@ public class ChatRoomMapper {
 		);
 	}
 
-	public static ChatRoomDetailResponse toChatRoomDetailResponse(ChatRoom chatRoom) {
+	public static ChatRoomDetailResponse toChatRoomDetailResponse(
+		ChatRoom chatRoom,
+		Member chatPartner
+	) {
 		QuestionPost questionPost = chatRoom.getQuestionPost();
-		Member answerer = chatRoom.getAnswerer(); // 요청자만 채팅방 생성 가능 -> 상태방: 답변자
 
 		return new ChatRoomDetailResponse(
 			questionPost.getId(),
 			questionPost.getJobGroup().getLabel(),
 			questionPost.getTitle(),
 			new MemberInfo(
-				answerer.getId(),
-				answerer.getNickname(),
-				answerer.getJobGroup().getLabel(),
-				answerer.getProfileImageNo()
+				chatPartner.getId(),
+				chatPartner.getNickname(),
+				chatPartner.getJobGroup().getLabel(),
+				chatPartner.getProfileImageNo()
 			),
 			chatRoom.getStatus().getLabel()
 		);

--- a/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomDetailResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomDetailResponse.java
@@ -7,6 +7,6 @@ public record ChatRoomDetailResponse(
 	String targetJobGroup,
 	String title,
 	MemberInfo receiverInfo,
-	String status
+	String chatStatus
 ) {
 }

--- a/src/main/java/com/dnd/gongmuin/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/chat/exception/ChatErrorCode.java
@@ -12,7 +12,8 @@ public enum ChatErrorCode implements ErrorCode {
 	INVALID_MESSAGE_TYPE("메시지 타입을 올바르게 입력해주세요.", "CH_001"),
 	NOT_FOUND_CHAT_ROOM("해당 아이디의 채팅방이 존재하지 않습니다.", "CH_002"),
 	UNAUTHORIZED_REQUEST("채팅 수락을 하거나 거절할 권한이 없습니다.", "CH_003"),
-	UNABLE_TO_CHANGE_CHAT_STATUS("이미 수락했거나 거절한 요청입니다.", "CH_004");
+	UNABLE_TO_CHANGE_CHAT_STATUS("이미 수락했거나 거절한 요청입니다.", "CH_004"),
+	UNAUTHORIZED_CHAT_ROOM("권한이 없는 채팅방입니다", "CH_005");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
@@ -67,7 +67,7 @@ public class ChatRoomService {
 	}
 
 	@Transactional(readOnly = true)
-	public ChatRoomDetailResponse getChatRoomById(Long chatRoomId, Member member){
+	public ChatRoomDetailResponse getChatRoomById(Long chatRoomId, Member member) {
 		ChatRoom chatRoom = getChatRoomById(chatRoomId);
 		Member chatPartner = getChatPartner(member.getId(), chatRoom);
 		return ChatRoomMapper.toChatRoomDetailResponse(chatRoom, chatPartner);
@@ -106,11 +106,10 @@ public class ChatRoomService {
 			.orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
 	}
 
-	private Member getChatPartner(Long memberId, ChatRoom chatRoom){
-		if (Objects.equals(chatRoom.getAnswerer().getId(), memberId)){
+	private Member getChatPartner(Long memberId, ChatRoom chatRoom) {
+		if (Objects.equals(chatRoom.getAnswerer().getId(), memberId)) {
 			return chatRoom.getInquirer();
-		}
-		else if (Objects.equals(chatRoom.getInquirer().getId(), memberId)){
+		} else if (Objects.equals(chatRoom.getInquirer().getId(), memberId)) {
 			return chatRoom.getAnswerer();
 		} else {
 			throw new ValidationException(ChatErrorCode.UNAUTHORIZED_CHAT_ROOM);

--- a/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
@@ -81,6 +81,25 @@ class ChatRoomControllerTest extends ApiTestSupport {
 			.andExpect(status().isOk());
 	}
 
+	@DisplayName("[채팅방 아이디로 채팅방을 상세조회할 수 있다.]")
+	@Test
+	void getChatRoomById() throws Exception {
+		Member inquirer = memberRepository.save(MemberFixture.member4());
+		QuestionPost questionPost = questionPostRepository.save(QuestionPostFixture.questionPost(inquirer));
+		ChatRoom chatRoom = chatRoomRepository.save(ChatRoomFixture.chatRoom(questionPost, inquirer, loginMember));
+
+		mockMvc.perform(get("/api/chat-rooms/{chatRoomId}", chatRoom.getId())
+				.cookie(accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.questionPostId").value(questionPost.getId()))
+			.andExpect(jsonPath("$.targetJobGroup").value(questionPost.getJobGroup().getLabel()))
+			.andExpect(jsonPath("$.title").value(questionPost.getTitle()))
+			.andExpect(jsonPath("$.receiverInfo.memberId").value(inquirer.getId()))
+			.andExpect(jsonPath("$.receiverInfo.nickname").value(inquirer.getNickname()))
+			.andExpect(jsonPath("$.receiverInfo.memberJobGroup").value(inquirer.getJobGroup().getLabel()))
+			.andExpect(jsonPath("$.receiverInfo.profileImageNo").value(inquirer.getProfileImageNo()));
+	}
+
 	@DisplayName("[답변자가 채팅 요청을 수락할 수 있다.]")
 	@Test
 	void acceptChatRoom() throws Exception {


### PR DESCRIPTION
### 관련 이슈
- close #119 

### 📑 작업 상세 내용
- 채팅방 상세 조회 API
  - answerer, inquirer 판단해 상대방 정보 넘겨줌
  - 채팅방 생성과 동일한 응답 사용

### 💫 작업 요약
- 채팅방 상세 조회 API

### 🔍 중점적으로 리뷰 할 부분
- 추후에 parameterized test를 통해 중복되는 테스트 코드를 리팩토링 해볼까 생각중입니다..
