### PR TITLE
[feat #116] 채팅방 목록 조회 API

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
@@ -1,5 +1,7 @@
 package com.dnd.gongmuin.chat.controller;
 
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,6 +16,7 @@ import com.dnd.gongmuin.chat.dto.request.CreateChatRoomRequest;
 import com.dnd.gongmuin.chat.dto.response.AcceptChatResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatMessageResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomDetailResponse;
+import com.dnd.gongmuin.chat.dto.response.ChatRoomSimpleResponse;
 import com.dnd.gongmuin.chat.dto.response.RejectChatResponse;
 import com.dnd.gongmuin.chat.service.ChatRoomService;
 import com.dnd.gongmuin.common.dto.PageResponse;
@@ -49,6 +52,15 @@ public class ChatRoomController {
 		@AuthenticationPrincipal Member member
 	) {
 		ChatRoomDetailResponse response = chatRoomService.createChatRoom(request, member);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "채팅방 목록 조회 API", description = "회원의 채팅방 목록을 조회한다.")
+	@GetMapping("/api/chat-rooms")
+	public ResponseEntity<List<ChatRoomSimpleResponse>> getChatRoomsByMember(
+		@AuthenticationPrincipal Member member
+	) {
+		List<ChatRoomSimpleResponse> response = chatRoomService.getChatRoomsByMember(member);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/chat/dto/ChatMessageMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/ChatMessageMapper.java
@@ -18,6 +18,7 @@ public class ChatMessageMapper {
 			chatMessage.getMemberId(),
 			chatMessage.getContent(),
 			chatMessage.getType().getLabel(),
+			chatMessage.getIsRead(),
 			chatMessage.getCreatedAt().toString()
 		);
 	}

--- a/src/main/java/com/dnd/gongmuin/chat/dto/request/ChatMessageRequest.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/request/ChatMessageRequest.java
@@ -10,6 +10,6 @@ public record ChatMessageRequest(
 	String type,
 
 	@NotNull(message = "회원 아이디를 입력해주세요.")
-	Long memberId
+	Long senderId
 ) {
 }

--- a/src/main/java/com/dnd/gongmuin/chat/dto/request/CreateChatRoomRequest.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/request/CreateChatRoomRequest.java
@@ -6,7 +6,7 @@ public record CreateChatRoomRequest(
 	@NotNull(message = "질문 게시글 아이디는 필수 입력 항목입니다.")
 	Long questionPostId,
 
-	@NotNull(message = "답변 아이디는 필수 입력 항목입니다.")
+	@NotNull(message = "답변자 아이디는 필수 입력 항목입니다.")
 	Long answererId
 ) {
 }

--- a/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatMessageResponse.java
@@ -4,6 +4,7 @@ public record ChatMessageResponse(
 	Long senderId,
 	String content,
 	String type,
+	boolean isRead,
 	String createdAt
 ) {
 }

--- a/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomInfo.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomInfo.java
@@ -1,0 +1,29 @@
+package com.dnd.gongmuin.chat.dto.response;
+
+import com.dnd.gongmuin.member.domain.JobGroup;
+import com.querydsl.core.annotations.QueryProjection;
+
+public record ChatRoomInfo(
+	Long chatRoomId,
+	Long partnerId,
+	String partnerNickname,
+	String partnerJobGroup,
+	int partnerProfileImageNo
+) {
+	@QueryProjection
+	public ChatRoomInfo(
+		Long chatRoomId,
+		Long partnerId,
+		String partnerNickname,
+		JobGroup partnerJobGroup,
+		int partnerProfileImageNo
+	) {
+		this(
+			chatRoomId,
+			partnerId,
+			partnerNickname,
+			partnerJobGroup.getLabel(),
+			partnerProfileImageNo
+		);
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomSimpleResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomSimpleResponse.java
@@ -1,0 +1,11 @@
+package com.dnd.gongmuin.chat.dto.response;
+
+import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
+
+public record ChatRoomSimpleResponse (
+	Long chatRoomId,
+	MemberInfo chatPartner,
+	String latestMessage,
+	String messageType,
+	String messageCreatedAt
+){}

--- a/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomSimpleResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomSimpleResponse.java
@@ -2,10 +2,11 @@ package com.dnd.gongmuin.chat.dto.response;
 
 import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
 
-public record ChatRoomSimpleResponse (
+public record ChatRoomSimpleResponse(
 	Long chatRoomId,
 	MemberInfo chatPartner,
 	String latestMessage,
 	String messageType,
 	String messageCreatedAt
-){}
+) {
+}

--- a/src/main/java/com/dnd/gongmuin/chat/dto/response/LatestChatMessage.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/response/LatestChatMessage.java
@@ -1,0 +1,11 @@
+package com.dnd.gongmuin.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+public record LatestChatMessage(
+	Long chatRoomId,
+	String content,
+	String type,
+	LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatMessageQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatMessageQueryRepository.java
@@ -1,0 +1,40 @@
+package com.dnd.gongmuin.chat.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.stereotype.Component;
+
+import com.dnd.gongmuin.chat.dto.response.LatestChatMessage;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class ChatMessageQueryRepository {
+
+	private final MongoTemplate mongoTemplate;
+
+	public List<LatestChatMessage> findLatestChatByChatRoomIds(List<Long> chatRoomIds) {
+		AggregationOperation sort = Aggregation.sort(Sort.Direction.DESC, "createdAt");
+		AggregationOperation match = Aggregation.match(Criteria.where("chatRoomId").in(chatRoomIds));
+		AggregationOperation group = Aggregation.group("chatRoomId")
+			.first("createdAt").as("createdAt")
+			.first("content").as("content")
+			.first("type").as("type");
+		AggregationOperation project = Aggregation.project()
+			.and("_id").as("chatRoomId")
+			.and("createdAt").as("createdAt")
+			.and("content").as("content")
+			.and("type").as("type");
+		Aggregation aggregation = Aggregation.newAggregation(sort, match, group, project);
+		AggregationResults<LatestChatMessage> results = mongoTemplate.aggregate(aggregation, "chat_messages",
+			LatestChatMessage.class);
+		return results.getMappedResults();
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
@@ -1,0 +1,10 @@
+package com.dnd.gongmuin.chat.repository;
+
+import java.util.List;
+
+import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
+import com.dnd.gongmuin.member.domain.Member;
+
+public interface ChatRoomQueryRepository {
+	List<ChatRoomInfo> getChatRoomsByMember(Member member);
+}

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
 	private final JPAQueryFactory queryFactory;
+
 	public List<ChatRoomInfo> getChatRoomsByMember(Member member) {
 		return queryFactory
 			.select(new QChatRoomInfo(

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.dnd.gongmuin.chat.repository;
+
+import static com.dnd.gongmuin.chat.domain.QChatRoom.*;
+
+import java.util.List;
+
+import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
+import com.dnd.gongmuin.chat.dto.response.QChatRoomInfo;
+import com.dnd.gongmuin.member.domain.Member;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
+	private final JPAQueryFactory queryFactory;
+	public List<ChatRoomInfo> getChatRoomsByMember(Member member) {
+		return queryFactory
+			.select(new QChatRoomInfo(
+				chatRoom.id,
+				new CaseBuilder()
+					.when(chatRoom.inquirer.id.eq(member.getId()))
+					.then(chatRoom.answerer.id)
+					.otherwise(chatRoom.inquirer.id),
+				new CaseBuilder()
+					.when(chatRoom.inquirer.id.eq(member.getId()))
+					.then(chatRoom.answerer.nickname)
+					.otherwise(chatRoom.inquirer.nickname),
+				new CaseBuilder()
+					.when(chatRoom.inquirer.id.eq(member.getId()))
+					.then(chatRoom.answerer.jobGroup)
+					.otherwise(chatRoom.inquirer.jobGroup),
+				new CaseBuilder()
+					.when(chatRoom.inquirer.id.eq(member.getId()))
+					.then(chatRoom.answerer.profileImageNo)
+					.otherwise(chatRoom.inquirer.profileImageNo)
+			))
+			.from(chatRoom)
+			.where(chatRoom.inquirer.id.eq(member.getId())
+				.or(chatRoom.answerer.id.eq(member.getId())))
+			.fetch();
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.dnd.gongmuin.chat.domain.ChatRoom;
 
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatRoomQueryRepository {
 }

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatMessageService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatMessageService.java
@@ -24,10 +24,10 @@ public class ChatMessageService {
 		ChatMessageRequest request,
 		Long chatRoomId
 	) {
-		Long memberId = request.memberId();
+		Long senderId = request.senderId();
 		ChatMessage chatMessage = chatMessageRepository.save(
-			ChatMessageMapper.toChatMessage(request, chatRoomId, memberId));
-		log.info("chatRoomId = {}, memberId= {}, chatMessageId= {}", chatRoomId, memberId, chatMessage.getId());
+			ChatMessageMapper.toChatMessage(request, chatRoomId, senderId));
+		log.info("chatRoomId = {}, senderId= {}, chatMessageId= {}", chatRoomId, senderId, chatMessage.getId());
 		return ChatMessageMapper.toChatMessageResponse(chatMessage);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
@@ -85,18 +85,21 @@ public class ChatRoomService {
 			.map(ChatRoomInfo::chatRoomId)
 			.toList();
 		// 각 채팅방 최근 메시지 정보
-		List<LatestChatMessage> latestChatMessages = chatMessageQueryRepository.findLatestChatByChatRoomIds(chatRoomIds);
+		List<LatestChatMessage> latestChatMessages = chatMessageQueryRepository.findLatestChatByChatRoomIds(
+			chatRoomIds);
 		// <chatRoomId, LatestMessage> -> 순서 보장 x
 		Map<Long, LatestChatMessage> messageMap = latestChatMessages.stream()
 			.collect(Collectors.toMap(LatestChatMessage::chatRoomId, message -> message));
 		// 최신순 정렬
 		return chatRoomInfos.stream()
-			.sorted(Comparator.comparing((ChatRoomInfo info) -> messageMap.get(info.chatRoomId()).createdAt()).reversed())
+			.sorted(
+				Comparator.comparing((ChatRoomInfo info) -> messageMap.get(info.chatRoomId()).createdAt()).reversed())
 			.map(chatRoomInfo -> {
 				LatestChatMessage latestMessage = messageMap.get(chatRoomInfo.chatRoomId());
 				return new ChatRoomSimpleResponse(
 					chatRoomInfo.chatRoomId(),
-					new MemberInfo(chatRoomInfo.partnerId(), chatRoomInfo.partnerNickname(), chatRoomInfo.partnerJobGroup(), chatRoomInfo.partnerProfileImageNo()),
+					new MemberInfo(chatRoomInfo.partnerId(), chatRoomInfo.partnerNickname(),
+						chatRoomInfo.partnerJobGroup(), chatRoomInfo.partnerProfileImageNo()),
 					latestMessage.content(),
 					latestMessage.type(),
 					latestMessage.createdAt().toString()

--- a/src/main/java/com/dnd/gongmuin/member/domain/Member.java
+++ b/src/main/java/com/dnd/gongmuin/member/domain/Member.java
@@ -62,16 +62,6 @@ public class Member extends TimeBaseEntity {
 		this.role = role;
 	}
 
-	@Override
-	public String toString() {
-		return "MEMBER INFO{" +
-			"id=" + id +
-			", role='" + role + '\'' +
-			", jobGroup=" + jobGroup +
-			", socialEmail='" + socialEmail + '\'' +
-			'}';
-	}
-
 	public static Member of(String socialName, String socialEmail, int credit) {
 		return Member.builder()
 			.socialName(socialName)
@@ -101,6 +91,16 @@ public class Member extends TimeBaseEntity {
 			.credit(credit)
 			.role(role)
 			.build();
+	}
+
+	@Override
+	public String toString() {
+		return "MEMBER INFO{" +
+			"id=" + id +
+			", role='" + role + '\'' +
+			", jobGroup=" + jobGroup +
+			", socialEmail='" + socialEmail + '\'' +
+			'}';
 	}
 
 	public void updateSocialEmail(String socialEmail) {

--- a/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
@@ -4,12 +4,14 @@ import static org.springframework.http.MediaType.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import com.dnd.gongmuin.chat.domain.ChatMessage;
 import com.dnd.gongmuin.chat.domain.ChatRoom;
@@ -80,6 +82,50 @@ class ChatRoomControllerTest extends ApiTestSupport {
 				.content(toJson(request))
 				.contentType(APPLICATION_JSON))
 			.andExpect(status().isOk());
+	}
+
+	@DisplayName("[회원의 채팅방 목록을 조회할 수 있다.]")
+	@Test
+	void getChatRoomsByMember() throws Exception {
+		//given
+		Member member1 = memberRepository.save(MemberFixture.member4());
+		Member member2 = memberRepository.save(MemberFixture.member5());
+		List<QuestionPost> questionPosts = questionPostRepository.saveAll(
+			List.of(
+				questionPostRepository.save(QuestionPostFixture.questionPost(member1)),
+				questionPostRepository.save(QuestionPostFixture.questionPost(member2))
+			)
+		);
+		ChatRoom chatRoom1 = chatRoomRepository.save(
+			ChatRoomFixture.chatRoom(questionPosts.get(0), member1, loginMember));
+		ChatRoom chatRoom2 = chatRoomRepository.save(
+			ChatRoomFixture.chatRoom(questionPosts.get(0), member2, loginMember));
+		ChatRoom chatRoom3 = chatRoomRepository.save(
+			ChatRoomFixture.chatRoom(questionPosts.get(1), loginMember, member1));
+		ChatRoom chatRoom4 = chatRoomRepository.save(ChatRoomFixture.chatRoom(questionPosts.get(1), member2, member1));
+		chatMessageRepository.saveAll(
+			List.of(
+				chatMessageRepository.save(
+					ChatMessageFixture.chatMessage(chatRoom1.getId(), "11", LocalDateTime.now())),
+				chatMessageRepository.save(
+					ChatMessageFixture.chatMessage(chatRoom1.getId(), "12", LocalDateTime.now())),
+				chatMessageRepository.save(
+					ChatMessageFixture.chatMessage(chatRoom2.getId(), "21", LocalDateTime.now())),
+				chatMessageRepository.save(
+					ChatMessageFixture.chatMessage(chatRoom2.getId(), "22", LocalDateTime.now())),
+				chatMessageRepository.save(
+					ChatMessageFixture.chatMessage(chatRoom3.getId(), "31", LocalDateTime.now())),
+				chatMessageRepository.save(
+					ChatMessageFixture.chatMessage(chatRoom3.getId(), "32", LocalDateTime.now())),
+				chatMessageRepository.save(
+					ChatMessageFixture.chatMessage(chatRoom4.getId(), "41", LocalDateTime.now())),
+				chatMessageRepository.save(ChatMessageFixture.chatMessage(chatRoom4.getId(), "42", LocalDateTime.now()))
+			)
+		);
+		mockMvc.perform(get("/api/chat-rooms")
+				.cookie(accessToken))
+			.andExpect(status().isOk())
+			.andDo(MockMvcResultHandlers.print());
 	}
 
 	@DisplayName("[채팅방 아이디로 채팅방을 상세조회할 수 있다.]")

--- a/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
@@ -64,7 +64,8 @@ class ChatRoomControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.size").value(2))
 			.andExpect(jsonPath("$.content[0].senderId").value(chatMessages.get(0).getMemberId()))
 			.andExpect(jsonPath("$.content[0].content").value(chatMessages.get(0).getContent()))
-			.andExpect(jsonPath("$.content[0].type").value(chatMessages.get(0).getType().getLabel()));
+			.andExpect(jsonPath("$.content[0].type").value(chatMessages.get(0).getType().getLabel()))
+			.andExpect(jsonPath("$.content[0].isRead").value(chatMessages.get(0).getIsRead()));
 	}
 
 	@DisplayName("[채팅방을 생성할 수 있다.]")

--- a/src/test/java/com/dnd/gongmuin/chat/repository/ChatMessageQueryRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/repository/ChatMessageQueryRepositoryTest.java
@@ -1,0 +1,50 @@
+package com.dnd.gongmuin.chat.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.dnd.gongmuin.chat.dto.response.LatestChatMessage;
+import com.dnd.gongmuin.common.fixture.ChatMessageFixture;
+import com.dnd.gongmuin.common.support.TestContainerSupport;
+
+@SpringBootTest
+class ChatMessageQueryRepositoryTest extends TestContainerSupport {
+
+	@Autowired
+	ChatMessageQueryRepository chatMessageQueryRepository;
+	@Autowired
+	ChatMessageRepository chatMessageRepository;
+
+	@DisplayName("채팅방 아이디 리스트로 각 채팅방의 최근 채팅 메시지를 가져올 수 있다.")
+	@Test
+	void findLatestChatByChatRoomIds() {
+		//given
+		chatMessageRepository.saveAll(List.of(
+			ChatMessageFixture.chatMessage(1L, "첫번째 채팅방 첫번째 메시지", LocalDateTime.now()),
+			ChatMessageFixture.chatMessage(1L, "첫번째 채팅방 두번째 메시지", LocalDateTime.now().plusHours(11)),
+			ChatMessageFixture.chatMessage(2L, "두번째 채팅방 첫번째 메시지", LocalDateTime.now()),
+			ChatMessageFixture.chatMessage(2L, "두번째 채팅방 두번째 메시지", LocalDateTime.now().plusHours(22)),
+			ChatMessageFixture.chatMessage(3L, "세번째 채팅방 첫번째 메시지", LocalDateTime.now())
+		));
+
+		//when
+		List<LatestChatMessage> responses = chatMessageQueryRepository.findLatestChatByChatRoomIds(
+			List.of(1L, 2L));
+
+		//then
+		Assertions.assertAll(
+			() -> assertThat(responses).hasSize(2),
+			() -> assertThat(responses.stream().map(LatestChatMessage::content).collect(Collectors.toList()))
+				.containsExactlyInAnyOrder("두번째 채팅방 두번째 메시지", "첫번째 채팅방 두번째 메시지") // 순서 보장x
+		);
+	}
+}

--- a/src/test/java/com/dnd/gongmuin/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/repository/ChatRoomRepositoryTest.java
@@ -1,0 +1,56 @@
+package com.dnd.gongmuin.chat.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.dnd.gongmuin.chat.domain.ChatRoom;
+import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
+import com.dnd.gongmuin.common.fixture.ChatRoomFixture;
+import com.dnd.gongmuin.common.fixture.MemberFixture;
+import com.dnd.gongmuin.common.fixture.QuestionPostFixture;
+import com.dnd.gongmuin.common.support.DataJpaTestSupport;
+import com.dnd.gongmuin.member.domain.Member;
+import com.dnd.gongmuin.member.repository.MemberRepository;
+import com.dnd.gongmuin.question_post.domain.QuestionPost;
+import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
+
+@DisplayName("[ChatRoomRepository 테스트]")
+class ChatRoomRepositoryTest extends DataJpaTestSupport {
+	@Autowired
+	ChatRoomRepository chatRoomRepository;
+	@Autowired
+	MemberRepository memberRepository;
+	@Autowired
+	QuestionPostRepository questionPostRepository;
+
+	@DisplayName("회원이 속한 채팅방을 모두 조회할 수 있다.")
+	@Test
+	void getChatRoomsByMember() {
+		//given
+		Member questioner = memberRepository.save(MemberFixture.member());
+		Member target = memberRepository.save(MemberFixture.member());
+		Member answerer = memberRepository.save(MemberFixture.member());
+		QuestionPost questionPost = questionPostRepository.save(QuestionPostFixture.questionPost(questioner));
+		List<ChatRoom> chatRooms = chatRoomRepository.saveAll(List.of(
+			chatRoomRepository.save(ChatRoomFixture.chatRoom(questionPost, questioner, answerer)),
+			chatRoomRepository.save(ChatRoomFixture.chatRoom(questionPost, questioner, target)),
+			chatRoomRepository.save(ChatRoomFixture.chatRoom(questionPost, target, answerer))
+		));
+		//when
+		List<ChatRoomInfo> chatRoomInfos = chatRoomRepository.getChatRoomsByMember(target);
+		//then
+		Assertions.assertAll(
+			() -> assertThat(chatRoomInfos).hasSize(2),
+			() -> assertThat(chatRoomInfos.get(0).chatRoomId()).isEqualTo(chatRooms.get(1).getId()),
+			() -> assertThat(chatRoomInfos.get(0).partnerId()).isEqualTo(questioner.getId()),
+			() -> assertThat(chatRoomInfos.get(1).chatRoomId()).isEqualTo(chatRooms.get(2).getId()),
+			() -> assertThat(chatRoomInfos.get(1).partnerId()).isEqualTo(answerer.getId())
+		);
+	}
+}

--- a/src/test/java/com/dnd/gongmuin/common/fixture/ChatMessageFixture.java
+++ b/src/test/java/com/dnd/gongmuin/common/fixture/ChatMessageFixture.java
@@ -1,5 +1,9 @@
 package com.dnd.gongmuin.common.fixture;
 
+import java.time.LocalDateTime;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.dnd.gongmuin.chat.domain.ChatMessage;
 import com.dnd.gongmuin.chat.domain.MessageType;
 
@@ -16,5 +20,16 @@ public class ChatMessageFixture {
 			1L,
 			MessageType.TEXT
 		);
+	}
+
+	public static ChatMessage chatMessage(Long chatRoomId, String content, LocalDateTime createdAt) {
+		ChatMessage chatmessage = ChatMessage.of(
+			content,
+			chatRoomId,
+			1L,
+			MessageType.TEXT
+		);
+		ReflectionTestUtils.setField(chatmessage, "createdAt", createdAt);
+		return chatmessage;
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/common/fixture/MemberFixture.java
+++ b/src/test/java/com/dnd/gongmuin/common/fixture/MemberFixture.java
@@ -62,6 +62,19 @@ public class MemberFixture {
 		);
 	}
 
+	public static Member member5() {
+		return Member.of(
+			"회원",
+			"소셜회원",
+			JobGroup.AD,
+			JobCategory.ME,
+			"KAKAO12345/member2@daum.net",
+			"member@korea.kr",
+			20000,
+			"ROLE_USER"
+		);
+	}
+
 	public static Member member(Long memberId) {
 		Member member = Member.of(
 			"김회원",


### PR DESCRIPTION
### 관련 이슈
- close #116

### 📑 작업 상세 내용
- 채팅방 목록 조회

### 💫 작업 요약
- querydsl로 멤버가 속한 채팅방 목록 조회
- mongoTemplate 활용해 각 채팅방의 최근 메시지 조회
- service에서 stream, map 활용해 통합 및 최신순 정렬

### 🔍 중점적으로 리뷰 할 부분
- caseBuilder로는 객체 조회가 안되더라고요. 그래서 각 필드마다 caseBuilder를 적용했습니다.
- 한 번 리팩토링을 거쳐야 할 것 같습니다..
- 현재는 페이징 처리가 안되는데 추후에 처리할 수 있는지 한번 고민해보겠습니다.
- 채팅방 안읽음 수는 채팅방 메시지 읽기 구현 후 추가할 수 있을 듯 합니다.