### PR TITLE
[feat #149] 채팅 요청 수락 시 채팅 요청 메시지를 채팅방 메시지에 저장

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/domain/ChatInquiry.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/domain/ChatInquiry.java
@@ -4,7 +4,7 @@ import static jakarta.persistence.ConstraintMode.*;
 import static jakarta.persistence.EnumType.*;
 import static jakarta.persistence.FetchType.*;
 
-import com.dnd.gongmuin.chatroom.exception.ChatErrorCode;
+import com.dnd.gongmuin.chat_inquiry.exception.ChatInquiryErrorCode;
 import com.dnd.gongmuin.common.entity.TimeBaseEntity;
 import com.dnd.gongmuin.common.exception.runtime.ValidationException;
 import com.dnd.gongmuin.member.domain.Member;
@@ -77,7 +77,7 @@ public class ChatInquiry extends TimeBaseEntity {
 
 	public void updateStatusAccepted() {
 		if (status != InquiryStatus.PENDING) {
-			throw new ValidationException(ChatErrorCode.UNABLE_TO_CHANGE_CHAT_STATUS);
+			throw new ValidationException(ChatInquiryErrorCode.UNABLE_TO_CHANGE_STATUS);
 		}
 		status = InquiryStatus.ACCEPTED;
 		answerer.increaseCredit(CHAT_REWARD);
@@ -85,7 +85,7 @@ public class ChatInquiry extends TimeBaseEntity {
 
 	public void updateStatusRejected() {
 		if (status != InquiryStatus.PENDING) {
-			throw new ValidationException(ChatErrorCode.UNABLE_TO_CHANGE_CHAT_STATUS);
+			throw new ValidationException(ChatInquiryErrorCode.UNABLE_TO_CHANGE_STATUS);
 		}
 		status = InquiryStatus.REJECTED;
 		inquirer.increaseCredit(CHAT_REWARD);

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/domain/InquiryStatus.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/domain/InquiryStatus.java
@@ -2,7 +2,7 @@ package com.dnd.gongmuin.chat_inquiry.domain;
 
 import java.util.Arrays;
 
-import com.dnd.gongmuin.chatroom.exception.ChatErrorCode;
+import com.dnd.gongmuin.chat_inquiry.exception.ChatInquiryErrorCode;
 import com.dnd.gongmuin.common.exception.runtime.ValidationException;
 
 import lombok.Getter;
@@ -22,7 +22,7 @@ public enum InquiryStatus {
 		return Arrays.stream(values())
 			.filter(status -> status.isEqual(input))
 			.findAny()
-			.orElseThrow(() -> new ValidationException(ChatErrorCode.NOT_FOUND_CHAT_STATUS));
+			.orElseThrow(() -> new ValidationException(ChatInquiryErrorCode.NOT_FOUND_STATUS));
 	}
 
 	private boolean isEqual(String input) {

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/exception/ChatInquiryErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/exception/ChatInquiryErrorCode.java
@@ -1,0 +1,18 @@
+package com.dnd.gongmuin.chat_inquiry.exception;
+
+import com.dnd.gongmuin.common.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatInquiryErrorCode implements ErrorCode {
+
+	NOT_FOUND_INQUIRY("해당 아이디의 채팅 요청이 존재하지 않습니다.", "CI_001"),
+	UNAUTHORIZED_REQUEST("채팅 수락을 하거나 거절할 권한이 없습니다.", "CI_002"),
+	UNABLE_TO_CHANGE_STATUS("이미 수락했거나 거절한 요청입니다.", "CI_003");
+
+	private final String message;
+	private final String code;
+}

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/exception/ChatInquiryErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/exception/ChatInquiryErrorCode.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 public enum ChatInquiryErrorCode implements ErrorCode {
 
 	NOT_FOUND_INQUIRY("해당 아이디의 채팅 요청이 존재하지 않습니다.", "CI_001"),
-	UNAUTHORIZED_REQUEST("채팅 수락을 하거나 거절할 권한이 없습니다.", "CI_002"),
+	UNAUTHORIZED_REQUEST("채팅 요청을 수락을 하거나 거절할 권한이 없습니다.", "CI_002"),
 	UNABLE_TO_CHANGE_STATUS("이미 수락했거나 거절한 요청입니다.", "CI_003");
 
 	private final String message;

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/exception/ChatInquiryErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/exception/ChatInquiryErrorCode.java
@@ -11,7 +11,8 @@ public enum ChatInquiryErrorCode implements ErrorCode {
 
 	NOT_FOUND_INQUIRY("해당 아이디의 채팅 요청이 존재하지 않습니다.", "CI_001"),
 	UNAUTHORIZED_REQUEST("채팅 요청을 수락을 하거나 거절할 권한이 없습니다.", "CI_002"),
-	UNABLE_TO_CHANGE_STATUS("이미 수락했거나 거절한 요청입니다.", "CI_003");
+	UNABLE_TO_CHANGE_STATUS("이미 수락했거나 거절한 요청입니다.", "CI_003"),
+	NOT_FOUND_STATUS("채팅방 상태값을 올바르게 입력해주세요.", "CI_004");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
@@ -113,17 +113,19 @@ public class ChatInquiryService {
 		List<Long> rejectedInquirerIds = chatInquiryRepository.getAutoRejectedInquirerIds();
 		chatInquiryRepository.updateChatInquiryStatusRejected();
 		memberRepository.refundInMemberIds(rejectedInquirerIds, CHAT_REWARD);
-		creditHistoryService.saveCreditHistoryInMemberIds(rejectedInquirerIds, CreditType.CHAT_REFUND, CHAT_REWARD);
+		creditHistoryService.saveCreditHistoryInMemberIds(
+			rejectedInquirerIds, CreditType.CHAT_REFUND, CHAT_REWARD
+		);
 	}
 
 	private ChatInquiry getChatProposalById(Long id) {
 		return chatInquiryRepository.findById(id)
-			.orElseThrow(() -> new NotFoundException(ChatErrorCode.NOT_FOUND_CHAT_ROOM));
+			.orElseThrow(() -> new NotFoundException(ChatInquiryErrorCode.NOT_FOUND_INQUIRY));
 	}
 
 	private static void validateIfAnswerer(Member member, ChatInquiry chatInquiry) {
 		if (!Objects.equals(member.getId(), chatInquiry.getAnswerer().getId())) {
-			throw new ValidationException(ChatErrorCode.UNAUTHORIZED_REQUEST);
+			throw new ValidationException(ChatInquiryErrorCode.UNAUTHORIZED_REQUEST);
 		}
 	}
 

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
@@ -80,7 +80,7 @@ public class ChatInquiryService {
 
 	@Transactional
 	public AcceptChatResponse acceptChat(Long chatInquiryId, Member answerer) {
-		ChatInquiry chatInquiry = getChatProposalById(chatInquiryId);
+		ChatInquiry chatInquiry = getChatInquiryById(chatInquiryId);
 		validateIfAnswerer(answerer, chatInquiry);
 		chatInquiry.updateStatusAccepted();
 		creditHistoryService.saveChatCreditHistory(CreditType.CHAT_ACCEPT, answerer);
@@ -101,7 +101,7 @@ public class ChatInquiryService {
 
 	@Transactional
 	public RejectChatResponse rejectChat(Long chatInquiryId, Member answerer) {
-		ChatInquiry chatInquiry = getChatProposalById(chatInquiryId);
+		ChatInquiry chatInquiry = getChatInquiryById(chatInquiryId);
 
 		validateIfAnswerer(answerer, chatInquiry);
 		chatInquiry.updateStatusRejected();
@@ -124,7 +124,7 @@ public class ChatInquiryService {
 		);
 	}
 
-	private ChatInquiry getChatProposalById(Long id) {
+	private ChatInquiry getChatInquiryById(Long id) {
 		return chatInquiryRepository.findById(id)
 			.orElseThrow(() -> new NotFoundException(ChatInquiryErrorCode.NOT_FOUND_INQUIRY));
 	}

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
@@ -16,10 +16,12 @@ import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.CreateChatInquiryRequest;
 import com.dnd.gongmuin.chat_inquiry.dto.CreateChatInquiryResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.RejectChatResponse;
+import com.dnd.gongmuin.chat_inquiry.exception.ChatInquiryErrorCode;
 import com.dnd.gongmuin.chat_inquiry.repository.ChatInquiryRepository;
 import com.dnd.gongmuin.chatroom.domain.ChatRoom;
+import com.dnd.gongmuin.chatroom.dto.ChatMessageMapper;
 import com.dnd.gongmuin.chatroom.dto.ChatRoomMapper;
-import com.dnd.gongmuin.chatroom.exception.ChatErrorCode;
+import com.dnd.gongmuin.chatroom.repository.ChatMessageRepository;
 import com.dnd.gongmuin.chatroom.repository.ChatRoomRepository;
 import com.dnd.gongmuin.common.dto.PageMapper;
 import com.dnd.gongmuin.common.dto.PageResponse;
@@ -49,6 +51,7 @@ public class ChatInquiryService {
 	private final QuestionPostRepository questionPostRepository;
 	private final CreditHistoryService creditHistoryService;
 	private final ApplicationEventPublisher eventPublisher;
+	private final ChatMessageRepository chatMessageRepository;
 
 	@Transactional
 	public CreateChatInquiryResponse createChatInquiry(CreateChatInquiryRequest request, Member inquirer) {
@@ -84,6 +87,9 @@ public class ChatInquiryService {
 
 		ChatRoom chatRoom = chatRoomRepository.save(
 			ChatRoomMapper.toChatRoom(chatInquiry.getQuestionPost(), chatInquiry.getInquirer(), answerer)
+		);
+		chatMessageRepository.save(
+			ChatMessageMapper.toChatMessage(chatInquiry.getMessage(), chatRoom)
 		);
 		eventPublisher.publishEvent(
 			new NotificationEvent(NotificationType.CHAT_ACCEPT, chatInquiry.getId(), answerer.getId(),

--- a/src/main/java/com/dnd/gongmuin/chatroom/dto/ChatMessageMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chatroom/dto/ChatMessageMapper.java
@@ -27,6 +27,18 @@ public class ChatMessageMapper {
 	}
 
 	public static ChatMessage toChatMessage(
+		String message,
+		ChatRoom chatRoom
+	) {
+		return ChatMessage.of(
+			message,
+			chatRoom.getId(),
+			chatRoom.getInquirer().getId(),
+			MessageType.TEXT
+		);
+	}
+
+	public static ChatMessage toChatMessage(
 		ChatMessageRequest request,
 		long chatRoomId
 	) {

--- a/src/main/java/com/dnd/gongmuin/chatroom/exception/ChatErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/chatroom/exception/ChatErrorCode.java
@@ -11,10 +11,7 @@ public enum ChatErrorCode implements ErrorCode {
 
 	INVALID_MESSAGE_TYPE("메시지 타입을 올바르게 입력해주세요.", "CH_001"),
 	NOT_FOUND_CHAT_ROOM("해당 아이디의 채팅방이 존재하지 않습니다.", "CH_002"),
-	UNAUTHORIZED_REQUEST("채팅 수락을 하거나 거절할 권한이 없습니다.", "CH_003"),
-	UNABLE_TO_CHANGE_CHAT_STATUS("이미 수락했거나 거절한 요청입니다.", "CH_004"),
-	UNAUTHORIZED_CHAT_ROOM("권한이 없는 채팅방입니다.", "CH_005"),
-	NOT_FOUND_CHAT_STATUS("채팅방 상태값을 올바르게 입력해주세요.", "CH_006");
+	UNAUTHORIZED_CHAT_ROOM("채팅방 조회 권한이 없습니다.", "CH_003");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chatroom/service/ChatRoomService.java
@@ -103,9 +103,10 @@ public class ChatRoomService {
 	}
 
 	private Member getChatPartner(Member member, ChatRoom chatRoom) {
-		if (member.isEqualMember(chatRoom.getAnswerer().getId())) {
+		if (member.equals(chatRoom.getAnswerer())) {
 			return chatRoom.getInquirer();
-		} else if (member.isEqualMember(chatRoom.getInquirer().getId())) {
+		}
+		if (member.equals(chatRoom.getInquirer())) {
 			return chatRoom.getAnswerer();
 		}
 		throw new ValidationException(ChatErrorCode.UNAUTHORIZED_CHAT_ROOM);

--- a/src/main/java/com/dnd/gongmuin/member/domain/Member.java
+++ b/src/main/java/com/dnd/gongmuin/member/domain/Member.java
@@ -4,6 +4,7 @@ import static jakarta.persistence.EnumType.*;
 import static jakarta.persistence.GenerationType.*;
 import static lombok.AccessLevel.*;
 
+import java.util.Objects;
 import java.util.Random;
 
 import com.dnd.gongmuin.common.entity.TimeBaseEntity;
@@ -133,12 +134,29 @@ public class Member extends TimeBaseEntity {
 		this.jobCategory = jobCategory;
 	}
 
+	private int setRandomNumber() {
+		Random random = new Random();
+		return random.nextInt(1, 10);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Member)) {
+			return false;
+		}
+		Member member = (Member) o;
+		return Objects.equals(id, member.getId());
+	}
+
 	public boolean isEqualMember(Long id) {
 		return this.id.equals(id);
 	}
 
-	private int setRandomNumber() {
-		Random random = new Random();
-		return random.nextInt(1, 10);
+	@Override
+	public int hashCode() {
+		return Objects.hash(id);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/member/domain/Member.java
+++ b/src/main/java/com/dnd/gongmuin/member/domain/Member.java
@@ -147,12 +147,8 @@ public class Member extends TimeBaseEntity {
 		if (!(o instanceof Member)) {
 			return false;
 		}
-		Member member = (Member) o;
+		Member member = (Member)o;
 		return Objects.equals(id, member.getId());
-	}
-
-	public boolean isEqualMember(Long id) {
-		return this.id.equals(id);
 	}
 
 	@Override

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
@@ -27,6 +27,7 @@ import com.dnd.gongmuin.chat_inquiry.dto.CreateChatInquiryResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.RejectChatResponse;
 import com.dnd.gongmuin.chat_inquiry.repository.ChatInquiryRepository;
 import com.dnd.gongmuin.chatroom.domain.ChatRoom;
+import com.dnd.gongmuin.chatroom.repository.ChatMessageRepository;
 import com.dnd.gongmuin.chatroom.repository.ChatRoomRepository;
 import com.dnd.gongmuin.common.exception.runtime.ValidationException;
 import com.dnd.gongmuin.common.fixture.ChatInquiryFixture;
@@ -67,6 +68,9 @@ class ChatInquiryServiceTest {
 
 	@Mock
 	private CreditHistoryService creditHistoryService;
+
+	@Mock
+	private ChatMessageRepository chatMessageRepository;
 
 	@InjectMocks
 	private ChatInquiryService chatInquiryService;


### PR DESCRIPTION
### 관련 이슈
- close #149 
### 📑 작업 상세 내용
- 요청 수락 시 요청 메시지 -> 채팅 메시지에 저장
- 채팅 요청 관련 에러 코드 추가
- 이전 pr 리뷰 반영
### 💫 작업 요약
- 채팅 요청 수락 시 메시지에 채팅 메시지 저장
### 🔍 중점적으로 리뷰 할 부분
- 
