### PR TITLE
[feat #134] 채팅 요청 자동 거절 스케줄러

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
@@ -13,9 +13,8 @@ import com.dnd.gongmuin.member.domain.Member;
 public interface ChatRoomQueryRepository {
 
 	Slice<ChatRoomInfo> getChatRoomsByMember(Member member, ChatStatus chatStatus, Pageable pageable);
-
-
 	List<Long> getAutoRejectedInquirerIds();
 	void updateChatRoomStatusRejected();
 	void refundInMemberIds(List<Long> memberIds, int credit);
+	void saveCreditHistoryInMemberIds(List<Long> memberIds, CreditType type, int credit);
 }

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
@@ -1,15 +1,20 @@
 package com.dnd.gongmuin.chat.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import com.dnd.gongmuin.chat.domain.ChatStatus;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
+import com.dnd.gongmuin.credit_history.domain.CreditType;
 import com.dnd.gongmuin.member.domain.Member;
 
 public interface ChatRoomQueryRepository {
+
 	Slice<ChatRoomInfo> getChatRoomsByMember(Member member, ChatStatus chatStatus, Pageable pageable);
 
 
 	List<Long> getAutoRejectedInquirerIds();
+	void updateChatRoomStatusRejected();
 }

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
@@ -9,4 +9,7 @@ import com.dnd.gongmuin.member.domain.Member;
 
 public interface ChatRoomQueryRepository {
 	Slice<ChatRoomInfo> getChatRoomsByMember(Member member, ChatStatus chatStatus, Pageable pageable);
+
+
+	List<Long> getAutoRejectedInquirerIds();
 }

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
@@ -7,14 +7,13 @@ import org.springframework.data.domain.Slice;
 
 import com.dnd.gongmuin.chat.domain.ChatStatus;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
-import com.dnd.gongmuin.credit_history.domain.CreditType;
 import com.dnd.gongmuin.member.domain.Member;
 
 public interface ChatRoomQueryRepository {
 
 	Slice<ChatRoomInfo> getChatRoomsByMember(Member member, ChatStatus chatStatus, Pageable pageable);
+
 	List<Long> getAutoRejectedInquirerIds();
+
 	void updateChatRoomStatusRejected();
-	void refundInMemberIds(List<Long> memberIds, int credit);
-	void saveCreditHistoryInMemberIds(List<Long> memberIds, CreditType type, int credit);
 }

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
@@ -17,4 +17,5 @@ public interface ChatRoomQueryRepository {
 
 	List<Long> getAutoRejectedInquirerIds();
 	void updateChatRoomStatusRejected();
+	void refundInMemberIds(List<Long> memberIds, int credit);
 }

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
@@ -88,7 +88,6 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
 			.execute();
 	}
 
