### PR TITLE
[feat #146] 채팅 상세조회 응답 dto 필드명 수정

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/domain/ChatInquiry.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/domain/ChatInquiry.java
@@ -54,7 +54,7 @@ public class ChatInquiry extends TimeBaseEntity {
 	@Column(name = "status", nullable = false)
 	private InquiryStatus status;
 
-	@Column(name = "inquiryMessage", nullable = false)
+	@Column(name = "message", nullable = false)
 	private String message;
 
 	private ChatInquiry(QuestionPost questionPost, Member inquirer, Member answerer, String message) {

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryResponse.java
@@ -10,7 +10,7 @@ public record ChatInquiryResponse(
 	String inquiryMessage,
 	String inquiryStatus,
 	boolean isInquirer,
-	MemberInfo partnerInfo
+	MemberInfo chatPartner
 ) {
 	@QueryProjection
 	public ChatInquiryResponse(

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryResponse.java
@@ -7,7 +7,7 @@ import com.querydsl.core.annotations.QueryProjection;
 
 public record ChatInquiryResponse(
 	Long chatInquiryId,
-	String message,
+	String inquiryMessage,
 	String inquiryStatus,
 	boolean isInquirer,
 	MemberInfo partnerInfo

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/CreateChatInquiryResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/CreateChatInquiryResponse.java
@@ -6,6 +6,6 @@ public record CreateChatInquiryResponse(
 	Long chatInquiryId,
 	String inquiryMessage,
 	String inquiryStatus,
-	MemberInfo partnerInfo
+	MemberInfo chatPartner
 ) {
 }

--- a/src/main/java/com/dnd/gongmuin/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/dnd/gongmuin/chatroom/controller/ChatRoomController.java
@@ -36,7 +36,7 @@ public class ChatRoomController {
 		return ResponseEntity.ok(response);
 	}
 
-	@Operation(summary = "채팅방 활성화 목록 조회 API", description = "회원의 채팅방 목록을 조회한다.")
+	@Operation(summary = "채팅방 목록 조회 API", description = "회원의 채팅방 목록을 조회한다.")
 	@GetMapping("/api/chat-rooms")
 	public ResponseEntity<PageResponse<ChatRoomSimpleResponse>> getChatRoomsByMember(
 		@AuthenticationPrincipal Member member,
@@ -47,7 +47,7 @@ public class ChatRoomController {
 		return ResponseEntity.ok(response);
 	}
 
-	@Operation(summary = "채팅방 조회 API", description = "채팅방 아이디로 채팅방을 조회한다.")
+	@Operation(summary = "채팅방 상세조회 API", description = "채팅방 아이디로 채팅방을 조회한다.")
 	@GetMapping("/api/chat-rooms/{chatRoomId}")
 	public ResponseEntity<ChatRoomDetailResponse> createChatRoom(
 		@PathVariable("chatRoomId") Long chatRoomId,

--- a/src/main/java/com/dnd/gongmuin/chatroom/dto/response/ChatRoomDetailResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chatroom/dto/response/ChatRoomDetailResponse.java
@@ -6,7 +6,7 @@ public record ChatRoomDetailResponse(
 	Long questionPostId,
 	String targetJobGroup,
 	String title,
-	MemberInfo receiverInfo,
+	MemberInfo chatPartner,
 	boolean isInquirer
 ) {
 }

--- a/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/controller/ChatRoomControllerTest.java
@@ -142,10 +142,10 @@ class ChatRoomControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.questionPostId").value(questionPost.getId()))
 			.andExpect(jsonPath("$.targetJobGroup").value(questionPost.getJobGroup().getLabel()))
 			.andExpect(jsonPath("$.title").value(questionPost.getTitle()))
-			.andExpect(jsonPath("$.receiverInfo.memberId").value(inquirer.getId()))
-			.andExpect(jsonPath("$.receiverInfo.nickname").value(inquirer.getNickname()))
-			.andExpect(jsonPath("$.receiverInfo.memberJobGroup").value(inquirer.getJobGroup().getLabel()))
-			.andExpect(jsonPath("$.receiverInfo.profileImageNo").value(inquirer.getProfileImageNo()))
+			.andExpect(jsonPath("$.chatPartner.memberId").value(inquirer.getId()))
+			.andExpect(jsonPath("$.chatPartner.nickname").value(inquirer.getNickname()))
+			.andExpect(jsonPath("$.chatPartner.memberJobGroup").value(inquirer.getJobGroup().getLabel()))
+			.andExpect(jsonPath("$.chatPartner.profileImageNo").value(inquirer.getProfileImageNo()))
 			.andExpect(jsonPath("$.isInquirer").value(false));
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
@@ -128,7 +128,7 @@ class ChatRoomServiceTest {
 		assertAll(
 			() -> assertThat(response.questionPostId())
 				.isEqualTo(questionPost.getId()),
-			() -> assertThat(response.receiverInfo().memberId())
+			() -> assertThat(response.chatPartner().memberId())
 				.isEqualTo(answerer.getId())
 		);
 	}
@@ -154,7 +154,7 @@ class ChatRoomServiceTest {
 		assertAll(
 			() -> assertThat(response.questionPostId())
 				.isEqualTo(questionPost.getId()),
-			() -> assertThat(response.receiverInfo().memberId())
+			() -> assertThat(response.chatPartner().memberId())
 				.isEqualTo(inquirer.getId())
 		);
 	}

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/controller/ChatInquiryControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/controller/ChatInquiryControllerTest.java
@@ -105,12 +105,12 @@ class ChatInquiryControllerTest extends ApiTestSupport {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.size").value(2))
 			.andExpect(jsonPath("$.content[0].chatInquiryId").value(chatInquiry2.getId())) // 내림차순
-			.andExpect(jsonPath("$.content[0].partnerInfo.memberId").value(member2.getId()))
+			.andExpect(jsonPath("$.content[0].chatPartner.memberId").value(member2.getId()))
 			.andExpect(jsonPath("$.content[0].isInquirer").value(true))
 			.andExpect(jsonPath("$.content[0].inquiryStatus").value(InquiryStatus.PENDING.getLabel()))
 
 			.andExpect(jsonPath("$.content[1].chatInquiryId").value(chatInquiry1.getId()))
-			.andExpect(jsonPath("$.content[1].partnerInfo.memberId").value(member1.getId()))
+			.andExpect(jsonPath("$.content[1].chatPartner.memberId").value(member1.getId()))
 			.andExpect(jsonPath("$.content[1].isInquirer").value(false))
 			.andExpect(jsonPath("$.content[1].inquiryStatus").value(InquiryStatus.PENDING.getLabel()))
 			.andDo(MockMvcResultHandlers.print());

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryRepositoryTest.java
@@ -64,9 +64,9 @@ class ChatInquiryRepositoryTest extends DataJpaTestSupport {
 		Assertions.assertAll(
 			() -> assertThat(responses).hasSize(2),
 			() -> assertThat(responses.get(0).chatInquiryId()).isEqualTo(chatInquiries.get(1).getId()),
-			() -> assertThat(responses.get(0).partnerInfo().memberId()).isEqualTo(questioner.getId()),
+			() -> assertThat(responses.get(0).chatPartner().memberId()).isEqualTo(questioner.getId()),
 			() -> assertThat(responses.get(1).chatInquiryId()).isEqualTo(chatInquiries.get(0).getId()),
-			() -> assertThat(responses.get(1).partnerInfo().memberId()).isEqualTo(answerer.getId())
+			() -> assertThat(responses.get(1).chatPartner().memberId()).isEqualTo(answerer.getId())
 		);
 	}
 

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
@@ -98,7 +98,7 @@ class ChatInquiryServiceTest {
 		assertAll(
 			() -> assertThat(response.chatInquiryId())
 				.isEqualTo(chatInquiryId),
-			() -> assertThat(response.partnerInfo().memberId())
+			() -> assertThat(response.chatPartner().memberId())
 				.isEqualTo(answerer.getId()),
 			() -> assertThat(response.inquiryMessage())
 				.isEqualTo(INQUIRY_MESSAGE)
@@ -153,7 +153,7 @@ class ChatInquiryServiceTest {
 			() -> assertThat(response).hasSize(1),
 			() -> assertThat(response.get(0).chatInquiryId())
 				.isEqualTo(chatInquiryId),
-			() -> assertThat(response.get(0).partnerInfo().memberId())
+			() -> assertThat(response.get(0).chatPartner().memberId())
 				.isEqualTo(partner.getId()),
 			() -> assertThat(response.get(0).inquiryMessage())
 				.isEqualTo(INQUIRY_MESSAGE)

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
@@ -155,7 +155,7 @@ class ChatInquiryServiceTest {
 				.isEqualTo(chatInquiryId),
 			() -> assertThat(response.get(0).partnerInfo().memberId())
 				.isEqualTo(partner.getId()),
-			() -> assertThat(response.get(0).message())
+			() -> assertThat(response.get(0).inquiryMessage())
 				.isEqualTo(INQUIRY_MESSAGE)
 		);
 	}


### PR DESCRIPTION
### 관련 이슈
- close #146 

### 📑 작업 상세 내용
- 채팅방 상세조회 응답 chatPartner로 통일
- message-> inquiryMessage
- 채팅방 상세조회 API 명세 수정

### 💫 작업 요약
- 

### 🔍 중점적으로 리뷰 할 부분
- 
