### PR TITLE
[feat #140] 채팅 요청 목록 조회 API

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.dnd.gongmuin.chat.dto.request.CreateChatRoomRequest;
 import com.dnd.gongmuin.chat.dto.response.AcceptChatResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatMessageResponse;
+import com.dnd.gongmuin.chat.dto.response.ChatProposalResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomDetailResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomSimpleResponse;
 import com.dnd.gongmuin.chat.dto.response.CreateChatRoomResponse;
@@ -54,7 +55,7 @@ public class ChatRoomController {
 		return ResponseEntity.ok(response);
 	}
 
-	@Operation(summary = "채팅방 목록 조회 API", description = "회원의 채팅방 목록을 조회한다.")
+	@Operation(summary = "채팅방 활성화 목록 조회 API", description = "회원의 채팅방 목록을 조회한다.")
 	@GetMapping("/api/chat-rooms")
 	public ResponseEntity<PageResponse<ChatRoomSimpleResponse>> getChatRoomsByMember(
 		@AuthenticationPrincipal Member member,
@@ -62,6 +63,17 @@ public class ChatRoomController {
 	) {
 		PageResponse<ChatRoomSimpleResponse> response
 			= chatRoomService.getChatRoomsByMember(member, pageable);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "채팅방 요청 목록 조회 API", description = "회원의 채팅방 목록을 조회한다.")
+	@GetMapping("/api/chat-rooms/proposals")
+	public ResponseEntity<PageResponse<ChatProposalResponse>> getChatProposalsByMember(
+		@AuthenticationPrincipal Member member,
+		Pageable pageable
+	) {
+		PageResponse<ChatProposalResponse> response
+			= chatRoomService.getChatProposalsByMember(member, pageable);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dnd/gongmuin/chat/controller/ChatRoomController.java
@@ -1,7 +1,5 @@
 package com.dnd.gongmuin.chat.controller;
 
-import java.util.List;
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -10,7 +8,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dnd.gongmuin.chat.dto.request.CreateChatRoomRequest;
@@ -60,12 +57,11 @@ public class ChatRoomController {
 	@Operation(summary = "채팅방 목록 조회 API", description = "회원의 채팅방 목록을 조회한다.")
 	@GetMapping("/api/chat-rooms")
 	public ResponseEntity<PageResponse<ChatRoomSimpleResponse>> getChatRoomsByMember(
-		@RequestParam("statuses") List<String> statuses,
 		@AuthenticationPrincipal Member member,
 		Pageable pageable
 	) {
-		PageResponse<ChatRoomSimpleResponse> response = chatRoomService.getChatRoomsByMember(member, statuses,
-			pageable);
+		PageResponse<ChatRoomSimpleResponse> response
+			= chatRoomService.getChatRoomsByMember(member, pageable);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/chat/domain/ChatStatus.java
+++ b/src/main/java/com/dnd/gongmuin/chat/domain/ChatStatus.java
@@ -1,7 +1,6 @@
 package com.dnd.gongmuin.chat.domain;
 
 import java.util.Arrays;
-import java.util.List;
 
 import com.dnd.gongmuin.chat.exception.ChatErrorCode;
 import com.dnd.gongmuin.common.exception.runtime.ValidationException;
@@ -24,15 +23,6 @@ public enum ChatStatus {
 			.filter(status -> status.isEqual(input))
 			.findAny()
 			.orElseThrow(() -> new ValidationException(ChatErrorCode.NOT_FOUND_CHAT_STATUS));
-	}
-
-	public static List<ChatStatus> from(List<String> inputs) {
-		return inputs.stream()
-			.map(input -> Arrays.stream(ChatStatus.values())
-				.filter(status -> status.isEqual(input))
-				.findAny()
-				.orElseThrow(() -> new ValidationException(ChatErrorCode.NOT_FOUND_CHAT_STATUS)))
-			.toList();
 	}
 
 	private boolean isEqual(String input) {

--- a/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/ChatRoomMapper.java
@@ -2,6 +2,8 @@ package com.dnd.gongmuin.chat.dto;
 
 import com.dnd.gongmuin.chat.domain.ChatRoom;
 import com.dnd.gongmuin.chat.dto.response.AcceptChatResponse;
+import com.dnd.gongmuin.chat.dto.response.ChatProposalInfo;
+import com.dnd.gongmuin.chat.dto.response.ChatProposalResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomDetailResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomSimpleResponse;
@@ -90,12 +92,31 @@ public class ChatRoomMapper {
 	) {
 		return new ChatRoomSimpleResponse(
 			chatRoomInfo.chatRoomId(),
-			chatRoomInfo.chatStatus(),
 			new MemberInfo(
 				chatRoomInfo.partnerId(),
 				chatRoomInfo.partnerNickname(),
 				chatRoomInfo.partnerJobGroup(),
 				chatRoomInfo.partnerProfileImageNo()
+			),
+			latestChatMessage.content(),
+			latestChatMessage.type(),
+			latestChatMessage.createdAt().toString()
+		);
+	}
+
+	public static ChatProposalResponse toChatProposalResponse(
+		ChatProposalInfo chatProposalInfo,
+		LatestChatMessage latestChatMessage
+	) {
+		return new ChatProposalResponse(
+			chatProposalInfo.chatRoomId(),
+			chatProposalInfo.chatStatus(),
+			chatProposalInfo.isInquirer(),
+			new MemberInfo(
+				chatProposalInfo.partnerId(),
+				chatProposalInfo.partnerNickname(),
+				chatProposalInfo.partnerJobGroup(),
+				chatProposalInfo.partnerProfileImageNo()
 			),
 			latestChatMessage.content(),
 			latestChatMessage.type(),

--- a/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatProposalInfo.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatProposalInfo.java
@@ -1,0 +1,36 @@
+package com.dnd.gongmuin.chat.dto.response;
+
+import com.dnd.gongmuin.chat.domain.ChatStatus;
+import com.dnd.gongmuin.member.domain.JobGroup;
+import com.querydsl.core.annotations.QueryProjection;
+
+public record ChatProposalInfo(
+	Long chatRoomId,
+	String chatStatus,
+	boolean isInquirer,
+	Long partnerId,
+	String partnerNickname,
+	String partnerJobGroup,
+	int partnerProfileImageNo
+) {
+	@QueryProjection
+	public ChatProposalInfo(
+		Long chatRoomId,
+		ChatStatus chatStatus,
+		boolean isInquirer,
+		Long partnerId,
+		String partnerNickname,
+		JobGroup partnerJobGroup,
+		int partnerProfileImageNo
+	) {
+		this(
+			chatRoomId,
+			chatStatus.getLabel(),
+			isInquirer,
+			partnerId,
+			partnerNickname,
+			partnerJobGroup.getLabel(),
+			partnerProfileImageNo
+		);
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatProposalResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatProposalResponse.java
@@ -1,0 +1,13 @@
+package com.dnd.gongmuin.chat.dto.response;
+
+import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
+
+public record ChatProposalResponse (
+	Long chatRoomId,
+	String chatStatus,
+	boolean isInquirer,
+	MemberInfo chatPartner,
+	String latestMessage,
+	String messageType,
+	String messageCreatedAt
+){}

--- a/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomInfo.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomInfo.java
@@ -1,12 +1,10 @@
 package com.dnd.gongmuin.chat.dto.response;
 
-import com.dnd.gongmuin.chat.domain.ChatStatus;
 import com.dnd.gongmuin.member.domain.JobGroup;
 import com.querydsl.core.annotations.QueryProjection;
 
 public record ChatRoomInfo(
 	Long chatRoomId,
-	String chatStatus,
 	Long partnerId,
 	String partnerNickname,
 	String partnerJobGroup,
@@ -15,7 +13,6 @@ public record ChatRoomInfo(
 	@QueryProjection
 	public ChatRoomInfo(
 		Long chatRoomId,
-		ChatStatus chatStatus,
 		Long partnerId,
 		String partnerNickname,
 		JobGroup partnerJobGroup,
@@ -23,7 +20,6 @@ public record ChatRoomInfo(
 	) {
 		this(
 			chatRoomId,
-			chatStatus.getLabel(),
 			partnerId,
 			partnerNickname,
 			partnerJobGroup.getLabel(),

--- a/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomSimpleResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat/dto/response/ChatRoomSimpleResponse.java
@@ -4,7 +4,6 @@ import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
 
 public record ChatRoomSimpleResponse(
 	Long chatRoomId,
-	String chatStatus,
 	MemberInfo chatPartner,
 	String latestMessage,
 	String messageType,

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
@@ -5,13 +5,12 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-import com.dnd.gongmuin.chat.domain.ChatStatus;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
 import com.dnd.gongmuin.member.domain.Member;
 
 public interface ChatRoomQueryRepository {
 
-	Slice<ChatRoomInfo> getChatRoomsByMember(Member member, List<ChatStatus> chatStatuses, Pageable pageable);
+	Slice<ChatRoomInfo> getChatRoomsByMember(Member member, Pageable pageable);
 
 	List<Long> getAutoRejectedInquirerIds();
 

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepository.java
@@ -5,12 +5,15 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import com.dnd.gongmuin.chat.domain.ChatStatus;
+import com.dnd.gongmuin.chat.dto.response.ChatProposalInfo;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
 import com.dnd.gongmuin.member.domain.Member;
 
 public interface ChatRoomQueryRepository {
 
 	Slice<ChatRoomInfo> getChatRoomsByMember(Member member, Pageable pageable);
+	Slice<ChatProposalInfo> getChatProposalsByMember(Member member, Pageable pageable);
 
 	List<Long> getAutoRejectedInquirerIds();
 

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
@@ -25,7 +25,6 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
 
 	public Slice<ChatRoomInfo> getChatRoomsByMember(
 		Member member,
-		List<ChatStatus> chatStatuses,
 		Pageable pageable
 	) {
 		List<ChatRoomInfo> content = queryFactory
@@ -52,7 +51,7 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
 			.from(chatRoom)
 			.where(chatRoom.inquirer.id.eq(member.getId())
 				.or(chatRoom.answerer.id.eq(member.getId()))
-				.and(chatRoom.status.in(chatStatuses)))
+				.and(chatRoom.status.eq(ChatStatus.ACCEPTED)))
 			.fetch();
 
 		boolean hasNext = hasNext(pageable.getPageSize(), content);

--- a/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/chat/repository/ChatRoomQueryRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.dnd.gongmuin.chat.repository;
 
+
 import static com.dnd.gongmuin.chat.domain.QChatRoom.*;
 
 import java.time.LocalDateTime;
@@ -10,7 +11,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
 import com.dnd.gongmuin.chat.domain.ChatStatus;
+import com.dnd.gongmuin.chat.dto.response.ChatProposalInfo;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
+import com.dnd.gongmuin.chat.dto.response.QChatProposalInfo;
 import com.dnd.gongmuin.chat.dto.response.QChatRoomInfo;
 import com.dnd.gongmuin.member.domain.Member;
 import com.querydsl.core.types.dsl.CaseBuilder;
@@ -30,11 +33,11 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
 		List<ChatRoomInfo> content = queryFactory
 			.select(new QChatRoomInfo(
 				chatRoom.id,
-				chatRoom.status,
 				new CaseBuilder()
 					.when(chatRoom.inquirer.id.eq(member.getId()))
 					.then(chatRoom.answerer.id)
 					.otherwise(chatRoom.inquirer.id),
+
 				new CaseBuilder()
 					.when(chatRoom.inquirer.id.eq(member.getId()))
 					.then(chatRoom.answerer.nickname)
@@ -52,6 +55,43 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
 			.where(chatRoom.inquirer.id.eq(member.getId())
 				.or(chatRoom.answerer.id.eq(member.getId()))
 				.and(chatRoom.status.eq(ChatStatus.ACCEPTED)))
+			.fetch();
+
+		boolean hasNext = hasNext(pageable.getPageSize(), content);
+		return new SliceImpl<>(content, pageable, hasNext);
+	}
+
+	public Slice<ChatProposalInfo> getChatProposalsByMember(Member member, Pageable pageable){
+		List<ChatProposalInfo> content = queryFactory
+			.select(new QChatProposalInfo(
+				chatRoom.id,
+				chatRoom.status,
+				new CaseBuilder()
+					.when(chatRoom.inquirer.id.eq(member.getId()))
+					.then(true)
+					.otherwise(false),
+				new CaseBuilder()
+					.when(chatRoom.inquirer.id.eq(member.getId()))
+					.then(chatRoom.answerer.id)
+					.otherwise(chatRoom.inquirer.id),
+
+				new CaseBuilder()
+					.when(chatRoom.inquirer.id.eq(member.getId()))
+					.then(chatRoom.answerer.nickname)
+					.otherwise(chatRoom.inquirer.nickname),
+				new CaseBuilder()
+					.when(chatRoom.inquirer.id.eq(member.getId()))
+					.then(chatRoom.answerer.jobGroup)
+					.otherwise(chatRoom.inquirer.jobGroup),
+				new CaseBuilder()
+					.when(chatRoom.inquirer.id.eq(member.getId()))
+					.then(chatRoom.answerer.profileImageNo)
+					.otherwise(chatRoom.inquirer.profileImageNo)
+			))
+			.from(chatRoom)
+			.where(chatRoom.inquirer.id.eq(member.getId())
+				.or(chatRoom.answerer.id.eq(member.getId()))
+				.and(chatRoom.status.in(List.of(ChatStatus.REJECTED, ChatStatus.PENDING))))
 			.fetch();
 
 		boolean hasNext = hasNext(pageable.getPageSize(), content);

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dnd.gongmuin.chat.domain.ChatRoom;
-import com.dnd.gongmuin.chat.domain.ChatStatus;
 import com.dnd.gongmuin.chat.dto.ChatMessageMapper;
 import com.dnd.gongmuin.chat.dto.ChatRoomMapper;
 import com.dnd.gongmuin.chat.dto.request.CreateChatRoomRequest;
@@ -94,11 +93,10 @@ public class ChatRoomService {
 	}
 
 	@Transactional(readOnly = true)
-	public PageResponse<ChatRoomSimpleResponse> getChatRoomsByMember(Member member, List<String> chatStatuses,
-		Pageable pageable) {
+	public PageResponse<ChatRoomSimpleResponse> getChatRoomsByMember(Member member, Pageable pageable) {
 		// 회원 채팅방 정보 가져오기
 		Slice<ChatRoomInfo> chatRoomInfos = chatRoomRepository.getChatRoomsByMember(
-			member, ChatStatus.from(chatStatuses), pageable
+			member, pageable
 		);
 
 		// chatRoomId 리스트 추출

--- a/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chat/service/ChatRoomService.java
@@ -18,6 +18,8 @@ import com.dnd.gongmuin.chat.dto.ChatRoomMapper;
 import com.dnd.gongmuin.chat.dto.request.CreateChatRoomRequest;
 import com.dnd.gongmuin.chat.dto.response.AcceptChatResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatMessageResponse;
+import com.dnd.gongmuin.chat.dto.response.ChatProposalInfo;
+import com.dnd.gongmuin.chat.dto.response.ChatProposalResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomDetailResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomSimpleResponse;
@@ -117,6 +119,26 @@ public class ChatRoomService {
 	}
 
 	@Transactional(readOnly = true)
+	public PageResponse<ChatProposalResponse> getChatProposalsByMember(Member member, Pageable pageable) {
+		Slice<ChatProposalInfo> chatProposalInfos = chatRoomRepository.getChatProposalsByMember(
+			member, pageable
+		);
+
+		List<Long> chatRoomIds = chatProposalInfos.stream()
+			.map(ChatProposalInfo::chatRoomId)
+			.toList();
+
+		List<LatestChatMessage> latestChatMessages
+			= chatMessageQueryRepository.findLatestChatByChatRoomIds(chatRoomIds);
+
+		List<ChatProposalResponse> responses = getChatProposalResponse(latestChatMessages,
+			chatProposalInfos);
+
+		return new PageResponse<>(responses, responses.size(), chatProposalInfos.hasNext());
+	}
+
+
+	@Transactional(readOnly = true)
 	public ChatRoomDetailResponse getChatRoomById(Long chatRoomId, Member member) {
 		ChatRoom chatRoom = getChatRoomById(chatRoomId);
 		Member chatPartner = getChatPartner(member.getId(), chatRoom);
@@ -175,6 +197,26 @@ public class ChatRoomService {
 				LatestChatMessage latestMessage = messageMap.get(chatRoomInfo.chatRoomId());
 				return ChatRoomMapper.toChatRoomSimpleResponse(
 					chatRoomInfo, latestMessage
+				);
+			}).toList();
+	}
+
+	private List<ChatProposalResponse> getChatProposalResponse(List<LatestChatMessage> latestChatMessages,
+		Slice<ChatProposalInfo> chatProposalInfos) {
+		// <chatRoomId, LatestMessage> -> 순서 보장 x
+		Map<Long, LatestChatMessage> messageMap = latestChatMessages.stream()
+			.collect(Collectors.toMap(LatestChatMessage::chatRoomId, message -> message));
+
+		// 최신순 정렬 및 변환
+		return chatProposalInfos.stream()
+			.sorted(
+				Comparator.comparing(
+					(ChatProposalInfo info) -> messageMap.get(info.chatRoomId()).createdAt()
+				).reversed())
+			.map(chatProposalInfo -> {
+				LatestChatMessage latestMessage = messageMap.get(chatProposalInfo.chatRoomId());
+				return ChatRoomMapper.toChatProposalResponse(
+					chatProposalInfo, latestMessage
 				);
 			}).toList();
 	}

--- a/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
@@ -156,6 +156,55 @@ class ChatRoomControllerTest extends ApiTestSupport {
 			.andDo(MockMvcResultHandlers.print());
 	}
 
+	@DisplayName("[회원의 채팅 요청 목록을 조회할 수 있다.]")
+	@Test
+	void getChatProposalsByMember() throws Exception {
+		//given
+		Member member1 = memberRepository.save(MemberFixture.member4());
+		Member member2 = memberRepository.save(MemberFixture.member5());
+		List<QuestionPost> questionPosts = questionPostRepository.saveAll(
+			List.of(
+				questionPostRepository.save(QuestionPostFixture.questionPost(member1)),
+				questionPostRepository.save(QuestionPostFixture.questionPost(member2))
+			)
+		);
+		ChatRoom chatRoom1 = chatRoomRepository.save(
+			ChatRoomFixture.chatRoom(questionPosts.get(0), member1, loginMember));
+		ChatRoom chatRoom2 = chatRoomRepository.save(
+			ChatRoomFixture.chatRoom(questionPosts.get(1), loginMember, member1));
+		ChatRoom unrelatedChatroom = chatRoomRepository.save(
+			ChatRoomFixture.chatRoom(questionPosts.get(1), member2, member1));
+
+		chatMessageRepository.saveAll(
+			List.of(
+				chatMessageRepository.save(
+					ChatMessageFixture.chatMessage(chatRoom1.getId(), "11", LocalDateTime.now())),
+				chatMessageRepository.save(
+					ChatMessageFixture.chatMessage(chatRoom2.getId(), "21", LocalDateTime.now())),
+				chatMessageRepository.save(
+					ChatMessageFixture.chatMessage(unrelatedChatroom.getId(), "31", LocalDateTime.now()))
+			)
+		);
+
+		// when & then
+		mockMvc.perform(get("/api/chat-rooms/proposals")
+				.cookie(accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.size").value(2))
+			.andExpect(jsonPath("$.content[0].chatRoomId").value(chatRoom2.getId()))
+			.andExpect(jsonPath("$.content[0].latestMessage").value("21"))
+			.andExpect(jsonPath("$.content[0].chatPartner.memberId").value(member1.getId()))
+			.andExpect(jsonPath("$.content[0].isInquirer").value(true))
+			.andExpect(jsonPath("$.content[0].chatStatus").value(ChatStatus.PENDING.getLabel()))
+
+			.andExpect(jsonPath("$.content[1].chatRoomId").value(chatRoom1.getId()))
+			.andExpect(jsonPath("$.content[1].latestMessage").value("11"))
+			.andExpect(jsonPath("$.content[1].chatPartner.memberId").value(member1.getId()))
+			.andExpect(jsonPath("$.content[1].isInquirer").value(false))
+			.andExpect(jsonPath("$.content[1].chatStatus").value(ChatStatus.PENDING.getLabel()))
+			.andDo(MockMvcResultHandlers.print());
+	}
+
 	@DisplayName("[채팅방 아이디로 채팅방을 상세조회할 수 있다.]")
 	@Test
 	void getChatRoomById() throws Exception {

--- a/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
@@ -98,7 +98,7 @@ class ChatRoomControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.receiverInfo.profileImageNo").value(answerer.getProfileImageNo()));
 	}
 
-	@DisplayName("[회원의 요청 상태 채팅방 목록을 조회할 수 있다.]")
+	@DisplayName("[회원의 채팅방 목록을 조회할 수 있다.]")
 	@Test
 	void getChatRoomsByMember() throws Exception {
 		//given
@@ -111,13 +111,14 @@ class ChatRoomControllerTest extends ApiTestSupport {
 			)
 		);
 		ChatRoom chatRoom1 = chatRoomRepository.save(
-			ChatRoomFixture.chatRoom(questionPosts.get(0), member1, loginMember));
+			ChatRoomFixture.acceptedChatRoom(questionPosts.get(0), member1, loginMember));
 		ChatRoom chatRoom2 = chatRoomRepository.save(
-			ChatRoomFixture.chatRoom(questionPosts.get(0), member2, loginMember));
+			ChatRoomFixture.acceptedChatRoom(questionPosts.get(0), member2, loginMember));
 		ChatRoom chatRoom3 = chatRoomRepository.save(
-			ChatRoomFixture.chatRoom(questionPosts.get(1), loginMember, member1));
+			ChatRoomFixture.acceptedChatRoom(questionPosts.get(1), loginMember, member1));
 		ChatRoom unrelatedChatroom = chatRoomRepository.save(
-			ChatRoomFixture.chatRoom(questionPosts.get(1), member2, member1));
+			ChatRoomFixture.acceptedChatRoom(questionPosts.get(1), member2, member1));
+
 		chatMessageRepository.saveAll(
 			List.of(
 				chatMessageRepository.save(
@@ -140,8 +141,7 @@ class ChatRoomControllerTest extends ApiTestSupport {
 
 		// when & then
 		mockMvc.perform(get("/api/chat-rooms")
-				.cookie(accessToken)
-				.param("statuses", ChatStatus.PENDING.getLabel()))
+				.cookie(accessToken))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.size").value(3))
 			.andExpect(jsonPath("$.content[0].chatRoomId").value(chatRoom3.getId()))

--- a/src/test/java/com/dnd/gongmuin/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/repository/ChatRoomRepositoryTest.java
@@ -44,7 +44,7 @@ class ChatRoomRepositoryTest extends DataJpaTestSupport {
 	@Autowired
 	CreditHistoryRepository creditHistoryRepository;
 
-	@DisplayName("회원이 속한 채팅방을 모두 조회할 수 있다.")
+	@DisplayName("회원이 속한 채팅방 목록을 조회할 수 있다.")
 	@Test
 	void getChatRoomsByMember() {
 		//given
@@ -53,15 +53,15 @@ class ChatRoomRepositoryTest extends DataJpaTestSupport {
 		Member answerer = memberRepository.save(MemberFixture.member());
 		QuestionPost questionPost = questionPostRepository.save(QuestionPostFixture.questionPost(questioner));
 		List<ChatRoom> chatRooms = chatRoomRepository.saveAll(List.of(
-			chatRoomRepository.save(ChatRoomFixture.chatRoom(questionPost, questioner, answerer)),
-			chatRoomRepository.save(ChatRoomFixture.chatRoom(questionPost, questioner, target)),
-			chatRoomRepository.save(ChatRoomFixture.chatRoom(questionPost, target, answerer))
+			chatRoomRepository.save(ChatRoomFixture.acceptedChatRoom(questionPost, questioner, answerer)),
+			chatRoomRepository.save(ChatRoomFixture.acceptedChatRoom(questionPost, questioner, target)),
+			chatRoomRepository.save(ChatRoomFixture.acceptedChatRoom(questionPost, target, answerer))
 		));
-		//when
 
-		List<ChatRoomInfo> chatRoomInfos = chatRoomRepository.getChatRoomsByMember(target, List.of(ChatStatus.PENDING),
-				pageRequest)
+		//when
+		List<ChatRoomInfo> chatRoomInfos = chatRoomRepository.getChatRoomsByMember(target, pageRequest)
 			.getContent();
+
 		//then
 		Assertions.assertAll(
 			() -> assertThat(chatRoomInfos).hasSize(2),

--- a/src/test/java/com/dnd/gongmuin/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/repository/ChatRoomRepositoryTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.dnd.gongmuin.chat.domain.ChatRoom;
 import com.dnd.gongmuin.chat.domain.ChatStatus;
+import com.dnd.gongmuin.chat.dto.response.ChatProposalInfo;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
 import com.dnd.gongmuin.common.fixture.ChatRoomFixture;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
@@ -69,6 +70,34 @@ class ChatRoomRepositoryTest extends DataJpaTestSupport {
 			() -> assertThat(chatRoomInfos.get(0).partnerId()).isEqualTo(questioner.getId()),
 			() -> assertThat(chatRoomInfos.get(1).chatRoomId()).isEqualTo(chatRooms.get(2).getId()),
 			() -> assertThat(chatRoomInfos.get(1).partnerId()).isEqualTo(answerer.getId())
+		);
+	}
+
+	@DisplayName("회원의 채팅 요청 목록을 조회할 수 있다.")
+	@Test
+	void getChatProposalsByMember() {
+		//given
+		Member questioner = memberRepository.save(MemberFixture.member());
+		Member target = memberRepository.save(MemberFixture.member());
+		Member answerer = memberRepository.save(MemberFixture.member());
+		QuestionPost questionPost = questionPostRepository.save(QuestionPostFixture.questionPost(questioner));
+		List<ChatRoom> chatRooms = chatRoomRepository.saveAll(List.of(
+			chatRoomRepository.save(ChatRoomFixture.chatRoom(questionPost, questioner, answerer)),
+			chatRoomRepository.save(ChatRoomFixture.chatRoom(questionPost, questioner, target)),
+			chatRoomRepository.save(ChatRoomFixture.chatRoom(questionPost, target, answerer))
+		));
+
+		//when
+		List<ChatProposalInfo> chatProposalInfos = chatRoomRepository.getChatProposalsByMember(target, pageRequest)
+			.getContent();
+
+		//then
+		Assertions.assertAll(
+			() -> assertThat(chatProposalInfos).hasSize(2),
+			() -> assertThat(chatProposalInfos.get(0).chatRoomId()).isEqualTo(chatRooms.get(1).getId()),
+			() -> assertThat(chatProposalInfos.get(0).partnerId()).isEqualTo(questioner.getId()),
+			() -> assertThat(chatProposalInfos.get(1).chatRoomId()).isEqualTo(chatRooms.get(2).getId()),
+			() -> assertThat(chatProposalInfos.get(1).partnerId()).isEqualTo(answerer.getId())
 		);
 	}
 

--- a/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
@@ -26,6 +26,8 @@ import com.dnd.gongmuin.chat.domain.MessageType;
 import com.dnd.gongmuin.chat.dto.request.CreateChatRoomRequest;
 import com.dnd.gongmuin.chat.dto.response.AcceptChatResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatMessageResponse;
+import com.dnd.gongmuin.chat.dto.response.ChatProposalInfo;
+import com.dnd.gongmuin.chat.dto.response.ChatProposalResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomDetailResponse;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomInfo;
 import com.dnd.gongmuin.chat.dto.response.ChatRoomSimpleResponse;
@@ -191,7 +193,7 @@ class ChatRoomServiceTest {
 			.hasMessageContaining(MemberErrorCode.NOT_ENOUGH_CREDIT.getMessage());
 	}
 
-	@DisplayName("[회원이 속한 수락 상태 채팅방 목록을 조회할 수 있다.]")
+	@DisplayName("[회원이 속한 채팅방 목록을 조회할 수 있다.]")
 	@Test
 	void getChatRoomsByMember() {
 		//given
@@ -213,6 +215,42 @@ class ChatRoomServiceTest {
 
 		//when
 		List<ChatRoomSimpleResponse> response = chatRoomService.getChatRoomsByMember(
+			targetMember, pageRequest).content();
+
+		//then
+		assertAll(
+			() -> assertThat(response).hasSize(1),
+			() -> assertThat(response.get(0).chatRoomId())
+				.isEqualTo(chatRoomId),
+			() -> assertThat(response.get(0).chatPartner().memberId())
+				.isEqualTo(partner.getId()),
+			() -> assertThat(response.get(0).latestMessage())
+				.isEqualTo(latestChatMessage.content())
+		);
+	}
+
+	@DisplayName("[회원이 속한 채팅 요청 목록을 조회할 수 있다.]")
+	@Test
+	void getChatProposalsByMember() {
+		//given
+		Long chatRoomId = 1L;
+		Member targetMember = MemberFixture.member(1L);
+		Member partner = MemberFixture.member(2L);
+		ChatProposalInfo chatProposalInfo = new ChatProposalInfo(
+			chatRoomId, ChatStatus.PENDING, true, partner.getId(),
+			partner.getNickname(), partner.getJobGroup(), partner.getProfileImageNo()
+		);
+		LatestChatMessage latestChatMessage = new LatestChatMessage(
+			chatRoomId, "와", "텍스트", LocalDateTime.now()
+		);
+
+		given(chatRoomRepository.getChatProposalsByMember(targetMember, pageRequest))
+			.willReturn(new SliceImpl<>(List.of(chatProposalInfo), pageRequest, false));
+		given(chatMessageQueryRepository.findLatestChatByChatRoomIds(List.of(chatRoomId)))
+			.willReturn(List.of(latestChatMessage));
+
+		//when
+		List<ChatProposalResponse> response = chatRoomService.getChatProposalsByMember(
 			targetMember, pageRequest).content();
 
 		//then

--- a/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
@@ -199,7 +199,7 @@ class ChatRoomServiceTest {
 		Member targetMember = MemberFixture.member(1L);
 		Member partner = MemberFixture.member(2L);
 		ChatRoomInfo chatRoomInfo = new ChatRoomInfo(
-			chatRoomId, ChatStatus.ACCEPTED, partner.getId(),
+			chatRoomId, partner.getId(),
 			partner.getNickname(), partner.getJobGroup(), partner.getProfileImageNo()
 		);
 		LatestChatMessage latestChatMessage = new LatestChatMessage(

--- a/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
@@ -206,14 +206,14 @@ class ChatRoomServiceTest {
 			chatRoomId, "와", "텍스트", LocalDateTime.now()
 		);
 
-		given(chatRoomRepository.getChatRoomsByMember(targetMember, List.of(ChatStatus.ACCEPTED), pageRequest))
+		given(chatRoomRepository.getChatRoomsByMember(targetMember, pageRequest))
 			.willReturn(new SliceImpl<>(List.of(chatRoomInfo), pageRequest, false));
 		given(chatMessageQueryRepository.findLatestChatByChatRoomIds(List.of(chatRoomId)))
 			.willReturn(List.of(latestChatMessage));
 
 		//when
 		List<ChatRoomSimpleResponse> response = chatRoomService.getChatRoomsByMember(
-			targetMember, List.of(ChatStatus.ACCEPTED.getLabel()), pageRequest).content();
+			targetMember, pageRequest).content();
 
 		//then
 		assertAll(

--- a/src/test/java/com/dnd/gongmuin/common/fixture/ChatRoomFixture.java
+++ b/src/test/java/com/dnd/gongmuin/common/fixture/ChatRoomFixture.java
@@ -3,6 +3,7 @@ package com.dnd.gongmuin.common.fixture;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.dnd.gongmuin.chat.domain.ChatRoom;
+import com.dnd.gongmuin.chat.domain.ChatStatus;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 
@@ -22,6 +23,20 @@ public class ChatRoomFixture {
 			inquirer,
 			answerer
 		);
+	}
+
+	public static ChatRoom acceptedChatRoom(
+		QuestionPost questionPost,
+		Member inquirer,
+		Member answerer
+	) {
+		ChatRoom chatRoom = ChatRoom.of(
+			questionPost,
+			inquirer,
+			answerer
+		);
+		ReflectionTestUtils.setField(chatRoom, "status", ChatStatus.ACCEPTED);
+		return chatRoom;
 	}
 
 	public static ChatRoom chatRoom(


### PR DESCRIPTION
### 관련 이슈
- close #140 

### 📑 작업 상세 내용
<img width="180" alt="image" src="https://github.com/user-attachments/assets/f38d5ae8-35db-434a-a91c-213c8bd61528">
<img width="180" alt="image" src="https://github.com/user-attachments/assets/4deb3ede-09bb-443a-b3c5-4f1369e76904">

- 요청 주체에 따라 `요청중` 상태의 표시 UI가 다름 -> `요청대기`, `수락하기`
  - 요청 목록에 `isInquirer`, `chatStatus` 필드 추가
- 채팅 목록 조회에 불필요한 chatStatus 필드 제거 

### 💫 작업 요약
- 기존) 상태 파라미터에 따라 하나의 API 조회했던 채팅 목록, 요청 목록
- 변화) 각각의 API로 쪼개기

### 🔍 중점적으로 리뷰 할 부분
- 비즈니스 로직 중복되는 코드 어떻게 메서드로 추출할지 고민해보겠습니다.
- 추후 채팅방 목록 조회에 채팅방 별 안 읽은 메시지 수를 추가할 예정입니다.
