### PR TITLE
[feat #130] 채팅 크레딧 내역 추가

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
@@ -16,6 +16,7 @@ import com.dnd.gongmuin.chat.dto.response.AcceptChatResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatMessageResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomDetailResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomSimpleResponse;
+import com.dnd.gongmuin.chat.dto.response.CreateChatRoomResponse;
 import com.dnd.gongmuin.chat.dto.response.RejectChatResponse;
 import com.dnd.gongmuin.chat.service.ChatRoomService;
 import com.dnd.gongmuin.common.dto.PageResponse;
@@ -46,11 +47,11 @@ public class ChatRoomController {
 
 	@Operation(summary = "채팅방 생성 API", description = "요청자가 답변자와의 채팅방을 생성한다.")
 	@PostMapping("/api/chat-rooms")
-	public ResponseEntity<ChatRoomDetailResponse> createChatRoom(
+	public ResponseEntity<CreateChatRoomResponse> createChatRoom(
 		@Valid @RequestBody CreateChatRoomRequest request,
 		@AuthenticationPrincipal Member member
 	) {
-		ChatRoomDetailResponse response = chatRoomService.createChatRoom(request, member);
+		CreateChatRoomResponse response = chatRoomService.createChatRoom(request, member);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
@@ -5,6 +5,7 @@ import com.dnd.gongmuin.chat.dto.response.AcceptChatResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomDetailResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomSimpleResponse;
+import com.dnd.gongmuin.chat.dto.response.CreateChatRoomResponse;
 import com.dnd.gongmuin.chat.dto.response.LatestChatMessage;
 import com.dnd.gongmuin.chat.dto.response.RejectChatResponse;
 import com.dnd.gongmuin.member.domain.Member;
@@ -26,6 +27,26 @@ public class ChatRoomMapper {
 			questionPost,
 			inquirer,
 			answerer
+		);
+	}
+
+	public static CreateChatRoomResponse toCreateChatRoomResponse(
+		ChatRoom chatRoom
+	) {
+		QuestionPost questionPost = chatRoom.getQuestionPost();
+		Member answerer = chatRoom.getAnswerer();
+		return new CreateChatRoomResponse(
+			questionPost.getId(),
+			questionPost.getJobGroup().getLabel(),
+			questionPost.getTitle(),
+			new MemberInfo(
+				answerer.getId(),
+				answerer.getNickname(),
+				answerer.getJobGroup().getLabel(),
+				answerer.getProfileImageNo()
+			),
+			chatRoom.getStatus().getLabel(),
+			chatRoom.getInquirer().getCredit()
 		);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/chat/dto/response/CreateChatRoomResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/response/CreateChatRoomResponse.java
@@ -1,0 +1,13 @@
+package com.dnd.gongmuin.chat.dto.response;
+
+import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
+
+public record CreateChatRoomResponse(
+	Long questionPostId,
+	String targetJobGroup,
+	String title,
+	MemberInfo receiverInfo,
+	String chatStatus,
+	int credit
+) {
+}

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
@@ -70,7 +70,7 @@ public class ChatRoomService {
 	}
 
 	@Transactional
-	public ChatRoomDetailResponse createChatRoom(CreateChatRoomRequest request, Member inquirer) {
+	public CreateChatRoomResponse createChatRoom(CreateChatRoomRequest request, Member inquirer) {
 		QuestionPost questionPost = getQuestionPostById(request.questionPostId());
 		Member answerer = getMemberById(request.answererId());
 
@@ -82,10 +82,7 @@ public class ChatRoomService {
 			new NotificationEvent(CHAT_REQUEST, chatRoom.getId(), inquirer.getId(), answerer)
 		);
 
-		return ChatRoomMapper.toChatRoomDetailResponse(
-			chatRoom,
-			answerer
-		);
+		return ChatRoomMapper.toCreateChatRoomResponse(chatRoom);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
@@ -1,7 +1,5 @@
 package com.dnd.gongmuin.chat.service;
 
-import static com.dnd.gongmuin.notification.domain.NotificationType.*;
-
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +22,7 @@ import com.dnd.gongmuin.chat.dto.response.ChatMessageResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomDetailResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomSimpleResponse;
+import com.dnd.gongmuin.chat.dto.response.CreateChatRoomResponse;
 import com.dnd.gongmuin.chat.dto.response.LatestChatMessage;
 import com.dnd.gongmuin.chat.dto.response.RejectChatResponse;
 import com.dnd.gongmuin.chat.exception.ChatErrorCode;
@@ -34,9 +33,12 @@ import com.dnd.gongmuin.common.dto.PageMapper;
 import com.dnd.gongmuin.common.dto.PageResponse;
 import com.dnd.gongmuin.common.exception.runtime.NotFoundException;
 import com.dnd.gongmuin.common.exception.runtime.ValidationException;
+import com.dnd.gongmuin.credit_history.domain.CreditType;
+import com.dnd.gongmuin.credit_history.service.CreditHistoryService;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.exception.MemberErrorCode;
 import com.dnd.gongmuin.member.repository.MemberRepository;
+import com.dnd.gongmuin.notification.domain.NotificationType;
 import com.dnd.gongmuin.notification.dto.NotificationEvent;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.exception.QuestionPostErrorCode;
@@ -53,6 +55,7 @@ public class ChatRoomService {
 	private final ChatRoomRepository chatRoomRepository;
 	private final MemberRepository memberRepository;
 	private final QuestionPostRepository questionPostRepository;
+	private final CreditHistoryService creditHistoryService;
 	private final ApplicationEventPublisher eventPublisher;
 
 	private static void validateIfAnswerer(Member member, ChatRoom chatRoom) {
@@ -78,8 +81,10 @@ public class ChatRoomService {
 			ChatRoomMapper.toChatRoom(questionPost, inquirer, answerer)
 		);
 
+		creditHistoryService.saveChatCreditHistory(CreditType.CHAT_REQUEST, inquirer);
+
 		eventPublisher.publishEvent(
-			new NotificationEvent(CHAT_REQUEST, chatRoom.getId(), inquirer.getId(), answerer)
+			new NotificationEvent(NotificationType.CHAT_REQUEST, chatRoom.getId(), inquirer.getId(), answerer)
 		);
 
 		return ChatRoomMapper.toCreateChatRoomResponse(chatRoom);
@@ -118,26 +123,26 @@ public class ChatRoomService {
 	}
 
 	@Transactional
-	public AcceptChatResponse acceptChat(Long chatRoomId, Member member) {
+	public AcceptChatResponse acceptChat(Long chatRoomId, Member answerer) {
 		ChatRoom chatRoom = getChatRoomById(chatRoomId);
-		validateIfAnswerer(member, chatRoom);
+		validateIfAnswerer(answerer, chatRoom);
 		chatRoom.updateStatusAccepted();
-
+		creditHistoryService.saveChatCreditHistory(CreditType.CHAT_ACCEPT, answerer);
 		eventPublisher.publishEvent(
-			new NotificationEvent(CHAT_ACCEPT, chatRoom.getId(), member.getId(), chatRoom.getInquirer())
+			new NotificationEvent(NotificationType.CHAT_ACCEPT, chatRoom.getId(), answerer.getId(), chatRoom.getInquirer())
 		);
 
 		return ChatRoomMapper.toAcceptChatResponse(chatRoom);
 	}
 
 	@Transactional
-	public RejectChatResponse rejectChat(Long chatRoomId, Member member) {
+	public RejectChatResponse rejectChat(Long chatRoomId, Member answerer) {
 		ChatRoom chatRoom = getChatRoomById(chatRoomId);
-		validateIfAnswerer(member, chatRoom);
+		validateIfAnswerer(answerer, chatRoom);
 		chatRoom.updateStatusRejected();
-
+		creditHistoryService.saveChatCreditHistory(CreditType.CHAT_REFUND, chatRoom.getInquirer());
 		eventPublisher.publishEvent(
-			new NotificationEvent(CHAT_REJECT, chatRoom.getId(), member.getId(), chatRoom.getInquirer())
+			new NotificationEvent(NotificationType.CHAT_REJECT, chatRoom.getId(), answerer.getId(), chatRoom.getInquirer())
 		);
 
 		return ChatRoomMapper.toRejectChatResponse(chatRoom);

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
@@ -129,7 +129,8 @@ public class ChatRoomService {
 		chatRoom.updateStatusAccepted();
 		creditHistoryService.saveChatCreditHistory(CreditType.CHAT_ACCEPT, answerer);
 		eventPublisher.publishEvent(
-			new NotificationEvent(NotificationType.CHAT_ACCEPT, chatRoom.getId(), answerer.getId(), chatRoom.getInquirer())
+			new NotificationEvent(NotificationType.CHAT_ACCEPT, chatRoom.getId(), answerer.getId(),
+				chatRoom.getInquirer())
 		);
 
 		return ChatRoomMapper.toAcceptChatResponse(chatRoom);
@@ -142,13 +143,15 @@ public class ChatRoomService {
 		chatRoom.updateStatusRejected();
 		creditHistoryService.saveChatCreditHistory(CreditType.CHAT_REFUND, chatRoom.getInquirer());
 		eventPublisher.publishEvent(
-			new NotificationEvent(NotificationType.CHAT_REJECT, chatRoom.getId(), answerer.getId(), chatRoom.getInquirer())
+			new NotificationEvent(NotificationType.CHAT_REJECT, chatRoom.getId(), answerer.getId(),
+				chatRoom.getInquirer())
 		);
 
 		return ChatRoomMapper.toRejectChatResponse(chatRoom);
 	}
 
-	private List<ChatRoomSimpleResponse> getChatRoomSimpleResponses(List<LatestChatMessage> latestChatMessages, Slice<ChatRoomInfo> chatRoomInfos) {
+	private List<ChatRoomSimpleResponse> getChatRoomSimpleResponses(List<LatestChatMessage> latestChatMessages,
+		Slice<ChatRoomInfo> chatRoomInfos) {
 		// <chatRoomId, LatestMessage> -> 순서 보장 x
 		Map<Long, LatestChatMessage> messageMap = latestChatMessages.stream()
 			.collect(Collectors.toMap(LatestChatMessage::chatRoomId, message -> message));

--- a/src/main/java/com/dnd/gongmuin/credit_history/domain/CreditType.java
+++ b/src/main/java/com/dnd/gongmuin/credit_history/domain/CreditType.java
@@ -11,8 +11,9 @@ public enum CreditType {
 
 	CHOOSE("채택하기", "출금"),
 	CHOSEN("채택받기", "입금"),
-	CHAT_REQUEST("채팅신청", "출금"),
-	CHAT_ACCEPT("채팅받기", "입금");
+	CHAT_REQUEST("채팅 요청", "출금"),
+	CHAT_ACCEPT("채팅 수락", "입금"),
+	CHAT_REFUND("채팅 환급", "입금");
 
 	private final String label;
 	private final String detail;

--- a/src/main/java/com/dnd/gongmuin/credit_history/service/CreditHistoryService.java
+++ b/src/main/java/com/dnd/gongmuin/credit_history/service/CreditHistoryService.java
@@ -29,7 +29,7 @@ public class CreditHistoryService {
 	}
 
 	@Transactional
-	public void saveChatCreditHistory(CreditType creditType, Member member){
+	public void saveChatCreditHistory(CreditType creditType, Member member) {
 		int chatCredit = 2000;
 		creditHistoryRepository.save(
 			CreditHistoryMapper.toCreditHistory(creditType, chatCredit, member)

--- a/src/main/java/com/dnd/gongmuin/credit_history/service/CreditHistoryService.java
+++ b/src/main/java/com/dnd/gongmuin/credit_history/service/CreditHistoryService.java
@@ -9,6 +9,7 @@ import com.dnd.gongmuin.answer.domain.Answer;
 import com.dnd.gongmuin.credit_history.domain.CreditType;
 import com.dnd.gongmuin.credit_history.dto.CreditHistoryMapper;
 import com.dnd.gongmuin.credit_history.repository.CreditHistoryRepository;
+import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 
 import lombok.RequiredArgsConstructor;
@@ -25,5 +26,13 @@ public class CreditHistoryService {
 			CreditHistoryMapper.toCreditHistory(CreditType.CHOSEN, questionPost.getReward(), answer.getMember()),
 			CreditHistoryMapper.toCreditHistory(CreditType.CHOOSE, questionPost.getReward(), questionPost.getMember())
 		));
+	}
+
+	@Transactional
+	public void saveChatCreditHistory(CreditType creditType, Member member){
+		int chatCredit = 2000;
+		creditHistoryRepository.save(
+			CreditHistoryMapper.toCreditHistory(creditType, chatCredit, member)
+		);
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
@@ -86,7 +86,15 @@ class ChatRoomControllerTest extends ApiTestSupport {
 				.cookie(accessToken)
 				.content(toJson(request))
 				.contentType(APPLICATION_JSON))
-			.andExpect(status().isOk());
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.credit").value(loginMember.getCredit() - CHAT_REWARD))
+			.andExpect(jsonPath("$.questionPostId").value(questionPost.getId()))
+			.andExpect(jsonPath("$.targetJobGroup").value(questionPost.getJobGroup().getLabel()))
+			.andExpect(jsonPath("$.title").value(questionPost.getTitle()))
+			.andExpect(jsonPath("$.receiverInfo.memberId").value(answerer.getId()))
+			.andExpect(jsonPath("$.receiverInfo.nickname").value(answerer.getNickname()))
+			.andExpect(jsonPath("$.receiverInfo.memberJobGroup").value(answerer.getJobGroup().getLabel()))
+			.andExpect(jsonPath("$.receiverInfo.profileImageNo").value(answerer.getProfileImageNo()));
 	}
 
 	@DisplayName("[회원의 요청 상태 채팅방 목록을 조회할 수 있다.]")

--- a/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
@@ -24,6 +24,7 @@ import com.dnd.gongmuin.common.fixture.ChatRoomFixture;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
 import com.dnd.gongmuin.common.fixture.QuestionPostFixture;
 import com.dnd.gongmuin.common.support.ApiTestSupport;
+import com.dnd.gongmuin.credit_history.repository.CreditHistoryRepository;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.repository.MemberRepository;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
@@ -46,8 +47,12 @@ class ChatRoomControllerTest extends ApiTestSupport {
 	@Autowired
 	private ChatRoomRepository chatRoomRepository;
 
+	@Autowired
+	private CreditHistoryRepository creditHistoryRepository;
+
 	@AfterEach
 	void teardown() {
+		creditHistoryRepository.deleteAll();
 		memberRepository.deleteAll();
 		questionPostRepository.deleteAll();
 		chatRoomRepository.deleteAll();

--- a/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
@@ -40,6 +40,7 @@ import com.dnd.gongmuin.common.fixture.ChatMessageFixture;
 import com.dnd.gongmuin.common.fixture.ChatRoomFixture;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
 import com.dnd.gongmuin.common.fixture.QuestionPostFixture;
+import com.dnd.gongmuin.credit_history.service.CreditHistoryService;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.exception.MemberErrorCode;
 import com.dnd.gongmuin.member.repository.MemberRepository;
@@ -70,6 +71,9 @@ class ChatRoomServiceTest {
 
 	@Mock
 	private ApplicationEventPublisher eventPublisher;
+
+	@Mock
+	private CreditHistoryService creditHistoryService;
 
 	@InjectMocks
 	private ChatRoomService chatRoomService;

--- a/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
@@ -28,6 +28,7 @@ import com.dnd.gongmuin.chat.dto.response.ChatMessageResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomDetailResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomSimpleResponse;
+import com.dnd.gongmuin.chat.dto.response.CreateChatRoomResponse;
 import com.dnd.gongmuin.chat.dto.response.LatestChatMessage;
 import com.dnd.gongmuin.chat.dto.response.RejectChatResponse;
 import com.dnd.gongmuin.chat.exception.ChatErrorCode;
@@ -111,7 +112,7 @@ class ChatRoomServiceTest {
 			.willReturn(chatRoom);
 
 		//when
-		ChatRoomDetailResponse response = chatRoomService.createChatRoom(request, inquirer);
+		CreateChatRoomResponse response = chatRoomService.createChatRoom(request, inquirer);
 
 		//then
 		assertAll(
@@ -141,7 +142,7 @@ class ChatRoomServiceTest {
 			.willReturn(chatRoom);
 
 		//when
-		ChatRoomDetailResponse response = chatRoomService.createChatRoom(request, inquirer);
+		CreateChatRoomResponse response = chatRoomService.createChatRoom(request, inquirer);
 
 		//then
 		assertAll(


### PR DESCRIPTION
### 관련 이슈
- close #130 

### 📑 작업 상세 내용
- 기존에 누락된 크레딧 내역 저장 로직 추가
  - 채팅 요청, 채팅 수락, 채팅 거절
-  채팅 생성(요청) API 응답값에 질문자의 잔여 크레딧 필드 추가
   - 통합 테스트 응답값 검증 추가 
   - 채팅 생성 응답과 채팅방 상세조회 응답 분리

### 💫 작업 요약
- 채팅 관련 creditHistory 저장 로직 추가

### 🔍 중점적으로 리뷰 할 부분
- 
