### PR TITLE
[feat #138] 채팅방 목록 조회 API 상태 필드 추가 및 필터링 수정

### DIFF
--- a/src/main/java/com/dnd/gongmuin/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/dnd/gongmuin/answer/repository/AnswerRepository.java
@@ -1,22 +1,24 @@
 package com.dnd.gongmuin.answer.repository;
 
-import com.dnd.gongmuin.answer.domain.Answer;
-import com.dnd.gongmuin.member.domain.Member;
 import java.util.List;
+
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import com.dnd.gongmuin.answer.domain.Answer;
+import com.dnd.gongmuin.member.domain.Member;
+
 @Repository
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
-    Slice<Answer> findByQuestionPostId(Long questionPostId);
+	Slice<Answer> findByQuestionPostId(Long questionPostId);
 
-    List<Answer> findAllByMember(Member member);
+	List<Answer> findAllByMember(Member member);
 
-    @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("UPDATE Answer a SET a.member = :member WHERE a.member.id = :memberId")
-    public void updateAnswersMember(Long memberId, Member member);
+	@Modifying(flushAutomatically = true, clearAutomatically = true)
+	@Query("UPDATE Answer a SET a.member = :member WHERE a.member.id = :memberId")
+	void updateAnswersMember(Long memberId, Member member);
 }

--- a/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
@@ -1,5 +1,13 @@
 package com.dnd.gongmuin.auth.service;
 
+import java.time.Duration;
+import java.util.Date;
+import java.util.Objects;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.dnd.gongmuin.answer.repository.AnswerRepository;
 import com.dnd.gongmuin.auth.dto.request.AdditionalInfoRequest;
 import com.dnd.gongmuin.auth.dto.request.TempSignInRequest;
@@ -29,222 +37,217 @@ import com.dnd.gongmuin.security.jwt.util.TokenProvider;
 import com.dnd.gongmuin.security.oauth2.AuthInfo;
 import com.dnd.gongmuin.security.oauth2.CustomOauth2User;
 import com.dnd.gongmuin.security.service.OAuth2UnlinkService;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.time.Duration;
-import java.util.Date;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
-    private static final String LOGOUT = "logout";
-    private static final String DELETE = "delete";
-    private static final String ANONYMOUS = "ROLE_ANONYMOUS";
-    private final TokenProvider tokenProvider;
-    private final MemberRepository memberRepository;
-    private final CookieUtil cookieUtil;
-    private final RedisUtil redisUtil;
-    private final OAuth2UnlinkService oAuth2UnlinkService;
-    private final CreditHistoryRepository creditHistoryRepository;
-    private final QuestionPostRepository questionPostRepository;
-    private final AnswerRepository answerRepository;
-    private final InteractionRepository interactionRepository;
-    private final NotificationRepository notificationRepository;
+	private static final String LOGOUT = "logout";
+	private static final String DELETE = "delete";
+	private static final String ANONYMOUS = "ROLE_ANONYMOUS";
+	private final TokenProvider tokenProvider;
+	private final MemberRepository memberRepository;
+	private final CookieUtil cookieUtil;
+	private final RedisUtil redisUtil;
+	private final OAuth2UnlinkService oAuth2UnlinkService;
+	private final CreditHistoryRepository creditHistoryRepository;
+	private final QuestionPostRepository questionPostRepository;
+	private final AnswerRepository answerRepository;
+	private final InteractionRepository interactionRepository;
+	private final NotificationRepository notificationRepository;
 
-    @Transactional
-    public TempSignResponse tempSignUp(TempSignUpRequest tempSignUpRequest, HttpServletResponse response) {
-        Date now = new Date();
-        Member member = Member.of(
-                tempSignUpRequest.socialName(),
-                "kakao/" + tempSignUpRequest.socialEmail(),
-                10000,
-                "ROLE_GUEST"
-        );
+	@Transactional
+	public TempSignResponse tempSignUp(TempSignUpRequest tempSignUpRequest, HttpServletResponse response) {
+		Date now = new Date();
+		Member member = Member.of(
+			tempSignUpRequest.socialName(),
+			"kakao/" + tempSignUpRequest.socialEmail(),
+			10000,
+			"ROLE_GUEST"
+		);
 
-        if (memberRepository.existsBySocialEmail(member.getSocialEmail())) {
-            throw new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER);
-        }
+		if (memberRepository.existsBySocialEmail(member.getSocialEmail())) {
+			throw new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER);
+		}
 
-        memberRepository.save(member);
+		memberRepository.save(member);
 
-        AuthInfo authInfo = AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole());
-        CustomOauth2User customOauth2User = new CustomOauth2User(authInfo);
+		AuthInfo authInfo = AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole());
+		CustomOauth2User customOauth2User = new CustomOauth2User(authInfo);
 
-        tokenProvider.generateRefreshToken(customOauth2User, now);
-        String accessToken = tokenProvider.generateAccessToken(customOauth2User, now);
-        response.addCookie(cookieUtil.createCookie(accessToken));
+		tokenProvider.generateRefreshToken(customOauth2User, now);
+		String accessToken = tokenProvider.generateAccessToken(customOauth2User, now);
+		response.addCookie(cookieUtil.createCookie(accessToken));
 
-        return new TempSignResponse(true);
-    }
+		return new TempSignResponse(true);
+	}
 
-    @Transactional
-    public TempSignResponse tempSignIn(TempSignInRequest tempSignInRequest, HttpServletResponse response) {
-        Date now = new Date();
+	@Transactional
+	public TempSignResponse tempSignIn(TempSignInRequest tempSignInRequest, HttpServletResponse response) {
+		Date now = new Date();
 
-        String prefixSocialEmail = "kakao/" + tempSignInRequest.socialEmail();
+		String prefixSocialEmail = "kakao/" + tempSignInRequest.socialEmail();
 
-        Member member = memberRepository.findBySocialEmail(prefixSocialEmail)
-                .orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
+		Member member = memberRepository.findBySocialEmail(prefixSocialEmail)
+			.orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
 
-        AuthInfo authInfo = AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole());
-        CustomOauth2User customOauth2User = new CustomOauth2User(authInfo);
+		AuthInfo authInfo = AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole());
+		CustomOauth2User customOauth2User = new CustomOauth2User(authInfo);
 
