### PR TITLE
[feat #136] 채팅방 상세 조회 응답에 요청자 여부 필드 추가

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
@@ -55,7 +55,7 @@ public class ChatRoomMapper {
 		Member chatPartner
 	) {
 		QuestionPost questionPost = chatRoom.getQuestionPost();
-
+		boolean isInquirer = !chatPartner.equals(chatRoom.getInquirer());
 		return new ChatRoomDetailResponse(
 			questionPost.getId(),
 			questionPost.getJobGroup().getLabel(),
@@ -66,7 +66,8 @@ public class ChatRoomMapper {
 				chatPartner.getJobGroup().getLabel(),
 				chatPartner.getProfileImageNo()
 			),
-			chatRoom.getStatus().getLabel()
+			chatRoom.getStatus().getLabel(),
+			isInquirer
 		);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomDetailResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomDetailResponse.java
@@ -7,6 +7,7 @@ public record ChatRoomDetailResponse(
 	String targetJobGroup,
 	String title,
 	MemberInfo receiverInfo,
-	String chatStatus
+	String chatStatus,
+	boolean isInquirer
 ) {
 }

--- a/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
@@ -172,7 +172,8 @@ class ChatRoomControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.receiverInfo.memberId").value(inquirer.getId()))
 			.andExpect(jsonPath("$.receiverInfo.nickname").value(inquirer.getNickname()))
 			.andExpect(jsonPath("$.receiverInfo.memberJobGroup").value(inquirer.getJobGroup().getLabel()))
-			.andExpect(jsonPath("$.receiverInfo.profileImageNo").value(inquirer.getProfileImageNo()));
+			.andExpect(jsonPath("$.receiverInfo.profileImageNo").value(inquirer.getProfileImageNo()))
+			.andExpect(jsonPath("$.isInquirer").value(false));
 	}
 
 	@DisplayName("[답변자가 채팅 요청을 수락할 수 있다.]")


### PR DESCRIPTION
### 관련 이슈
- close #136 

### 📑 작업 상세 내용
- 채팅방 상세 조회 시 [요청자|답변자] 구분 위해 isInquirer 필드 추가

### 💫 작업 요약
- 

### 🔍 중점적으로 리뷰 할 부분
- 
