### PR TITLE
[feat #132] 채팅방 입장 시 요청 메시지 전송

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat/dto/ChatMessageMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/ChatMessageMapper.java
@@ -1,6 +1,7 @@
 package com.dnd.gongmuin.chat.dto;
 
 import com.dnd.gongmuin.chat.domain.ChatMessage;
+import com.dnd.gongmuin.chat.domain.ChatRoom;
 import com.dnd.gongmuin.chat.domain.MessageType;
 import com.dnd.gongmuin.chat.dto.request.ChatMessageRequest;
 import com.dnd.gongmuin.chat.dto.response.ChatMessageResponse;
@@ -32,6 +33,17 @@ public class ChatMessageMapper {
 			chatRoomId,
 			request.senderId(),
 			MessageType.of(request.type())
+		);
+	}
+
+	public static ChatMessage toFirstChatMessage(
+		ChatRoom chatRoom
+	) {
+		return ChatMessage.of(
+			"님이 채팅을 요청하셨습니다.",
+			chatRoom.getId(),
+			chatRoom.getInquirer().getId(),
+			MessageType.of(MessageType.TEXT.getLabel())
 		);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/chat/dto/ChatMessageMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/ChatMessageMapper.java
@@ -12,6 +12,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ChatMessageMapper {
 
+	private static final String REQUEST_MESSAGE_POSTFIX = "님이 채팅을 요청하셨습니다.";
+
 	public static ChatMessageResponse toChatMessageResponse(
 		ChatMessage chatMessage
 	) {
@@ -40,7 +42,7 @@ public class ChatMessageMapper {
 		ChatRoom chatRoom
 	) {
 		return ChatMessage.of(
-			"님이 채팅을 요청하셨습니다.",
+			chatRoom.getInquirer().getNickname() + REQUEST_MESSAGE_POSTFIX,
 			chatRoom.getId(),
 			chatRoom.getInquirer().getId(),
 			MessageType.of(MessageType.TEXT.getLabel())

--- a/src/main/java/com/dnd/gongmuin/chat/dto/ChatMessageMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/ChatMessageMapper.java
@@ -25,13 +25,12 @@ public class ChatMessageMapper {
 
 	public static ChatMessage toChatMessage(
 		ChatMessageRequest request,
-		long chatRoomId,
-		long memberId
+		long chatRoomId
 	) {
 		return ChatMessage.of(
 			request.content(),
 			chatRoomId,
-			memberId,
+			request.senderId(),
 			MessageType.of(request.type())
 		);
 	}

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatMessageService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatMessageService.java
@@ -26,7 +26,7 @@ public class ChatMessageService {
 	) {
 		Long senderId = request.senderId();
 		ChatMessage chatMessage = chatMessageRepository.save(
-			ChatMessageMapper.toChatMessage(request, chatRoomId, senderId));
+			ChatMessageMapper.toChatMessage(request, chatRoomId));
 		log.info("chatRoomId = {}, senderId= {}, chatMessageId= {}", chatRoomId, senderId, chatMessage.getId());
 		return ChatMessageMapper.toChatMessageResponse(chatMessage);
 	}

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
@@ -80,7 +80,9 @@ public class ChatRoomService {
 		ChatRoom chatRoom = chatRoomRepository.save(
 			ChatRoomMapper.toChatRoom(questionPost, inquirer, answerer)
 		);
-
+		chatMessageRepository.save(
+			ChatMessageMapper.toFirstChatMessage(chatRoom)
+		);
 		creditHistoryService.saveChatCreditHistory(CreditType.CHAT_REQUEST, inquirer);
 
 		eventPublisher.publishEvent(

--- a/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
@@ -56,6 +56,7 @@ class ChatRoomControllerTest extends ApiTestSupport {
 		memberRepository.deleteAll();
 		questionPostRepository.deleteAll();
 		chatRoomRepository.deleteAll();
+		chatMessageRepository.deleteAll();
 	}
 
 	@DisplayName("[채팅방 아이디로 메시지를 조회할 수 있다.]")
@@ -68,7 +69,7 @@ class ChatRoomControllerTest extends ApiTestSupport {
 		mockMvc.perform(get("/api/chat-messages/{chatRoomId}", 1L)
 				.cookie(accessToken))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.size").value(2))
+			.andExpect(jsonPath("$.size").value(chatMessages.size()))
 			.andExpect(jsonPath("$.content[0].senderId").value(chatMessages.get(0).getMemberId()))
 			.andExpect(jsonPath("$.content[0].content").value(chatMessages.get(0).getContent()))
 			.andExpect(jsonPath("$.content[0].type").value(chatMessages.get(0).getType().getLabel()))

--- a/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.dnd.gongmuin.chat.domain.ChatMessage;
 import com.dnd.gongmuin.chat.domain.ChatRoom;
 import com.dnd.gongmuin.chat.domain.ChatStatus;
+import com.dnd.gongmuin.chat.domain.MessageType;
 import com.dnd.gongmuin.chat.dto.request.CreateChatRoomRequest;
 import com.dnd.gongmuin.chat.dto.response.AcceptChatResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatMessageResponse;
@@ -53,6 +54,7 @@ import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 class ChatRoomServiceTest {
 
 	private static final int CHAT_REWARD = 2000;
+	private static final String REQUEST_MESSAGE_POSTFIX = "님이 채팅을 요청하셨습니다.";
 	private final PageRequest pageRequest = PageRequest.of(0, 5);
 	@Mock
 	private ChatMessageRepository chatMessageRepository;
@@ -106,7 +108,7 @@ class ChatRoomServiceTest {
 			questionPost.getId(),
 			answerer.getId()
 		);
-		ChatRoom chatRoom = ChatRoomFixture.chatRoom(questionPost, inquirer, answerer);
+		ChatRoom chatRoom = ChatRoomFixture.chatRoom(1L, questionPost, inquirer, answerer);
 
 		given(questionPostRepository.findById(questionPost.getId()))
 			.willReturn(Optional.of(questionPost));
@@ -114,6 +116,10 @@ class ChatRoomServiceTest {
 			.willReturn(Optional.of(answerer));
 		given(chatRoomRepository.save(any(ChatRoom.class)))
 			.willReturn(chatRoom);
+		given(chatMessageRepository.save(any(ChatMessage.class)))
+			.willReturn(
+				ChatMessage.of(inquirer + REQUEST_MESSAGE_POSTFIX, chatRoom.getId(), inquirer.getId(), MessageType.TEXT)
+			);
 
 		//when
 		CreateChatRoomResponse response = chatRoomService.createChatRoom(request, inquirer);
@@ -136,7 +142,7 @@ class ChatRoomServiceTest {
 			questionPost.getId(),
 			answerer.getId()
 		);
-		ChatRoom chatRoom = ChatRoomFixture.chatRoom(questionPost, inquirer, answerer);
+		ChatRoom chatRoom = ChatRoomFixture.chatRoom(1L, questionPost, inquirer, answerer);
 
 		given(questionPostRepository.findById(questionPost.getId()))
 			.willReturn(Optional.of(questionPost));
@@ -144,6 +150,10 @@ class ChatRoomServiceTest {
 			.willReturn(Optional.of(answerer));
 		given(chatRoomRepository.save(any(ChatRoom.class)))
 			.willReturn(chatRoom);
+		given(chatMessageRepository.save(any(ChatMessage.class)))
+			.willReturn(
+				ChatMessage.of(inquirer + REQUEST_MESSAGE_POSTFIX, chatRoom.getId(), inquirer.getId(), MessageType.TEXT)
+			);
 
 		//when
 		CreateChatRoomResponse response = chatRoomService.createChatRoom(request, inquirer);

--- a/src/test/java/com/dnd/gongmuin/common/fixture/ChatRoomFixture.java
+++ b/src/test/java/com/dnd/gongmuin/common/fixture/ChatRoomFixture.java
@@ -1,5 +1,7 @@
 package com.dnd.gongmuin.common.fixture;
 
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.dnd.gongmuin.chat.domain.ChatRoom;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
@@ -20,5 +22,20 @@ public class ChatRoomFixture {
 			inquirer,
 			answerer
 		);
+	}
+
+	public static ChatRoom chatRoom(
+		Long id,
+		QuestionPost questionPost,
+		Member inquirer,
+		Member answerer
+	) {
+		ChatRoom chatRoom = ChatRoom.of(
+			questionPost,
+			inquirer,
+			answerer
+		);
+		ReflectionTestUtils.setField(chatRoom, "id", id);
+		return chatRoom;
 	}
 }


### PR DESCRIPTION
### 관련 이슈
- close #132

### 📑 작업 상세 내용
- 채팅 요청 시 요청 메시지 DB에 저장
  - 기존) 요청자가 채팅방만 생성(요청)
  - 문제) 채팅방 목록 조회 시 요청자가 메시지 하나도 보내지 않으면 NPE 발생
  - 해결) 요청자가 채팅방 생성 시 `~님이 채팅을 요청했습니다.` 채팅 메시지 저장

### 💫 작업 요약
- 채팅 요청 시 요청 메시지 전송

### 🔍 중점적으로 리뷰 할 부분
- 