-        tokenProvider.generateRefreshToken(customOauth2User, now);
-        String accessToken = tokenProvider.generateAccessToken(customOauth2User, now);
-        response.addCookie(cookieUtil.createCookie(accessToken));
+		tokenProvider.generateRefreshToken(customOauth2User, now);
+		String accessToken = tokenProvider.generateAccessToken(customOauth2User, now);
+		response.addCookie(cookieUtil.createCookie(accessToken));
 
-        return new TempSignResponse(true);
-    }
+		return new TempSignResponse(true);
+	}
 
-    @Transactional(readOnly = true)
-    public ValidateNickNameResponse isDuplicatedNickname(ValidateNickNameRequest request) {
-        boolean isDuplicated = memberRepository.existsByNickname(request.nickname());
+	@Transactional(readOnly = true)
+	public ValidateNickNameResponse isDuplicatedNickname(ValidateNickNameRequest request) {
+		boolean isDuplicated = memberRepository.existsByNickname(request.nickname());
 
-        return new ValidateNickNameResponse(isDuplicated);
-    }
+		return new ValidateNickNameResponse(isDuplicated);
+	}
 
-    @Transactional
-    public SignUpResponse signUp(AdditionalInfoRequest request, String email, HttpServletResponse response) {
-        Member foundMember = memberRepository.findBySocialEmail(email)
-                .orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
+	@Transactional
+	public SignUpResponse signUp(AdditionalInfoRequest request, String email, HttpServletResponse response) {
+		Member foundMember = memberRepository.findBySocialEmail(email)
+			.orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
 
-        if (!isOfficialEmail(foundMember)) {
-            throw new NotFoundException(MemberErrorCode.NOT_FOUND_NEW_MEMBER);
-        }
+		if (!isOfficialEmail(foundMember)) {
+			throw new NotFoundException(MemberErrorCode.NOT_FOUND_NEW_MEMBER);
+		}
 
-        updateAdditionalInfo(request, foundMember);
+		updateAdditionalInfo(request, foundMember);
 
-        cookieUtil.deleteCookie(response);
+		cookieUtil.deleteCookie(response);
 
-        return new SignUpResponse(foundMember.getNickname());
-    }
+		return new SignUpResponse(foundMember.getNickname());
+	}
 
-    public LogoutResponse logout(HttpServletRequest request, HttpServletResponse response) {
-        String accessToken = cookieUtil.getCookieValue(request);
+	public LogoutResponse logout(HttpServletRequest request, HttpServletResponse response) {
+		String accessToken = cookieUtil.getCookieValue(request);
 
-        if (!tokenProvider.validateToken(accessToken, new Date())) {
-            throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
-        }
+		if (!tokenProvider.validateToken(accessToken, new Date())) {
+			throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
+		}
 
-        Authentication authentication = tokenProvider.getAuthentication(accessToken);
-        Member member = (Member) authentication.getPrincipal();
+		Authentication authentication = tokenProvider.getAuthentication(accessToken);
+		Member member = (Member)authentication.getPrincipal();
 
-        if (!Objects.isNull(redisUtil.getValues("RT:" + member.getSocialEmail()))) {
-            redisUtil.deleteValues("RT:" + member.getSocialEmail());
-        }
+		if (!Objects.isNull(redisUtil.getValues("RT:" + member.getSocialEmail()))) {
+			redisUtil.deleteValues("RT:" + member.getSocialEmail());
+		}
 
-        Long expiration = tokenProvider.getExpiration(accessToken, new Date());
-        redisUtil.setValues(accessToken, LOGOUT, Duration.ofMillis(expiration));
+		Long expiration = tokenProvider.getExpiration(accessToken, new Date());
+		redisUtil.setValues(accessToken, LOGOUT, Duration.ofMillis(expiration));
 
-        String values = redisUtil.getValues(accessToken);
-        if (!Objects.equals(values, LOGOUT)) {
-            throw new NotFoundException(MemberErrorCode.LOGOUT_FAILED);
-        }
+		String values = redisUtil.getValues(accessToken);
+		if (!Objects.equals(values, LOGOUT)) {
+			throw new NotFoundException(MemberErrorCode.LOGOUT_FAILED);
+		}
 
-        cookieUtil.deleteCookie(response);
+		cookieUtil.deleteCookie(response);
 
-        return new LogoutResponse(true);
-    }
+		return new LogoutResponse(true);
+	}
 
-    public ReissueResponse reissue(HttpServletRequest request, HttpServletResponse response) {
-        String accessToken = cookieUtil.getCookieValue(request);
+	public ReissueResponse reissue(HttpServletRequest request, HttpServletResponse response) {
+		String accessToken = cookieUtil.getCookieValue(request);
 
-        // 로그아웃 토큰 처리
-        if ("logout".equals(redisUtil.getValues(accessToken))) {
-            throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
-        }
+		// 로그아웃 토큰 처리
+		if ("logout".equals(redisUtil.getValues(accessToken))) {
+			throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
+		}
 
-        Authentication authentication = tokenProvider.getAuthentication(accessToken);
-        Member member = (Member) authentication.getPrincipal();
+		Authentication authentication = tokenProvider.getAuthentication(accessToken);
+		Member member = (Member)authentication.getPrincipal();
 
-        String refreshToken = redisUtil.getValues("RT:" + member.getSocialEmail());
+		String refreshToken = redisUtil.getValues("RT:" + member.getSocialEmail());
 
-        // 로그아웃 또는 토큰 만료 경우 처리
-        if ("false".equals(refreshToken)) {
-            throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
-        }
+		// 로그아웃 또는 토큰 만료 경우 처리
+		if ("false".equals(refreshToken)) {
+			throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
+		}
 
-        CustomOauth2User customUser = new CustomOauth2User(
-                AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole()));
-        String reissuedAccessToken = tokenProvider.generateAccessToken(customUser, new Date());
-        tokenProvider.generateRefreshToken(customUser, new Date());
+		CustomOauth2User customUser = new CustomOauth2User(
+			AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole()));
+		String reissuedAccessToken = tokenProvider.generateAccessToken(customUser, new Date());
+		tokenProvider.generateRefreshToken(customUser, new Date());
 