-
 	private <T> boolean hasNext(int pageSize, List<T> items) {
 		if (items.size() <= pageSize) {
 			return false;

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
@@ -88,7 +88,14 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
 			.execute();
 	}
 
-
+	@Transactional
+	public void refundInMemberIds(List<Long> memberIds, int credit) {
+		queryFactory
+			.update(member)
+			.set(member.credit, member.credit.add(credit))
+			.where(member.id.in(memberIds))
+			.execute();
+	}
 
 
 	private <T> boolean hasNext(int pageSize, List<T> items) {

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
@@ -88,24 +88,6 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
 			.execute();
 	}
 
-	@Transactional
-	public void refundInMemberIds(List<Long> memberIds, int credit) {
-		queryFactory
-			.update(member)
-			.set(member.credit, member.credit.add(credit))
-			.where(member.id.in(memberIds))
-			.execute();
-	}
-
-	public void saveCreditHistoryInMemberIds(List<Long> memberIds, CreditType type, int credit) {
-		List<Member> inquirers = memberRepository.findAllById(memberIds);
-		List<CreditHistory> histories = inquirers.stream()
-			.map(inquirer -> CreditHistory.of(type, credit, inquirer))
-			.toList();
-		creditHistoryRepository.saveAll(histories);
-	}
-
-
 
 	private <T> boolean hasNext(int pageSize, List<T> items) {
 		if (items.size() <= pageSize) {

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
@@ -97,6 +97,15 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
 			.execute();
 	}
 
+	public void saveCreditHistoryInMemberIds(List<Long> memberIds, CreditType type, int credit) {
+		List<Member> inquirers = memberRepository.findAllById(memberIds);
+		List<CreditHistory> histories = inquirers.stream()
+			.map(inquirer -> CreditHistory.of(type, credit, inquirer))
+			.toList();
+		creditHistoryRepository.saveAll(histories);
+	}
+
+
 
 	private <T> boolean hasNext(int pageSize, List<T> items) {
 		if (items.size() <= pageSize) {

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.dnd.gongmuin.chat.repository;
 
 import static com.dnd.gongmuin.chat.domain.QChatRoom.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
@@ -12,6 +13,7 @@ import com.dnd.gongmuin.chat.domain.ChatStatus;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
 import com.dnd.gongmuin.chat.dto.response.QChatRoomInfo;
 import com.dnd.gongmuin.member.domain.Member;
+import com.dnd.gongmuin.member.repository.MemberRepository;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -57,6 +59,16 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
 		return new SliceImpl<>(content, pageable, hasNext);
 	}
 
+	public List<Long> getAutoRejectedInquirerIds() {
+		return queryFactory
+			.select(chatRoom.inquirer.id)
+			.from(chatRoom)
+			.where(
+				chatRoom.createdAt.loe(LocalDateTime.now().minusWeeks(1)),
+				chatRoom.status.eq(ChatStatus.PENDING)
+			)
+			.fetch();
+	}
 	private <T> boolean hasNext(int pageSize, List<T> items) {
 		if (items.size() <= pageSize) {
 			return false;

--- a/src/main/java/com/dnd/gongmuin/chat/scheduler/ChatScheduler.java
+++ b/src/main/java/com/dnd/gongmuin/chat/scheduler/ChatScheduler.java
@@ -1,35 +1,23 @@
 package com.dnd.gongmuin.chat.scheduler;
 
-import java.util.List;
-
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.dnd.gongmuin.chat.repository.ChatRoomRepository;
-import com.dnd.gongmuin.credit_history.domain.CreditType;
+import com.dnd.gongmuin.chat.service.ChatRoomService;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class ChatScheduler {
-	/*
-	- 2000 크레딧 반환
-		- 반환 이력 추가
-	- 상태 거절로 바꾸기
-	 */
-	private final ChatRoomRepository chatRoomRepository;
-	private static final int CHAT_REWARD = 2000;
+
+	private final ChatRoomService chatRoomService;
 
 	@Transactional
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	public void rejectChatRequest() {
-		List<Long> rejectedInquirerIds = chatRoomRepository.getAutoRejectedInquirerIds();
-		chatRoomRepository.updateChatRoomStatusRejected();
-		chatRoomRepository.refundInMemberIds(rejectedInquirerIds, CHAT_REWARD);
-		chatRoomRepository.saveCreditHistoryInMemberIds(
-			rejectedInquirerIds, CreditType.CHAT_REFUND, CHAT_REWARD
-		);
+		chatRoomService.rejectChatAuto();
 	}
+
 }

--- a/src/main/java/com/dnd/gongmuin/chat/scheduler/ChatScheduler.java
+++ b/src/main/java/com/dnd/gongmuin/chat/scheduler/ChatScheduler.java
@@ -1,0 +1,35 @@
+package com.dnd.gongmuin.chat.scheduler;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dnd.gongmuin.chat.repository.ChatRoomRepository;
+import com.dnd.gongmuin.credit_history.domain.CreditType;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ChatScheduler {
+	/*
+	- 2000 크레딧 반환
+		- 반환 이력 추가
+	- 상태 거절로 바꾸기
+	 */
+	private final ChatRoomRepository chatRoomRepository;
+	private static final int CHAT_REWARD = 2000;
+
+	@Transactional
+	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+	public void rejectChatRequest() {
+		List<Long> rejectedInquirerIds = chatRoomRepository.getAutoRejectedInquirerIds();
+		chatRoomRepository.updateChatRoomStatusRejected();
+		chatRoomRepository.refundInMemberIds(rejectedInquirerIds, CHAT_REWARD);
+		chatRoomRepository.saveCreditHistoryInMemberIds(
+			rejectedInquirerIds, CreditType.CHAT_REFUND, CHAT_REWARD
+		);
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
@@ -50,6 +50,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ChatRoomService {
 
+	private static final int CHAT_REWARD = 2000;
 	private final ChatMessageRepository chatMessageRepository;
 	private final ChatMessageQueryRepository chatMessageQueryRepository;
 	private final ChatRoomRepository chatRoomRepository;
@@ -150,6 +151,14 @@ public class ChatRoomService {
 		);
 
 		return ChatRoomMapper.toRejectChatResponse(chatRoom);
+	}
+
+	@Transactional
+	public void rejectChatAuto(){
+		List<Long> rejectedInquirerIds = chatRoomRepository.getAutoRejectedInquirerIds();
+		chatRoomRepository.updateChatRoomStatusRejected();
+		memberRepository.refundInMemberIds(rejectedInquirerIds, CHAT_REWARD);
+		creditHistoryService.saveCreditHistoryInMemberIds(rejectedInquirerIds, CreditType.CHAT_REFUND, CHAT_REWARD);
 	}
 
 	private List<ChatRoomSimpleResponse> getChatRoomSimpleResponses(List<LatestChatMessage> latestChatMessages,

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
@@ -154,7 +154,7 @@ public class ChatRoomService {
 	}
 
 	@Transactional
-	public void rejectChatAuto(){
+	public void rejectChatAuto() {
 		List<Long> rejectedInquirerIds = chatRoomRepository.getAutoRejectedInquirerIds();
 		chatRoomRepository.updateChatRoomStatusRejected();
 		memberRepository.refundInMemberIds(rejectedInquirerIds, CHAT_REWARD);

--- a/src/main/java/com/dnd/gongmuin/common/config/SchedulerConfig.java
+++ b/src/main/java/com/dnd/gongmuin/common/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.dnd.gongmuin.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/com/dnd/gongmuin/credit_history/domain/CreditHistory.java
+++ b/src/main/java/com/dnd/gongmuin/credit_history/domain/CreditHistory.java
@@ -49,7 +49,7 @@ public class CreditHistory extends TimeBaseEntity {
 		this.member = member;
 	}
 
-	public static CreditHistory of(CreditType type, String detail, int amount, Member member) {
-		return new CreditHistory(type, detail, amount, member);
+	public static CreditHistory of(CreditType type, int amount, Member member) {
+		return new CreditHistory(type, type.getDetail(), amount, member);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/credit_history/domain/CreditHistory.java
+++ b/src/main/java/com/dnd/gongmuin/credit_history/domain/CreditHistory.java
@@ -2,6 +2,8 @@ package com.dnd.gongmuin.credit_history.domain;
 
 import static jakarta.persistence.FetchType.*;
 
+import java.util.Objects;
+
 import com.dnd.gongmuin.common.entity.TimeBaseEntity;
 import com.dnd.gongmuin.member.domain.Member;
 
@@ -51,5 +53,21 @@ public class CreditHistory extends TimeBaseEntity {
 
 	public static CreditHistory of(CreditType type, int amount, Member member) {
 		return new CreditHistory(type, type.getDetail(), amount, member);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		CreditHistory that = (CreditHistory) o;
+		return amount == that.amount &&
+			Objects.equals(type, that.type) &&
+			Objects.equals(detail, that.detail) &&
+			Objects.equals(member, that.member);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(type, detail, amount, member);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/credit_history/domain/CreditHistory.java
+++ b/src/main/java/com/dnd/gongmuin/credit_history/domain/CreditHistory.java
@@ -57,9 +57,11 @@ public class CreditHistory extends TimeBaseEntity {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
-		CreditHistory that = (CreditHistory) o;
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		CreditHistory that = (CreditHistory)o;
 		return amount == that.amount &&
 			Objects.equals(type, that.type) &&
 			Objects.equals(detail, that.detail) &&

--- a/src/main/java/com/dnd/gongmuin/credit_history/dto/CreditHistoryMapper.java
+++ b/src/main/java/com/dnd/gongmuin/credit_history/dto/CreditHistoryMapper.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CreditHistoryMapper {
 	public static CreditHistory toCreditHistory(CreditType creditType, int reward, Member member) {
-		return CreditHistory.of(creditType, creditType.getDetail(), reward, member);
+		return CreditHistory.of(creditType, reward, member);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/credit_history/service/CreditHistoryService.java
+++ b/src/main/java/com/dnd/gongmuin/credit_history/service/CreditHistoryService.java
@@ -6,10 +6,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dnd.gongmuin.answer.domain.Answer;
+import com.dnd.gongmuin.credit_history.domain.CreditHistory;
 import com.dnd.gongmuin.credit_history.domain.CreditType;
 import com.dnd.gongmuin.credit_history.dto.CreditHistoryMapper;
 import com.dnd.gongmuin.credit_history.repository.CreditHistoryRepository;
 import com.dnd.gongmuin.member.domain.Member;
+import com.dnd.gongmuin.member.repository.MemberRepository;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class CreditHistoryService {
 
 	private final CreditHistoryRepository creditHistoryRepository;
+	private final MemberRepository memberRepository;
 
 	@Transactional
 	public void saveChosenCreditHistory(QuestionPost questionPost, Answer answer) {
@@ -34,5 +37,13 @@ public class CreditHistoryService {
 		creditHistoryRepository.save(
 			CreditHistoryMapper.toCreditHistory(creditType, chatCredit, member)
 		);
+	}
+
+	public void saveCreditHistoryInMemberIds(List<Long> memberIds, CreditType type, int credit){
+		List<Member> inquirers = memberRepository.findAllById(memberIds);
+		List<CreditHistory> histories = inquirers.stream()
+			.map(inquirer -> CreditHistory.of(type, credit, inquirer))
+			.toList();
+		creditHistoryRepository.saveAll(histories);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/credit_history/service/CreditHistoryService.java
+++ b/src/main/java/com/dnd/gongmuin/credit_history/service/CreditHistoryService.java
@@ -39,7 +39,7 @@ public class CreditHistoryService {
 		);
 	}
 
-	public void saveCreditHistoryInMemberIds(List<Long> memberIds, CreditType type, int credit){
+	public void saveCreditHistoryInMemberIds(List<Long> memberIds, CreditType type, int credit) {
 		List<Member> inquirers = memberRepository.findAllById(memberIds);
 		List<CreditHistory> histories = inquirers.stream()
 			.map(inquirer -> CreditHistory.of(type, credit, inquirer))

--- a/src/main/java/com/dnd/gongmuin/member/repository/MemberCustom.java
+++ b/src/main/java/com/dnd/gongmuin/member/repository/MemberCustom.java
@@ -1,5 +1,7 @@
 package com.dnd.gongmuin.member.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -17,4 +19,6 @@ public interface MemberCustom {
 	Slice<BookmarksResponse> getBookmarksByMember(Member member, Pageable pageable);
 
 	Slice<CreditHistoryResponse> getCreditHistoryByMember(String type, Member member, Pageable pageable);
+
+	void refundInMemberIds(List<Long> memberIds, int credit);
 }

--- a/src/main/java/com/dnd/gongmuin/member/repository/MemberCustomImpl.java
+++ b/src/main/java/com/dnd/gongmuin/member/repository/MemberCustomImpl.java
@@ -1,12 +1,14 @@
 package com.dnd.gongmuin.member.repository;
 
 import static com.dnd.gongmuin.credit_history.domain.QCreditHistory.*;
+import static com.dnd.gongmuin.member.domain.QMember.*;
 
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.dnd.gongmuin.answer.domain.QAnswer;
 import com.dnd.gongmuin.credit_history.domain.CreditType;
@@ -164,6 +166,15 @@ public class MemberCustomImpl implements MemberCustom {
 		boolean hasNext = hasNext(pageable.getPageSize(), content);
 
 		return new SliceImpl<>(content, pageable, hasNext);
+	}
+
+	@Transactional
+	public void refundInMemberIds(List<Long> memberIds, int credit) {
+		queryFactory
+			.update(member)
+			.set(member.credit, member.credit.add(credit))
+			.where(member.id.in(memberIds))
+			.execute();
 	}
 
 	private BooleanExpression creditTypeEq(String type) {

--- a/src/test/java/com/dnd/gongmuin/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/repository/ChatRoomRepositoryTest.java
@@ -36,7 +36,6 @@ import lombok.extern.slf4j.Slf4j;
 class ChatRoomRepositoryTest extends DataJpaTestSupport {
 
 	private final PageRequest pageRequest = PageRequest.of(0, 10);
-	private static final int CHAT_REWARD = 2000;
 
 	@Autowired
 	ChatRoomRepository chatRoomRepository;
@@ -47,9 +46,6 @@ class ChatRoomRepositoryTest extends DataJpaTestSupport {
 
 	@Autowired
 	CreditHistoryRepository creditHistoryRepository;
-
-	@Autowired
-	private EntityManager em;
 
 	@DisplayName("회원이 속한 채팅방을 모두 조회할 수 있다.")
 	@Test
@@ -106,80 +102,5 @@ class ChatRoomRepositoryTest extends DataJpaTestSupport {
 			() -> assertThat(chatRoom1.getStatus()).isEqualTo(ChatStatus.REJECTED),
 			() -> assertThat(chatRoom2.getStatus()).isEqualTo(ChatStatus.PENDING)
 		);
-	}
-
-	@DisplayName("아이디에 속하는 회원들의 채팅 금액을 환급한다.")
-	@Test
-	void refundInMemberIds() {
-
-		//given
-		List<Member> initMembers = memberRepository.saveAll(List.of(
-			MemberFixture.member(),
-			MemberFixture.member(),
-			MemberFixture.member()
-		));
-
-		//when
-		chatRoomRepository.refundInMemberIds(
-			List.of(
-				initMembers.get(0).getId(),
-				initMembers.get(1).getId()
-			),
-			CHAT_REWARD
-		);
-
-		em.flush();
-		em.clear();
-
-		List<Member> foundMembers = memberRepository.findAllById(
-			List.of(
-				initMembers.get(0).getId(),
-				initMembers.get(1).getId(),
-				initMembers.get(2).getId()
-			)
-		);
-
-		//then
-		assertAll(
-			() -> assertThat(foundMembers.get(0).getCredit())
-				.isEqualTo(initMembers.get(0).getCredit() + CHAT_REWARD),
-			() -> assertThat(foundMembers.get(1).getCredit())
-				.isEqualTo(initMembers.get(1).getCredit() + CHAT_REWARD),
-			() -> assertThat(foundMembers.get(2).getCredit())
-				.isEqualTo(initMembers.get(2).getCredit())
-		);
-	}
-
-	@DisplayName("아이디에 속하는 회원들의 채팅 환급 크레딧 내역을 추가한다.")
-	@Test
-	void saveCreditHistoryInMemberIds() {
-		//given
-		List<Member> initMembers = memberRepository.saveAll(List.of(
-			MemberFixture.member(),
-			MemberFixture.member(),
-			MemberFixture.member()
-		));
-
-		//when
-		chatRoomRepository.saveCreditHistoryInMemberIds(
-			List.of(
-				initMembers.get(0).getId(),
-				initMembers.get(1).getId()
-			),
-			CreditType.CHAT_REQUEST,
-			CHAT_REWARD
-		);
-
-		List<CreditHistory> histories = creditHistoryRepository.findAll();
-
-		//then
-		assertAll(
-			() -> assertThat(histories).hasSize(2),
-			() -> assertThat(histories.get(0).getMember().getId())
-				.isEqualTo(initMembers.get(0).getId()),
-			() -> assertThat(histories.get(1).getMember().getId())
-				.isEqualTo(initMembers.get(1).getId())
-		);
-
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/repository/ChatRoomRepositoryTest.java
@@ -1,7 +1,9 @@
 package com.dnd.gongmuin.chat.repository;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
@@ -9,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.dnd.gongmuin.chat.domain.ChatRoom;
 import com.dnd.gongmuin.chat.domain.ChatStatus;
@@ -17,21 +20,36 @@ import com.dnd.gongmuin.common.fixture.ChatRoomFixture;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
 import com.dnd.gongmuin.common.fixture.QuestionPostFixture;
 import com.dnd.gongmuin.common.support.DataJpaTestSupport;
+import com.dnd.gongmuin.credit_history.domain.CreditHistory;
+import com.dnd.gongmuin.credit_history.domain.CreditType;
+import com.dnd.gongmuin.credit_history.repository.CreditHistoryRepository;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.repository.MemberRepository;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @DisplayName("[ChatRoomRepository 테스트]")
 class ChatRoomRepositoryTest extends DataJpaTestSupport {
 
 	private final PageRequest pageRequest = PageRequest.of(0, 10);
+	private static final int CHAT_REWARD = 2000;
+
 	@Autowired
 	ChatRoomRepository chatRoomRepository;
 	@Autowired
 	MemberRepository memberRepository;
 	@Autowired
 	QuestionPostRepository questionPostRepository;
+
+	@Autowired
+	CreditHistoryRepository creditHistoryRepository;
+
+	@Autowired
+	private EntityManager em;
 
 	@DisplayName("회원이 속한 채팅방을 모두 조회할 수 있다.")
 	@Test
@@ -59,5 +77,109 @@ class ChatRoomRepositoryTest extends DataJpaTestSupport {
 			() -> assertThat(chatRoomInfos.get(1).chatRoomId()).isEqualTo(chatRooms.get(2).getId()),
 			() -> assertThat(chatRoomInfos.get(1).partnerId()).isEqualTo(answerer.getId())
 		);
+	}
+
+	@DisplayName("요청중인 채팅방이 일주일이 지나면, 채팅방 상태를 거절함으로 바꾼다.")
+	@Test
+	void updateChatRoomStatusRejected() {
+		//given
+		Member questioner = memberRepository.save(MemberFixture.member());
+		Member answerer = memberRepository.save(MemberFixture.member());
+		QuestionPost questionPost = questionPostRepository.save(QuestionPostFixture.questionPost(questioner));
+
+		List<ChatRoom> chatRooms = chatRoomRepository.saveAll(List.of(
+			chatRoomRepository.save(ChatRoomFixture.chatRoom(questionPost, questioner, answerer)),
+			chatRoomRepository.save(ChatRoomFixture.chatRoom(questionPost, questioner, answerer))
+		));
+		ReflectionTestUtils.setField(chatRooms.get(0), "createdAt", LocalDateTime.now().minusWeeks(1));
+
+		//when
+		chatRoomRepository.updateChatRoomStatusRejected();
+
+		em.flush();
+		em.clear();
+
+		//then
+		ChatRoom chatRoom1 = chatRoomRepository.findById(chatRooms.get(0).getId()).orElseThrow();
+		ChatRoom chatRoom2 = chatRoomRepository.findById(chatRooms.get(1).getId()).orElseThrow();
+		assertAll(
+			() -> assertThat(chatRoom1.getStatus()).isEqualTo(ChatStatus.REJECTED),
+			() -> assertThat(chatRoom2.getStatus()).isEqualTo(ChatStatus.PENDING)
+		);
+	}
+
+	@DisplayName("아이디에 속하는 회원들의 채팅 금액을 환급한다.")
+	@Test
+	void refundInMemberIds() {
+
+		//given
+		List<Member> initMembers = memberRepository.saveAll(List.of(
+			MemberFixture.member(),
+			MemberFixture.member(),
+			MemberFixture.member()
+		));
+
+		//when
+		chatRoomRepository.refundInMemberIds(
+			List.of(
+				initMembers.get(0).getId(),
+				initMembers.get(1).getId()
+			),
+			CHAT_REWARD
+		);
+
+		em.flush();
+		em.clear();
+
+		List<Member> foundMembers = memberRepository.findAllById(
+			List.of(
+				initMembers.get(0).getId(),
+				initMembers.get(1).getId(),
+				initMembers.get(2).getId()
+			)
+		);
+
+		//then
+		assertAll(
+			() -> assertThat(foundMembers.get(0).getCredit())
+				.isEqualTo(initMembers.get(0).getCredit() + CHAT_REWARD),
+			() -> assertThat(foundMembers.get(1).getCredit())
+				.isEqualTo(initMembers.get(1).getCredit() + CHAT_REWARD),
+			() -> assertThat(foundMembers.get(2).getCredit())
+				.isEqualTo(initMembers.get(2).getCredit())
+		);
+	}
+
+	@DisplayName("아이디에 속하는 회원들의 채팅 환급 크레딧 내역을 추가한다.")
+	@Test
+	void saveCreditHistoryInMemberIds() {
+		//given
+		List<Member> initMembers = memberRepository.saveAll(List.of(
+			MemberFixture.member(),
+			MemberFixture.member(),
+			MemberFixture.member()
+		));
+
+		//when
+		chatRoomRepository.saveCreditHistoryInMemberIds(
+			List.of(
+				initMembers.get(0).getId(),
+				initMembers.get(1).getId()
+			),
+			CreditType.CHAT_REQUEST,
+			CHAT_REWARD
+		);
+
+		List<CreditHistory> histories = creditHistoryRepository.findAll();
+
+		//then
+		assertAll(
+			() -> assertThat(histories).hasSize(2),
+			() -> assertThat(histories.get(0).getMember().getId())
+				.isEqualTo(initMembers.get(0).getId()),
+			() -> assertThat(histories.get(1).getMember().getId())
+				.isEqualTo(initMembers.get(1).getId())
+		);
+
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/common/fixture/CreditHistoryFixture.java
+++ b/src/test/java/com/dnd/gongmuin/common/fixture/CreditHistoryFixture.java
@@ -13,7 +13,6 @@ public class CreditHistoryFixture {
 	public static CreditHistory creditHistory(CreditType creditType, int reward, Member member) {
 		return CreditHistory.of(
 			creditType,
-			creditType.getDetail(),
 			reward,
 			member
 		);

--- a/src/test/java/com/dnd/gongmuin/common/support/DataJpaTestSupport.java
+++ b/src/test/java/com/dnd/gongmuin/common/support/DataJpaTestSupport.java
@@ -1,5 +1,6 @@
 package com.dnd.gongmuin.common.support;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan;
@@ -9,9 +10,13 @@ import org.springframework.stereotype.Repository;
 import com.dnd.gongmuin.common.config.QueryDslConfig;
 import com.dnd.gongmuin.config.TestAuditingConfig;
 
+import jakarta.persistence.EntityManager;
+
 //repository용
 @DataJpaTest(includeFilters = @ComponentScan.Filter(Repository.class))
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({TestAuditingConfig.class, QueryDslConfig.class})
 public abstract class DataJpaTestSupport extends TestContainerSupport {
+	@Autowired
+	protected EntityManager em;
 }

--- a/src/test/java/com/dnd/gongmuin/credit_history/service/CreditHistoryServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/credit_history/service/CreditHistoryServiceTest.java
@@ -3,6 +3,8 @@ package com.dnd.gongmuin.credit_history.service;
 import static org.mockito.BDDMockito.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,8 @@ import com.dnd.gongmuin.common.fixture.QuestionPostFixture;
 import com.dnd.gongmuin.credit_history.domain.CreditHistory;
 import com.dnd.gongmuin.credit_history.domain.CreditType;
 import com.dnd.gongmuin.credit_history.repository.CreditHistoryRepository;
+import com.dnd.gongmuin.member.domain.Member;
+import com.dnd.gongmuin.member.repository.MemberRepository;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 
 @DisplayName("[AnswerService 테스트]")
@@ -27,6 +31,9 @@ class CreditHistoryServiceTest {
 
 	@Mock
 	private CreditHistoryRepository creditHistoryRepository;
+
+	@Mock
+	private MemberRepository memberRepository;
 
 	@InjectMocks
 	private CreditHistoryService creditHistoryService;
@@ -44,5 +51,31 @@ class CreditHistoryServiceTest {
 		given(creditHistoryRepository.saveAll(anyList())).willReturn(creditHistories);
 
 		creditHistoryService.saveChosenCreditHistory(questionPost, answer);
+	}
+
+	@DisplayName("회원 아이디 리스트에 속하는 회원에 대한 크레딧을 모두 저장할 수 있다.")
+	@Test
+	void test() {
+		//given
+		List<Long> memberIds = List.of(1L, 2L);
+		Member member1 = MemberFixture.member(memberIds.get(0));
+		Member member2 = MemberFixture.member(memberIds.get(1));
+
+		given(memberRepository.findAllById(memberIds))
+			.willReturn(List.of(member1, member2));
+
+		List<CreditHistory> expectedHistories = Stream.of(member1, member2)
+			.map(member -> CreditHistoryFixture.creditHistory(CreditType.CHAT_REFUND, 2000, member))
+			.toList();
+
+		//when
+		creditHistoryService.saveCreditHistoryInMemberIds(
+			memberIds,
+			CreditType.CHAT_REFUND,
+			2000
+		);
+
+		//then
+		verify(creditHistoryRepository).saveAll(expectedHistories);
 	}
 }


### PR DESCRIPTION
### 관련 이슈
- close #134 

### 📑 작업 상세 내용
- 채팅 상태 변경
  - 일주일 이상 요청중인 채팅
  - 채팅 상태 요청중 > 거절됨
- 일주일 이상 요청 중인 채팅방에 속하는 요청자 아이디 모두 조회
  - 아래 나오는 함수들 파라미터로 사용
- 회원 크레딧 환급
   - 특정 아이디 회원들 크레딧 증가
- 회원 크레딧 내역 추가
   - 특정 크레딧 회원들 크레딧 내역 저장

### 💫 작업 요약
- 채팅방 자동거절 상태로 바뀜에 따라 채팅방,회원 업데이트 및 크레딧 내역 저장

### 🔍 중점적으로 리뷰 할 부분
- chatRoomRepositoryImpl
- chatScheduler
- 회원 크레딧 환급 함수 및 회원 크레딧 내역 추가 함수 memberRepository로 이동할지
- 업데이트는 bulk update인데 삽입은 bulk insert 아니라 saveAll로 사용
