### PR TITLE
[feat #127] 채팅방 목록 API 페이징, 테스트 추가

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
@@ -1,7 +1,5 @@
 package com.dnd.gongmuin.chat.controller;
 
-import java.util.List;
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -58,11 +56,13 @@ public class ChatRoomController {
 
 	@Operation(summary = "채팅방 목록 조회 API", description = "회원의 채팅방 목록을 조회한다.")
 	@GetMapping("/api/chat-rooms")
-	public ResponseEntity<List<ChatRoomSimpleResponse>> getChatRoomsByMember(
+	public ResponseEntity<PageResponse<ChatRoomSimpleResponse>> getChatRoomsByMember(
 		@RequestParam("status") String status,
-		@AuthenticationPrincipal Member member
+		@AuthenticationPrincipal Member member,
+		Pageable pageable
 	) {
-		List<ChatRoomSimpleResponse> response = chatRoomService.getChatRoomsByMember(member, status);
+		PageResponse<ChatRoomSimpleResponse> response = chatRoomService.getChatRoomsByMember(member, status,
+			pageable);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
@@ -3,6 +3,9 @@ package com.dnd.gongmuin.chat.dto;
 import com.dnd.gongmuin.chat.domain.ChatRoom;
 import com.dnd.gongmuin.chat.dto.response.AcceptChatResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomDetailResponse;
+import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
+import com.dnd.gongmuin.chat.dto.response.ChatRoomSimpleResponse;
+import com.dnd.gongmuin.chat.dto.response.LatestChatMessage;
 import com.dnd.gongmuin.chat.dto.response.RejectChatResponse;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
@@ -56,6 +59,24 @@ public class ChatRoomMapper {
 	public static RejectChatResponse toRejectChatResponse(ChatRoom chatRoom) {
 		return new RejectChatResponse(
 			chatRoom.getStatus().getLabel()
+		);
+	}
+
+	public static ChatRoomSimpleResponse toChatRoomSimpleResponse(
+		ChatRoomInfo chatRoomInfo,
+		LatestChatMessage latestChatMessage
+	){
+		return new ChatRoomSimpleResponse(
+			chatRoomInfo.chatRoomId(),
+			new MemberInfo(
+				chatRoomInfo.partnerId(),
+				chatRoomInfo.partnerNickname(),
+				chatRoomInfo.partnerJobGroup(),
+				chatRoomInfo.partnerProfileImageNo()
+			),
+			latestChatMessage.content(),
+			latestChatMessage.type(),
+			latestChatMessage.createdAt().toString()
 		);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
@@ -65,7 +65,7 @@ public class ChatRoomMapper {
 	public static ChatRoomSimpleResponse toChatRoomSimpleResponse(
 		ChatRoomInfo chatRoomInfo,
 		LatestChatMessage latestChatMessage
-	){
+	) {
 		return new ChatRoomSimpleResponse(
 			chatRoomInfo.chatRoomId(),
 			new MemberInfo(

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
@@ -1,11 +1,12 @@
 package com.dnd.gongmuin.chat.repository;
 
-import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import com.dnd.gongmuin.chat.domain.ChatStatus;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
 import com.dnd.gongmuin.member.domain.Member;
 
 public interface ChatRoomQueryRepository {
-	List<ChatRoomInfo> getChatRoomsByMember(Member member, ChatStatus chatStatus);
+	Slice<ChatRoomInfo> getChatRoomsByMember(Member member, ChatStatus chatStatus, Pageable pageable);
 }

--- a/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
@@ -84,7 +84,7 @@ class ChatRoomControllerTest extends ApiTestSupport {
 			.andExpect(status().isOk());
 	}
 
-	@DisplayName("[회원의 채팅방 목록을 조회할 수 있다.]")
+	@DisplayName("[회원의 요청 상태 채팅방 목록을 조회할 수 있다.]")
 	@Test
 	void getChatRoomsByMember() throws Exception {
 		//given

--- a/src/test/java/com/dnd/gongmuin/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/repository/ChatRoomRepositoryTest.java
@@ -48,7 +48,8 @@ class ChatRoomRepositoryTest extends DataJpaTestSupport {
 		));
 		//when
 
-		List<ChatRoomInfo> chatRoomInfos = chatRoomRepository.getChatRoomsByMember(target, ChatStatus.PENDING, pageRequest)
+		List<ChatRoomInfo> chatRoomInfos = chatRoomRepository.getChatRoomsByMember(target, ChatStatus.PENDING,
+				pageRequest)
 			.getContent();
 		//then
 		Assertions.assertAll(

--- a/src/test/java/com/dnd/gongmuin/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/repository/ChatRoomRepositoryTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 
 import com.dnd.gongmuin.chat.domain.ChatRoom;
 import com.dnd.gongmuin.chat.domain.ChatStatus;
@@ -23,6 +24,8 @@ import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 
 @DisplayName("[ChatRoomRepository 테스트]")
 class ChatRoomRepositoryTest extends DataJpaTestSupport {
+
+	private final PageRequest pageRequest = PageRequest.of(0, 10);
 	@Autowired
 	ChatRoomRepository chatRoomRepository;
 	@Autowired
@@ -44,7 +47,9 @@ class ChatRoomRepositoryTest extends DataJpaTestSupport {
 			chatRoomRepository.save(ChatRoomFixture.chatRoom(questionPost, target, answerer))
 		));
 		//when
-		List<ChatRoomInfo> chatRoomInfos = chatRoomRepository.getChatRoomsByMember(target, ChatStatus.PENDING);
+
+		List<ChatRoomInfo> chatRoomInfos = chatRoomRepository.getChatRoomsByMember(target, ChatStatus.PENDING, pageRequest)
+			.getContent();
 		//then
 		Assertions.assertAll(
 			() -> assertThat(chatRoomInfos).hasSize(2),

--- a/src/test/java/com/dnd/gongmuin/question_post/controller/QuestionPostControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/controller/QuestionPostControllerTest.java
@@ -108,7 +108,7 @@ class QuestionPostControllerTest extends ApiTestSupport {
 				.value(MemberErrorCode.NOT_ENOUGH_CREDIT.getCode()));
 	}
 
-	@DisplayName("[질문글을 조회할 수 있다.]")
+	@DisplayName("[질문글을 아이디로 상세 조회할 수 있다.]")
 	@Test
 	void getQuestionPostById() throws Exception {
 		QuestionPost questionPost = questionPostRepository.save(QuestionPostFixture.questionPost(loginMember));


### PR DESCRIPTION
### 관련 이슈
- close #127 

### 📑 작업 상세 내용
- 채팅방 목록 List 반환 -> PageResponse 반환
  - ChatRoomInfo 조회 시 Slice로 조회
- 통합 테스트 파라미터 검증
- 단위 테스트 코드 추가

### 💫 작업 요약
- 채팅방 목록 API 페이징
- 채팅방 목록 API 테스트 작성

### 🔍 중점적으로 리뷰 할 부분