-        response.addCookie(cookieUtil.createCookie(reissuedAccessToken));
+		response.addCookie(cookieUtil.createCookie(reissuedAccessToken));
 
-        return new ReissueResponse(true);
-    }
+		return new ReissueResponse(true);
+	}
 
-    public boolean isOfficialEmail(Member member) {
-        return Objects.isNull(member.getOfficialEmail());
-    }
+	public boolean isOfficialEmail(Member member) {
+		return Objects.isNull(member.getOfficialEmail());
+	}
 
-    private void updateAdditionalInfo(AdditionalInfoRequest request, Member findMember) {
-        findMember.updateAdditionalInfo(
-                request.nickname(),
-                request.officialEmail(),
-                JobGroup.from(request.jobGroup()),
-                JobCategory.from(request.jobCategory())
-        );
-    }
+	private void updateAdditionalInfo(AdditionalInfoRequest request, Member findMember) {
+		findMember.updateAdditionalInfo(
+			request.nickname(),
+			request.officialEmail(),
+			JobGroup.from(request.jobGroup()),
+			JobCategory.from(request.jobCategory())
+		);
+	}
 
-    @Transactional
-    public DeleteMemberResponse deleteMember(HttpServletRequest request) {
-        String accessToken = cookieUtil.getCookieValue(request);
+	@Transactional
+	public DeleteMemberResponse deleteMember(HttpServletRequest request) {
+		String accessToken = cookieUtil.getCookieValue(request);
 
-        if (!tokenProvider.validateToken(accessToken, new Date())) {
-            throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
-        }
+		if (!tokenProvider.validateToken(accessToken, new Date())) {
+			throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
+		}
 
-        Authentication authentication = tokenProvider.getAuthentication(accessToken);
-        Member member = (Member) authentication.getPrincipal();
+		Authentication authentication = tokenProvider.getAuthentication(accessToken);
+		Member member = (Member)authentication.getPrincipal();
 
-        // RefreshToken 삭제
-        if (!Objects.isNull(redisUtil.getValues("RT:" + member.getSocialEmail()))) {
-            redisUtil.deleteValues("RT:" + member.getSocialEmail());
-        }
+		// RefreshToken 삭제
+		if (!Objects.isNull(redisUtil.getValues("RT:" + member.getSocialEmail()))) {
+			redisUtil.deleteValues("RT:" + member.getSocialEmail());
+		}
 
-        // 현재 발급 되어 있는 AccessToken 블랙리스트 등록
-        Long expiration = tokenProvider.getExpiration(accessToken, new Date());
-        redisUtil.setValues(accessToken, DELETE, Duration.ofMillis(expiration));
+		// 현재 발급 되어 있는 AccessToken 블랙리스트 등록
+		Long expiration = tokenProvider.getExpiration(accessToken, new Date());
+		redisUtil.setValues(accessToken, DELETE, Duration.ofMillis(expiration));
 
-        // AccessToken 블랙리스트 등록 여부 검증
-        String values = redisUtil.getValues(accessToken);
-        if (!Objects.equals(values, DELETE)) {
-            throw new NotFoundException(MemberErrorCode.DELETE_FAILED);
-        }
+		// AccessToken 블랙리스트 등록 여부 검증
+		String values = redisUtil.getValues(accessToken);
+		if (!Objects.equals(values, DELETE)) {
+			throw new NotFoundException(MemberErrorCode.DELETE_FAILED);
+		}
 
-        deleteAssociation(member);
-        replaceWithAnonymous(member);
-        memberRepository.delete(member);
+		deleteAssociation(member);
+		replaceWithAnonymous(member);
+		memberRepository.delete(member);
 
-        // oauth2 서비스 연결 끊기
-        oAuth2UnlinkService.unlink(member.getSocialEmail());
+		// oauth2 서비스 연결 끊기
+		oAuth2UnlinkService.unlink(member.getSocialEmail());
 
-        // oauth2 access 토큰 삭제
-        if (redisUtil.getValues("AT(oauth):" + member.getSocialEmail()) != null) {
-            redisUtil.deleteValues("AT(oauth):" + member.getSocialEmail());
-        }
-        return new DeleteMemberResponse(member.getId());
-    }
+		// oauth2 access 토큰 삭제
+		if (redisUtil.getValues("AT(oauth):" + member.getSocialEmail()) != null) {
+			redisUtil.deleteValues("AT(oauth):" + member.getSocialEmail());
+		}
+		return new DeleteMemberResponse(member.getId());
+	}
 
-    private void deleteAssociation(Member member) {
-        creditHistoryRepository.deleteByMember(member);
-        notificationRepository.deleteByMember(member);
-        interactionRepository.deleteByMemberId(member.getId());
-    }
+	private void deleteAssociation(Member member) {
+		creditHistoryRepository.deleteByMember(member);
+		notificationRepository.deleteByMember(member);
+		interactionRepository.deleteByMemberId(member.getId());
+	}
 
-    private void replaceWithAnonymous(Member member) {
-        Member anonymous = memberRepository.findByRole(ANONYMOUS)
-                .orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
+	private void replaceWithAnonymous(Member member) {
+		Member anonymous = memberRepository.findByRole(ANONYMOUS)
+			.orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
 
-        questionPostRepository.updateQuestionPostsMember(member.getId(), anonymous);
-        answerRepository.updateAnswersMember(member.getId(), anonymous);
-    }
+		questionPostRepository.updateQuestionPostsMember(member.getId(), anonymous);
+		answerRepository.updateAnswersMember(member.getId(), anonymous);
+	}
 
 }

