### PR TITLE
[feat #122] 채팅방 목록 조회 API 필터링 추가

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dnd.gongmuin.chat.dto.request.CreateChatRoomRequest;
@@ -58,9 +59,10 @@ public class ChatRoomController {
 	@Operation(summary = "채팅방 목록 조회 API", description = "회원의 채팅방 목록을 조회한다.")
 	@GetMapping("/api/chat-rooms")
 	public ResponseEntity<List<ChatRoomSimpleResponse>> getChatRoomsByMember(
+		@RequestParam("status") String status,
 		@AuthenticationPrincipal Member member
 	) {
-		List<ChatRoomSimpleResponse> response = chatRoomService.getChatRoomsByMember(member);
+		List<ChatRoomSimpleResponse> response = chatRoomService.getChatRoomsByMember(member, status);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/chat/domain/ChatStatus.java
+++ b/src/main/java/com/dnd/gongmuin/chat/domain/ChatStatus.java
@@ -1,5 +1,10 @@
 package com.dnd.gongmuin.chat.domain;
 
+import java.util.Arrays;
+
+import com.dnd.gongmuin.chat.exception.ChatErrorCode;
+import com.dnd.gongmuin.common.exception.runtime.ValidationException;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -12,4 +17,15 @@ public enum ChatStatus {
 	REJECTED("거절됨");
 
 	private final String label;
+
+	public static ChatStatus from(String input) {
+		return Arrays.stream(values())
+			.filter(status -> status.isEqual(input))
+			.findAny()
+			.orElseThrow(() -> new ValidationException(ChatErrorCode.NOT_FOUND_CHAT_STATUS));
+	}
+
+	private boolean isEqual(String input) {
+		return input.equals(this.label);
+	}
 }

--- a/src/main/java/com/dnd/gongmuin/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/chat/exception/ChatErrorCode.java
@@ -14,7 +14,6 @@ public enum ChatErrorCode implements ErrorCode {
 	UNAUTHORIZED_REQUEST("채팅 수락을 하거나 거절할 권한이 없습니다.", "CH_003"),
 	UNABLE_TO_CHANGE_CHAT_STATUS("이미 수락했거나 거절한 요청입니다.", "CH_004"),
 	UNAUTHORIZED_CHAT_ROOM("권한이 없는 채팅방입니다.", "CH_005"),
-
 	NOT_FOUND_CHAT_STATUS("채팅방 상태값을 올바르게 입력해주세요.", "CH_006");
 
 	private final String message;

--- a/src/main/java/com/dnd/gongmuin/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/chat/exception/ChatErrorCode.java
@@ -13,7 +13,9 @@ public enum ChatErrorCode implements ErrorCode {
 	NOT_FOUND_CHAT_ROOM("해당 아이디의 채팅방이 존재하지 않습니다.", "CH_002"),
 	UNAUTHORIZED_REQUEST("채팅 수락을 하거나 거절할 권한이 없습니다.", "CH_003"),
 	UNABLE_TO_CHANGE_CHAT_STATUS("이미 수락했거나 거절한 요청입니다.", "CH_004"),
-	UNAUTHORIZED_CHAT_ROOM("권한이 없는 채팅방입니다", "CH_005");
+	UNAUTHORIZED_CHAT_ROOM("권한이 없는 채팅방입니다.", "CH_005"),
+
+	NOT_FOUND_CHAT_STATUS("채팅방 상태값을 올바르게 입력해주세요.", "CH_006");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
@@ -2,9 +2,10 @@ package com.dnd.gongmuin.chat.repository;
 
 import java.util.List;
 
+import com.dnd.gongmuin.chat.domain.ChatStatus;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
 import com.dnd.gongmuin.member.domain.Member;
 
 public interface ChatRoomQueryRepository {
-	List<ChatRoomInfo> getChatRoomsByMember(Member member);
+	List<ChatRoomInfo> getChatRoomsByMember(Member member, ChatStatus chatStatus);
 }

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
@@ -4,6 +4,7 @@ import static com.dnd.gongmuin.chat.domain.QChatRoom.*;
 
 import java.util.List;
 
+import com.dnd.gongmuin.chat.domain.ChatStatus;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
 import com.dnd.gongmuin.chat.dto.response.QChatRoomInfo;
 import com.dnd.gongmuin.member.domain.Member;
@@ -16,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
 	private final JPAQueryFactory queryFactory;
 
-	public List<ChatRoomInfo> getChatRoomsByMember(Member member) {
+	public List<ChatRoomInfo> getChatRoomsByMember(Member member, ChatStatus chatStatus) {
 		return queryFactory
 			.select(new QChatRoomInfo(
 				chatRoom.id,
@@ -39,7 +40,8 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
 			))
 			.from(chatRoom)
 			.where(chatRoom.inquirer.id.eq(member.getId())
-				.or(chatRoom.answerer.id.eq(member.getId())))
+				.or(chatRoom.answerer.id.eq(member.getId()))
+				.and(chatRoom.status.eq(chatStatus)))
 			.fetch();
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dnd.gongmuin.chat.domain.ChatRoom;
+import com.dnd.gongmuin.chat.domain.ChatStatus;
 import com.dnd.gongmuin.chat.dto.ChatMessageMapper;
 import com.dnd.gongmuin.chat.dto.ChatRoomMapper;
 import com.dnd.gongmuin.chat.dto.request.CreateChatRoomRequest;
@@ -77,9 +78,9 @@ public class ChatRoomService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<ChatRoomSimpleResponse> getChatRoomsByMember(Member member) {
+	public List<ChatRoomSimpleResponse> getChatRoomsByMember(Member member, String chatStatus) {
 		// 회원 채팅방 정보 가져오기
-		List<ChatRoomInfo> chatRoomInfos = chatRoomRepository.getChatRoomsByMember(member);
+		List<ChatRoomInfo> chatRoomInfos = chatRoomRepository.getChatRoomsByMember(member, ChatStatus.from(chatStatus));
 		// chatRoomId 리스트 추출
 		List<Long> chatRoomIds = chatRoomInfos.stream()
 			.map(ChatRoomInfo::chatRoomId)

--- a/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
@@ -123,7 +123,8 @@ class ChatRoomControllerTest extends ApiTestSupport {
 			)
 		);
 		mockMvc.perform(get("/api/chat-rooms")
-				.cookie(accessToken))
+				.cookie(accessToken)
+				.param("status", ChatStatus.PENDING.getLabel()))
 			.andExpect(status().isOk())
 			.andDo(MockMvcResultHandlers.print());
 	}

--- a/src/test/java/com/dnd/gongmuin/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/repository/ChatRoomRepositoryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.dnd.gongmuin.chat.domain.ChatRoom;
+import com.dnd.gongmuin.chat.domain.ChatStatus;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
 import com.dnd.gongmuin.common.fixture.ChatRoomFixture;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
@@ -43,7 +44,7 @@ class ChatRoomRepositoryTest extends DataJpaTestSupport {
 			chatRoomRepository.save(ChatRoomFixture.chatRoom(questionPost, target, answerer))
 		));
 		//when
-		List<ChatRoomInfo> chatRoomInfos = chatRoomRepository.getChatRoomsByMember(target);
+		List<ChatRoomInfo> chatRoomInfos = chatRoomRepository.getChatRoomsByMember(target, ChatStatus.PENDING);
 		//then
 		Assertions.assertAll(
 			() -> assertThat(chatRoomInfos).hasSize(2),

--- a/src/test/java/com/dnd/gongmuin/post_interaction/controller/InteractionControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/post_interaction/controller/InteractionControllerTest.java
@@ -71,7 +71,7 @@ class InteractionControllerTest extends ApiTestSupport {
 		mockMvc.perform(post("/api/question-posts/{questionPostId}/inactivated", questionPost.getId())
 				.contentType(APPLICATION_JSON)
 				.cookie(accessToken)
-				.param("type", "추천")
+				.param("type", InteractionType.RECOMMEND.getLabel())
 			)
 			.andExpect(status().isOk());
 	}


### PR DESCRIPTION
### 관련 이슈
- close #122 

### 📑 작업 상세 내용
- 기존 채팅방 목록 조회 API에 필터링 추가
  - 채팅방 상태(요청중, 수락됨)에 따라 분류
  - request param으로 채팅방 상태 받기

### 💫 작업 요약
- 필터링 추가
