### PR TITLE
[feat #115] 채팅 신청/수락/거절 알림 API

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
@@ -1,11 +1,14 @@
 package com.dnd.gongmuin.chat.service;
 
+import static com.dnd.gongmuin.notification.domain.NotificationType.*;
+
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -33,6 +36,7 @@ import com.dnd.gongmuin.common.exception.runtime.ValidationException;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.exception.MemberErrorCode;
 import com.dnd.gongmuin.member.repository.MemberRepository;
+import com.dnd.gongmuin.notification.dto.NotificationEvent;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
 import com.dnd.gongmuin.question_post.exception.QuestionPostErrorCode;
@@ -49,6 +53,7 @@ public class ChatRoomService {
 	private final ChatRoomRepository chatRoomRepository;
 	private final MemberRepository memberRepository;
 	private final QuestionPostRepository questionPostRepository;
+	private final ApplicationEventPublisher eventPublisher;
 
 	private static void validateIfAnswerer(Member member, ChatRoom chatRoom) {
 		if (!Objects.equals(member.getId(), chatRoom.getAnswerer().getId())) {
@@ -68,10 +73,17 @@ public class ChatRoomService {
 	public ChatRoomDetailResponse createChatRoom(CreateChatRoomRequest request, Member inquirer) {
 		QuestionPost questionPost = getQuestionPostById(request.questionPostId());
 		Member answerer = getMemberById(request.answererId());
+
+		ChatRoom chatRoom = chatRoomRepository.save(
+			ChatRoomMapper.toChatRoom(questionPost, inquirer, answerer)
+		);
+
+		eventPublisher.publishEvent(
+			new NotificationEvent(CHAT_REQUEST, chatRoom.getId(), inquirer.getId(), answerer)
+		);
+
 		return ChatRoomMapper.toChatRoomDetailResponse(
-			chatRoomRepository.save(
-				ChatRoomMapper.toChatRoom(questionPost, inquirer, answerer)
-			),
+			chatRoom,
 			answerer
 		);
 	}

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
@@ -145,6 +145,10 @@ public class ChatRoomService {
 		validateIfAnswerer(member, chatRoom);
 		chatRoom.updateStatusRejected();
 
+		eventPublisher.publishEvent(
+			new NotificationEvent(CHAT_REJECT, chatRoom.getId(), member.getId(), chatRoom.getInquirer())
+		);
+
 		return ChatRoomMapper.toRejectChatResponse(chatRoom);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
@@ -132,6 +132,10 @@ public class ChatRoomService {
 		validateIfAnswerer(member, chatRoom);
 		chatRoom.updateStatusAccepted();
 
+		eventPublisher.publishEvent(
+			new NotificationEvent(CHAT_ACCEPT, chatRoom.getId(), member.getId(), chatRoom.getInquirer())
+		);
+
 		return ChatRoomMapper.toAcceptChatResponse(chatRoom);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/notification/domain/NotificationType.java
+++ b/src/main/java/com/dnd/gongmuin/notification/domain/NotificationType.java
@@ -14,7 +14,9 @@ public enum NotificationType {
 
 	ANSWER("답변"),
 	CHOSEN("채택"),
-	CHAT("채팅");
+	CHAT_REQUEST("채팅신청"),
+	CHAT_REJECT("채팅거절"),
+	CHAT_ACCEPT("채팅수락");
 
 	private final String label;
 


### PR DESCRIPTION
### 관련 이슈
- close #115 

### 📑 작업 상세 내용
- 채팅 생성 시 신청 알림 생성(to. ChatRoom.answerer,  from ChatRoom.inquirer)
  -  채팅방 생성 시 알림 생성을 위한 로직 리팩토링
- 채팅 수락 시 수락 알림 생성(to. ChatRoom.inquirer, from ChatRoom.answerer)
- 채팅 거절 시 거절 알림 생성(to. ChatRoom.inquirer, from ChatRoom.answerer)


### 💫 작업 요약
- 채팅 신청/수락/거절 알림 API

### 🔍 중점적으로 리뷰 할 부분
- 채팅방 생성 시 알림 생성을 위한 로직 리팩토링