--- a/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
@@ -1,5 +1,7 @@
 package com.dnd.gongmuin.chat.controller;
 
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -58,11 +60,11 @@ public class ChatRoomController {
 	@Operation(summary = "채팅방 목록 조회 API", description = "회원의 채팅방 목록을 조회한다.")
 	@GetMapping("/api/chat-rooms")
 	public ResponseEntity<PageResponse<ChatRoomSimpleResponse>> getChatRoomsByMember(
-		@RequestParam("status") String status,
+		@RequestParam("statuses") List<String> statuses,
 		@AuthenticationPrincipal Member member,
 		Pageable pageable
 	) {
-		PageResponse<ChatRoomSimpleResponse> response = chatRoomService.getChatRoomsByMember(member, status,
+		PageResponse<ChatRoomSimpleResponse> response = chatRoomService.getChatRoomsByMember(member, statuses,
 			pageable);
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/com/dnd/gongmuin/chat/domain/ChatStatus.java
+++ b/src/main/java/com/dnd/gongmuin/chat/domain/ChatStatus.java
@@ -1,6 +1,7 @@
 package com.dnd.gongmuin.chat.domain;
 
 import java.util.Arrays;
+import java.util.List;
 
 import com.dnd.gongmuin.chat.exception.ChatErrorCode;
 import com.dnd.gongmuin.common.exception.runtime.ValidationException;
@@ -23,6 +24,15 @@ public enum ChatStatus {
 			.filter(status -> status.isEqual(input))
 			.findAny()
 			.orElseThrow(() -> new ValidationException(ChatErrorCode.NOT_FOUND_CHAT_STATUS));
+	}
+
+	public static List<ChatStatus> from(List<String> inputs) {
+		return inputs.stream()
+			.map(input -> Arrays.stream(ChatStatus.values())
+				.filter(status -> status.isEqual(input))
+				.findAny()
+				.orElseThrow(() -> new ValidationException(ChatErrorCode.NOT_FOUND_CHAT_STATUS)))
+			.toList();
 	}
 
 	private boolean isEqual(String input) {

--- a/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
@@ -90,6 +90,7 @@ public class ChatRoomMapper {
 	) {
 		return new ChatRoomSimpleResponse(
 			chatRoomInfo.chatRoomId(),
+			chatRoomInfo.chatStatus(),
 			new MemberInfo(
 				chatRoomInfo.partnerId(),
 				chatRoomInfo.partnerNickname(),

--- a/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomInfo.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomInfo.java
@@ -1,10 +1,12 @@
 package com.dnd.gongmuin.chat.dto.response;
 
+import com.dnd.gongmuin.chat.domain.ChatStatus;
 import com.dnd.gongmuin.member.domain.JobGroup;
 import com.querydsl.core.annotations.QueryProjection;
 
 public record ChatRoomInfo(
 	Long chatRoomId,
+	String chatStatus,
 	Long partnerId,
 	String partnerNickname,
 	String partnerJobGroup,
@@ -13,6 +15,7 @@ public record ChatRoomInfo(
 	@QueryProjection
 	public ChatRoomInfo(
 		Long chatRoomId,
+		ChatStatus chatStatus,
 		Long partnerId,
 		String partnerNickname,
 		JobGroup partnerJobGroup,
@@ -20,6 +23,7 @@ public record ChatRoomInfo(
 	) {
 		this(
 			chatRoomId,
+			chatStatus.getLabel(),
 			partnerId,
 			partnerNickname,
 			partnerJobGroup.getLabel(),

--- a/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomSimpleResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomSimpleResponse.java
@@ -4,6 +4,7 @@ import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
 
 public record ChatRoomSimpleResponse(
 	Long chatRoomId,
+	String chatStatus,
 	MemberInfo chatPartner,
 	String latestMessage,
 	String messageType,

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
@@ -11,7 +11,7 @@ import com.dnd.gongmuin.member.domain.Member;
 
 public interface ChatRoomQueryRepository {
 
-	Slice<ChatRoomInfo> getChatRoomsByMember(Member member, ChatStatus chatStatus, Pageable pageable);
+	Slice<ChatRoomInfo> getChatRoomsByMember(Member member, List<ChatStatus> chatStatuses, Pageable pageable);
 
 	List<Long> getAutoRejectedInquirerIds();
 

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.dnd.gongmuin.chat.repository;
 
 import static com.dnd.gongmuin.chat.domain.QChatRoom.*;
-import static com.dnd.gongmuin.member.domain.QMember.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -9,16 +8,11 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.dnd.gongmuin.chat.domain.ChatStatus;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
 import com.dnd.gongmuin.chat.dto.response.QChatRoomInfo;
-import com.dnd.gongmuin.credit_history.domain.CreditHistory;
-import com.dnd.gongmuin.credit_history.domain.CreditType;
-import com.dnd.gongmuin.credit_history.repository.CreditHistoryRepository;
 import com.dnd.gongmuin.member.domain.Member;
-import com.dnd.gongmuin.member.repository.MemberRepository;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -28,17 +22,16 @@ import lombok.RequiredArgsConstructor;
 public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
 
 	private final JPAQueryFactory queryFactory;
-	private final MemberRepository memberRepository;
-	private final CreditHistoryRepository creditHistoryRepository;
 
 	public Slice<ChatRoomInfo> getChatRoomsByMember(
 		Member member,
-		ChatStatus chatStatus,
+		List<ChatStatus> chatStatuses,
 		Pageable pageable
 	) {
 		List<ChatRoomInfo> content = queryFactory
 			.select(new QChatRoomInfo(
 				chatRoom.id,
+				chatRoom.status,
 				new CaseBuilder()
 					.when(chatRoom.inquirer.id.eq(member.getId()))
 					.then(chatRoom.answerer.id)
@@ -59,7 +52,7 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
 			.from(chatRoom)
 			.where(chatRoom.inquirer.id.eq(member.getId())
 				.or(chatRoom.answerer.id.eq(member.getId()))
-				.and(chatRoom.status.eq(chatStatus)))
+				.and(chatRoom.status.in(chatStatuses)))
 			.fetch();
 
 		boolean hasNext = hasNext(pageable.getPageSize(), content);
@@ -77,7 +70,6 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
 			.fetch();
 	}
 
-	@Transactional
 	public void updateChatRoomStatusRejected() {
 		queryFactory.update(chatRoom)
 			.set(chatRoom.status, ChatStatus.REJECTED)

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
@@ -94,11 +94,11 @@ public class ChatRoomService {
 	}
 
 	@Transactional(readOnly = true)
-	public PageResponse<ChatRoomSimpleResponse> getChatRoomsByMember(Member member, String chatStatus,
+	public PageResponse<ChatRoomSimpleResponse> getChatRoomsByMember(Member member, List<String> chatStatuses,
 		Pageable pageable) {
 		// 회원 채팅방 정보 가져오기
 		Slice<ChatRoomInfo> chatRoomInfos = chatRoomRepository.getChatRoomsByMember(
-			member, ChatStatus.from(chatStatus), pageable
+			member, ChatStatus.from(chatStatuses), pageable
 		);
 
 		// chatRoomId 리스트 추출

--- a/src/main/java/com/dnd/gongmuin/member/repository/MemberRepository.java
+++ b/src/main/java/com/dnd/gongmuin/member/repository/MemberRepository.java
@@ -1,22 +1,24 @@
 package com.dnd.gongmuin.member.repository;
 
-import com.dnd.gongmuin.member.domain.Member;
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.dnd.gongmuin.member.domain.Member;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustom {
-    Optional<Member> findBySocialEmail(String socialEmail);
+	Optional<Member> findBySocialEmail(String socialEmail);
 
-    boolean existsByNickname(String nickname);
+	boolean existsByNickname(String nickname);
 
-    boolean existsByOfficialEmail(String officialEmail);
+	boolean existsByOfficialEmail(String officialEmail);
 
-    boolean existsBySocialEmail(String socialEmail);
+	boolean existsBySocialEmail(String socialEmail);
 
-    Member findByOfficialEmail(String officialEmail);
+	Member findByOfficialEmail(String officialEmail);
 
-    Optional<Member> findByRole(String role);
+	Optional<Member> findByRole(String role);
 
 }

--- a/src/main/java/com/dnd/gongmuin/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/dnd/gongmuin/notification/repository/NotificationRepository.java
@@ -1,11 +1,12 @@
 package com.dnd.gongmuin.notification.repository;
 
-import com.dnd.gongmuin.member.domain.Member;
-import com.dnd.gongmuin.notification.domain.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.dnd.gongmuin.member.domain.Member;
+import com.dnd.gongmuin.notification.domain.Notification;
+
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationCustom {
-    void deleteByMember(Member member);
+	void deleteByMember(Member member);
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepository.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepository.java
@@ -1,20 +1,22 @@
 package com.dnd.gongmuin.question_post.repository;
 
-import com.dnd.gongmuin.member.domain.Member;
-import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import com.dnd.gongmuin.member.domain.Member;
+import com.dnd.gongmuin.question_post.domain.QuestionPost;
+
 @Repository
 public interface QuestionPostRepository extends JpaRepository<QuestionPost, Long>, QuestionPostQueryRepository {
-    boolean existsById(Long id);
+	boolean existsById(Long id);
 
-    List<QuestionPost> findAllByMember(Member member);
+	List<QuestionPost> findAllByMember(Member member);
 
-    @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("UPDATE QuestionPost q SET q.member = :member WHERE q.member.id = :memberId")
-    public void updateQuestionPostsMember(Long memberId, Member member);
+	@Modifying(flushAutomatically = true, clearAutomatically = true)
+	@Query("UPDATE QuestionPost q SET q.member = :member WHERE q.member.id = :memberId")
+	public void updateQuestionPostsMember(Long memberId, Member member);
 }

--- a/src/test/java/com/dnd/gongmuin/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/auth/service/AuthServiceTest.java
@@ -1,13 +1,24 @@
 package com.dnd.gongmuin.auth.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-import static org.mockito.BDDMockito.any;
-import static org.mockito.BDDMockito.anyString;
-import static org.mockito.BDDMockito.doNothing;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.verify;
-import static org.mockito.BDDMockito.willDoNothing;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 
 import com.dnd.gongmuin.answer.domain.Answer;
 import com.dnd.gongmuin.answer.repository.AnswerRepository;
@@ -33,224 +44,210 @@ import com.dnd.gongmuin.security.jwt.util.CookieUtil;
 import com.dnd.gongmuin.security.jwt.util.TokenProvider;
 import com.dnd.gongmuin.security.oauth2.CustomOauth2User;
 import com.dnd.gongmuin.security.service.OAuth2UnlinkService;
+
 import jakarta.servlet.http.Cookie;
-import java.time.Duration;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
 
-    @Mock
-    private MemberRepository memberRepository;
-    @Mock
-    private OAuth2UnlinkService oAuth2UnlinkService;
-    @Mock
-    private CreditHistoryRepository creditHistoryRepository;
-    @Mock
-    private QuestionPostRepository questionPostRepository;
-    @Mock
-    private AnswerRepository answerRepository;
-    @Mock
-    private InteractionRepository interactionRepository;
-    @Mock
-    private NotificationRepository notificationRepository;
+	@Mock
+	private MemberRepository memberRepository;
+	@Mock
+	private OAuth2UnlinkService oAuth2UnlinkService;
+	@Mock
+	private CreditHistoryRepository creditHistoryRepository;
+	@Mock
+	private QuestionPostRepository questionPostRepository;
+	@Mock
+	private AnswerRepository answerRepository;
+	@Mock
+	private InteractionRepository interactionRepository;
+	@Mock
+	private NotificationRepository notificationRepository;
 
-    @Mock
-    private TokenProvider tokenProvider;
+	@Mock
+	private TokenProvider tokenProvider;
 
-    @Mock
-    private RedisUtil redisUtil;
+	@Mock
+	private RedisUtil redisUtil;
 
-    @Mock
-    private CookieUtil cookieUtil;
+	@Mock
+	private CookieUtil cookieUtil;
 
-    @InjectMocks
-    private AuthService authService;
+	@InjectMocks
+	private AuthService authService;
 
-    @DisplayName("공무원 이메일이 존재하는지 체크한다.")
-    @Test
-    void isOfficialEmail() {
-        // given
-        Member kakaoMember = MemberFixture.member();
+	@DisplayName("공무원 이메일이 존재하는지 체크한다.")
+	@Test
+	void isOfficialEmail() {
+		// given
+		Member kakaoMember = MemberFixture.member();
 
-        // when
-        boolean result = authService.isOfficialEmail(kakaoMember);
+		// when
+		boolean result = authService.isOfficialEmail(kakaoMember);
 
-        // then
-        assertThat(result).isFalse();
+		// then
+		assertThat(result).isFalse();
 
-    }
+	}
 
-    @DisplayName("중복 닉네임이 존재하는지 체크한다.")
-    @Test
-    void isDuplicatedNickname() {
-        // given
-        given(memberRepository.existsByNickname("김철수")).willReturn(true);
-        ValidateNickNameRequest request = new ValidateNickNameRequest("김철수");
+	@DisplayName("중복 닉네임이 존재하는지 체크한다.")
+	@Test
+	void isDuplicatedNickname() {
+		// given
+		given(memberRepository.existsByNickname("김철수")).willReturn(true);
+		ValidateNickNameRequest request = new ValidateNickNameRequest("김철수");
 
-        // when
-        ValidateNickNameResponse duplicatedNickname = authService.isDuplicatedNickname(request);
+		// when
+		ValidateNickNameResponse duplicatedNickname = authService.isDuplicatedNickname(request);
 
-        // then
-        assertThat(duplicatedNickname.isDuplicated()).isTrue();
-    }
+		// then
+		assertThat(duplicatedNickname.isDuplicated()).isTrue();
+	}
 
-    @DisplayName("신규 회원은 추가 정보가 업데이트 된다.")
-    @Test
-    void signUp() {
-        // given
-        AdditionalInfoRequest request = new AdditionalInfoRequest("abc123@korea.com", "김신규", "공업", "일반기계");
-        MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+	@DisplayName("신규 회원은 추가 정보가 업데이트 된다.")
+	@Test
+	void signUp() {
+		// given
+		AdditionalInfoRequest request = new AdditionalInfoRequest("abc123@korea.com", "김신규", "공업", "일반기계");
+		MockHttpServletResponse mockResponse = new MockHttpServletResponse();
 
-        Member member1 = MemberFixture.member3();
-        given(memberRepository.findBySocialEmail(member1.getSocialEmail())).willReturn(
-                Optional.of(member1));
+		Member member1 = MemberFixture.member3();
+		given(memberRepository.findBySocialEmail(member1.getSocialEmail())).willReturn(
+			Optional.of(member1));
 
-        // when
-        authService.signUp(request, member1.getSocialEmail(), mockResponse);
+		// when
+		authService.signUp(request, member1.getSocialEmail(), mockResponse);
 
-        // then
-        assertThat(member1).extracting("officialEmail", "nickname", "jobGroup", "jobCategory")
-                .containsExactlyInAnyOrder(
-                        "abc123@korea.com",
-                        "김신규",
-                        JobGroup.ENG,
-                        JobCategory.GME
-                );
-    }
+		// then
+		assertThat(member1).extracting("officialEmail", "nickname", "jobGroup", "jobCategory")
+			.containsExactlyInAnyOrder(
+				"abc123@korea.com",
+				"김신규",
+				JobGroup.ENG,
+				JobCategory.GME
+			);
+	}
 
-    @DisplayName("로그인 회원은 로그아웃 할 수 있다.")
-    @Test
-    void logout() {
-        // given
-        Long fiveMinutes = 300_000L;
+	@DisplayName("로그인 회원은 로그아웃 할 수 있다.")
+	@Test
+	void logout() {
+		// given
+		Long fiveMinutes = 300_000L;
 
-        Member principal = MemberFixture.member();
-        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "test");
+		Member principal = MemberFixture.member();
+		Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "test");
 
-        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
-        MockHttpServletResponse mockResponse = new MockHttpServletResponse();
-        mockRequest.setCookies(new Cookie("Authorization", "testtesttesttest"));
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+		MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+		mockRequest.setCookies(new Cookie("Authorization", "testtesttesttest"));
 
-        given(cookieUtil.getCookieValue(mockRequest)).willReturn("testtesttesttest");
-        given(tokenProvider.validateToken(anyString(), any(Date.class))).willReturn(true);
-        given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
-        given(tokenProvider.getExpiration(anyString(), any(Date.class))).willReturn(fiveMinutes);
-        given(redisUtil.getValues(anyString())).willReturn("refresh");
-        given(redisUtil.getValues(anyString())).willReturn("logout");
+		given(cookieUtil.getCookieValue(mockRequest)).willReturn("testtesttesttest");
+		given(tokenProvider.validateToken(anyString(), any(Date.class))).willReturn(true);
+		given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
+		given(tokenProvider.getExpiration(anyString(), any(Date.class))).willReturn(fiveMinutes);
+		given(redisUtil.getValues(anyString())).willReturn("refresh");
+		given(redisUtil.getValues(anyString())).willReturn("logout");
 
-        willDoNothing().given(redisUtil).setValues(anyString(), anyString(), any(Duration.class));
+		willDoNothing().given(redisUtil).setValues(anyString(), anyString(), any(Duration.class));
 
-        // when
-        LogoutResponse response = authService.logout(mockRequest, mockResponse);
+		// when
+		LogoutResponse response = authService.logout(mockRequest, mockResponse);
 
-        // then
-        assertThat(response.result()).isTrue();
-        assertThat(mockResponse.getCookies()).isEmpty();
-    }
+		// then
+		assertThat(response.result()).isTrue();
+		assertThat(mockResponse.getCookies()).isEmpty();
+	}
 
-    @DisplayName("refresh 토큰이 만료되지 않았다면 재발급 할 수 있다.")
-    @Test
-    void reissue() {
-        // given
-        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
-        MockHttpServletResponse mockResponse = new MockHttpServletResponse();
-        mockRequest.setCookies(new Cookie("Authorization", "testtesttesttest"));
+	@DisplayName("refresh 토큰이 만료되지 않았다면 재발급 할 수 있다.")
+	@Test
+	void reissue() {
+		// given
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+		MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+		mockRequest.setCookies(new Cookie("Authorization", "testtesttesttest"));
 
-        Member principal = MemberFixture.member();
-        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "test");
+		Member principal = MemberFixture.member();
+		Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "test");
 
-        given(cookieUtil.getCookieValue(mockRequest)).willReturn("testtesttesttest");
-        given(cookieUtil.createCookie(anyString())).willReturn(new Cookie("Authorization", "reissueToken"));
-        given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
-        given(redisUtil.getValues(anyString())).willReturn("refreshToken");
-        given(tokenProvider.generateAccessToken(any(CustomOauth2User.class), any(Date.class))).willReturn(
-                "reissueToken");
-        given(tokenProvider.generateRefreshToken(any(CustomOauth2User.class), any(Date.class))).willReturn(
-                "reissueToken");
+		given(cookieUtil.getCookieValue(mockRequest)).willReturn("testtesttesttest");
+		given(cookieUtil.createCookie(anyString())).willReturn(new Cookie("Authorization", "reissueToken"));
+		given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
+		given(redisUtil.getValues(anyString())).willReturn("refreshToken");
+		given(tokenProvider.generateAccessToken(any(CustomOauth2User.class), any(Date.class))).willReturn(
+			"reissueToken");
+		given(tokenProvider.generateRefreshToken(any(CustomOauth2User.class), any(Date.class))).willReturn(
+			"reissueToken");
 
-        // when
-        ReissueResponse response = authService.reissue(mockRequest, mockResponse);
-        Cookie[] cookies = mockResponse.getCookies();
+		// when
+		ReissueResponse response = authService.reissue(mockRequest, mockResponse);
+		Cookie[] cookies = mockResponse.getCookies();
 
-        // then
-        Assertions.assertAll(
-                () -> assertThat(response.result()).isTrue(),
-                () -> assertThat(cookies)
-                        .hasSize(1)
-                        .extracting(Cookie::getName, Cookie::getValue)
-                        .containsExactly(tuple("Authorization", "reissueToken"))
-        );
-    }
+		// then
+		Assertions.assertAll(
+			() -> assertThat(response.result()).isTrue(),
+			() -> assertThat(cookies)
+				.hasSize(1)
+				.extracting(Cookie::getName, Cookie::getValue)
+				.containsExactly(tuple("Authorization", "reissueToken"))
+		);
+	}
 
-    @DisplayName("회원 삭제 시 크레딧 내역, 알림, 상호작용은 모두 삭제된다.")
-    @Test
-    void deleteMemberWithAssociatedDatas() {
-        // given
-        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
-        mockRequest.setCookies(new Cookie("Authorization", "testtesttesttest"));
+	@DisplayName("회원 삭제 시 크레딧 내역, 알림, 상호작용은 모두 삭제된다.")
+	@Test
+	void deleteMemberWithAssociatedDatas() {
+		// given
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+		mockRequest.setCookies(new Cookie("Authorization", "testtesttesttest"));
 
-        Member principal = MemberFixture.member(1L);
-        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "test");
+		Member principal = MemberFixture.member(1L);
+		Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "test");
 
-        given(cookieUtil.getCookieValue(mockRequest)).willReturn("testtesttesttest");
-        given(tokenProvider.validateToken(anyString(), any(Date.class))).willReturn(true);
-        given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
-        given(redisUtil.getValues(anyString())).willReturn("delete");
-        given(memberRepository.findByRole("ROLE_ANONYMOUS")).willReturn(Optional.of(principal));
+		given(cookieUtil.getCookieValue(mockRequest)).willReturn("testtesttesttest");
+		given(tokenProvider.validateToken(anyString(), any(Date.class))).willReturn(true);
+		given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
+		given(redisUtil.getValues(anyString())).willReturn("delete");
+		given(memberRepository.findByRole("ROLE_ANONYMOUS")).willReturn(Optional.of(principal));
 
-        doNothing().when(creditHistoryRepository).deleteByMember(principal);
-        doNothing().when(notificationRepository).deleteByMember(principal);
-        doNothing().when(interactionRepository).deleteByMemberId(principal.getId());
-        doNothing().when(memberRepository).delete(principal);
+		doNothing().when(creditHistoryRepository).deleteByMember(principal);
+		doNothing().when(notificationRepository).deleteByMember(principal);
+		doNothing().when(interactionRepository).deleteByMemberId(principal.getId());
+		doNothing().when(memberRepository).delete(principal);
 
-        // when
-        authService.deleteMember(mockRequest);
+		// when
+		authService.deleteMember(mockRequest);
 
-        // then
-        verify(creditHistoryRepository).deleteByMember(principal);
-        verify(notificationRepository).deleteByMember(principal);
-        verify(interactionRepository).deleteByMemberId(principal.getId());
-        verify(memberRepository).delete(principal);
-    }
+		// then
+		verify(creditHistoryRepository).deleteByMember(principal);
+		verify(notificationRepository).deleteByMember(principal);
+		verify(interactionRepository).deleteByMemberId(principal.getId());
+		verify(memberRepository).delete(principal);
+	}
 
-    @DisplayName("회원 삭제 시 연관된 답변과 게시글은 모두 익명 회원 정보로 교체된다.")
-    @Test
-    void deleteMember() {
-        // given
-        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
-        mockRequest.setCookies(new Cookie("Authorization", "testtesttesttest"));
+	@DisplayName("회원 삭제 시 연관된 답변과 게시글은 모두 익명 회원 정보로 교체된다.")
+	@Test
+	void deleteMember() {
+		// given
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+		mockRequest.setCookies(new Cookie("Authorization", "testtesttesttest"));
 
-        Member principal = MemberFixture.member(1L);
-        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "test");
+		Member principal = MemberFixture.member(1L);
+		Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "test");
 
-        List<QuestionPost> mockQuestionPosts = List.of(QuestionPostFixture.questionPost(1L, principal));
-        List<Answer> mockAnswers = List.of(AnswerFixture.answer(1L, principal));
+		List<QuestionPost> mockQuestionPosts = List.of(QuestionPostFixture.questionPost(1L, principal));
+		List<Answer> mockAnswers = List.of(AnswerFixture.answer(1L, principal));
 
-        given(cookieUtil.getCookieValue(mockRequest)).willReturn("testtesttesttest");
-        given(tokenProvider.validateToken(anyString(), any(Date.class))).willReturn(true);
-        given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
-        given(redisUtil.getValues(anyString())).willReturn("delete");
-        given(memberRepository.findByRole("ROLE_ANONYMOUS")).willReturn(Optional.of(principal));
+		given(cookieUtil.getCookieValue(mockRequest)).willReturn("testtesttesttest");
+		given(tokenProvider.validateToken(anyString(), any(Date.class))).willReturn(true);
+		given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
+		given(redisUtil.getValues(anyString())).willReturn("delete");
+		given(memberRepository.findByRole("ROLE_ANONYMOUS")).willReturn(Optional.of(principal));
 
-        // when
-        authService.deleteMember(mockRequest);
+		// when
+		authService.deleteMember(mockRequest);
 
-        // then
-        verify(questionPostRepository).updateQuestionPostsMember(any(), any());
-        verify(answerRepository).updateAnswersMember(any(), any());
-    }
+		// then
+		verify(questionPostRepository).updateQuestionPostsMember(any(), any());
+		verify(answerRepository).updateAnswersMember(any(), any());
+	}
 }

--- a/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
@@ -141,7 +141,7 @@ class ChatRoomControllerTest extends ApiTestSupport {
 		// when & then
 		mockMvc.perform(get("/api/chat-rooms")
 				.cookie(accessToken)
-				.param("status", ChatStatus.PENDING.getLabel()))
+				.param("statuses", ChatStatus.PENDING.getLabel()))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.size").value(3))
 			.andExpect(jsonPath("$.content[0].chatRoomId").value(chatRoom3.getId()))

--- a/src/test/java/com/dnd/gongmuin/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/repository/ChatRoomRepositoryTest.java
@@ -20,15 +20,12 @@ import com.dnd.gongmuin.common.fixture.ChatRoomFixture;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
 import com.dnd.gongmuin.common.fixture.QuestionPostFixture;
 import com.dnd.gongmuin.common.support.DataJpaTestSupport;
-import com.dnd.gongmuin.credit_history.domain.CreditHistory;
-import com.dnd.gongmuin.credit_history.domain.CreditType;
 import com.dnd.gongmuin.credit_history.repository.CreditHistoryRepository;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.repository.MemberRepository;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 
-import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -62,7 +59,7 @@ class ChatRoomRepositoryTest extends DataJpaTestSupport {
 		));
 		//when
 
-		List<ChatRoomInfo> chatRoomInfos = chatRoomRepository.getChatRoomsByMember(target, ChatStatus.PENDING,
+		List<ChatRoomInfo> chatRoomInfos = chatRoomRepository.getChatRoomsByMember(target, List.of(ChatStatus.PENDING),
 				pageRequest)
 			.getContent();
 		//then

--- a/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
@@ -196,24 +196,24 @@ class ChatRoomServiceTest {
 	void getChatRoomsByMember() {
 		//given
 		Long chatRoomId = 1L;
-		ChatStatus status = ChatStatus.ACCEPTED;
 		Member targetMember = MemberFixture.member(1L);
 		Member partner = MemberFixture.member(2L);
 		ChatRoomInfo chatRoomInfo = new ChatRoomInfo(
-			chatRoomId, partner.getId(), partner.getNickname(), partner.getJobGroup(), partner.getProfileImageNo()
+			chatRoomId, ChatStatus.ACCEPTED, partner.getId(),
+			partner.getNickname(), partner.getJobGroup(), partner.getProfileImageNo()
 		);
 		LatestChatMessage latestChatMessage = new LatestChatMessage(
 			chatRoomId, "와", "텍스트", LocalDateTime.now()
 		);
 
-		given(chatRoomRepository.getChatRoomsByMember(targetMember, status, pageRequest))
+		given(chatRoomRepository.getChatRoomsByMember(targetMember, List.of(ChatStatus.ACCEPTED), pageRequest))
 			.willReturn(new SliceImpl<>(List.of(chatRoomInfo), pageRequest, false));
 		given(chatMessageQueryRepository.findLatestChatByChatRoomIds(List.of(chatRoomId)))
 			.willReturn(List.of(latestChatMessage));
 
 		//when
 		List<ChatRoomSimpleResponse> response = chatRoomService.getChatRoomsByMember(
-			targetMember, status.getLabel(), pageRequest).content();
+			targetMember, List.of(ChatStatus.ACCEPTED.getLabel()), pageRequest).content();
 
 		//then
 		assertAll(

--- a/src/test/java/com/dnd/gongmuin/credit_history/service/CreditHistoryServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/credit_history/service/CreditHistoryServiceTest.java
@@ -3,7 +3,6 @@ package com.dnd.gongmuin.credit_history.service;
 import static org.mockito.BDDMockito.*;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/dnd/gongmuin/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/member/repository/MemberRepositoryTest.java
@@ -39,8 +39,6 @@ import com.dnd.gongmuin.post_interaction.repository.InteractionRepository;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 
-import jakarta.persistence.EntityManager;
-
 class MemberRepositoryTest extends DataJpaTestSupport {
 
 	private final PageRequest pageRequest = PageRequest.of(0, 10);


### PR DESCRIPTION
### 관련 이슈
- close #138 

### 📑 작업 상세 내용
- request param에 String 필드 -> List<String>으로 변경
  - 기존) 채팅방 목록 조회 시 요청중, 수락된 채팅방만 뜸
  - 변경) 거절된 채팅방도 뜨도록 변경
- 채팅방 목록 조회 API에 상태 필드 추가

### 💫 작업 요약
- 필드 추가 및 필터링 수정

### 🔍 중점적으로 리뷰 할 부분
- 코드 리포멧팅하니까 들여쓰기가 수정되네요..
b7cde2e7b621f5ec046b3b9e5c0f1b4b9838de1f 혹시 네이버 포메터 말고 다른 포메터 사용하고 계신가요??
