### PR TITLE
[Refactor #151] JWT Subject 개인정보 제거

### DIFF
--- a/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
@@ -74,13 +74,13 @@ public class AuthService {
 			throw new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER);
 		}
 
-		memberRepository.save(member);
+		Member savedMember = memberRepository.save(member);
 
 		AuthInfo authInfo = AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole());
 		CustomOauth2User customOauth2User = new CustomOauth2User(authInfo);
 
-		tokenProvider.generateRefreshToken(customOauth2User, now);
-		String accessToken = tokenProvider.generateAccessToken(customOauth2User, now);
+		tokenProvider.generateRefreshToken(savedMember, customOauth2User, now);
+		String accessToken = tokenProvider.generateAccessToken(savedMember, customOauth2User, now);
 		response.addCookie(cookieUtil.createCookie(accessToken));
 
 		return new TempSignResponse(true);
@@ -98,8 +98,8 @@ public class AuthService {
 		AuthInfo authInfo = AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole());
 		CustomOauth2User customOauth2User = new CustomOauth2User(authInfo);
 
-		tokenProvider.generateRefreshToken(customOauth2User, now);
-		String accessToken = tokenProvider.generateAccessToken(customOauth2User, now);
+		tokenProvider.generateRefreshToken(member, customOauth2User, now);
+		String accessToken = tokenProvider.generateAccessToken(member, customOauth2User, now);
 		response.addCookie(cookieUtil.createCookie(accessToken));
 
 		return new TempSignResponse(true);
@@ -175,8 +175,8 @@ public class AuthService {
 
 		CustomOauth2User customUser = new CustomOauth2User(
 			AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole()));
-		String reissuedAccessToken = tokenProvider.generateAccessToken(customUser, new Date());
-		tokenProvider.generateRefreshToken(customUser, new Date());
+		String reissuedAccessToken = tokenProvider.generateAccessToken(member, customUser, new Date());
+		tokenProvider.generateRefreshToken(member, customUser, new Date());
 
 		response.addCookie(cookieUtil.createCookie(reissuedAccessToken));
 

--- a/src/main/java/com/dnd/gongmuin/security/handler/CustomOauth2SuccessHandler.java
+++ b/src/main/java/com/dnd/gongmuin/security/handler/CustomOauth2SuccessHandler.java
@@ -42,8 +42,8 @@ public class CustomOauth2SuccessHandler implements AuthenticationSuccessHandler 
 		Member findmember = memberRepository.findBySocialEmail(socialEmail)
 			.orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
 
-		String token = tokenProvider.generateAccessToken(customOauth2User, new Date());
-		tokenProvider.generateRefreshToken(customOauth2User, new Date());
+		String token = tokenProvider.generateAccessToken(findmember, customOauth2User, new Date());
+		tokenProvider.generateRefreshToken(findmember, customOauth2User, new Date());
 
 		response.addCookie(cookieUtil.createCookie(token));
 

--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenProvider.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenProvider.java
@@ -54,12 +54,12 @@ public class TokenProvider {
 		this.secretKey = Keys.hmacShaKeyFor(key.getBytes());
 	}
 
-	public String generateAccessToken(CustomOauth2User authentication, Date now) {
-		return generateToken(authentication, ACCESS_TOKEN_EXPIRE_TIME, now);
+	public String generateAccessToken(Member findMember, CustomOauth2User authentication, Date now) {
+		return generateToken(findMember, authentication, ACCESS_TOKEN_EXPIRE_TIME, now);
 	}
 
-	public String generateRefreshToken(CustomOauth2User authentication, Date now) {
-		String refreshToken = generateToken(authentication, REFRESH_TOKEN_EXPIRE_TIME, now);
+	public String generateRefreshToken(Member findMember, CustomOauth2User authentication, Date now) {
+		String refreshToken = generateToken(findMember, authentication, REFRESH_TOKEN_EXPIRE_TIME, now);
 
 		// redis Refresh 저장
 		redisUtil.setValues("RT:" + authentication.getEmail(), refreshToken,
@@ -67,12 +67,12 @@ public class TokenProvider {
 		return refreshToken;
 	}
 
-	private String generateToken(CustomOauth2User authentication, long tokenExpireTime, Date now) {
+	private String generateToken(Member findMember, CustomOauth2User authentication, long tokenExpireTime, Date now) {
 		Date expiredTime = createExpiredDateWithTokenType(now, tokenExpireTime);
 		String authorities = getAuthorities(authentication);
 
 		return Jwts.builder()
-			.subject(authentication.getEmail())
+			.subject(String.valueOf(findMember.getId()))
 			.claim(ROLE_KEY, authorities)
 			.issuedAt(now)
 			.expiration(expiredTime)
@@ -94,8 +94,8 @@ public class TokenProvider {
 		Claims claims = parseToken(token);
 		List<SimpleGrantedAuthority> authorities = getAuthorities(claims);
 
-		String socialEmail = claims.getSubject();
-		Member principal = memberRepository.findBySocialEmail(socialEmail)
+		String subject = claims.getSubject();
+		Member principal = memberRepository.findById(Long.valueOf(subject))
 			.orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
 
 		return new UsernamePasswordAuthenticationToken(principal, token, authorities);

--- a/src/test/java/com/dnd/gongmuin/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/auth/controller/AuthControllerTest.java
@@ -102,7 +102,7 @@ class AuthControllerTest extends ApiTestSupport {
 			savedMember.getSocialEmail(),
 			savedMember.getRole()
 		);
-		String token = tokenProvider.generateAccessToken(new CustomOauth2User(authInfo), new Date());
+		String token = tokenProvider.generateAccessToken(savedMember, new CustomOauth2User(authInfo), new Date());
 		this.loginMember = savedMember;
 		this.accessToken = new Cookie("Authorization", token);
 

--- a/src/test/java/com/dnd/gongmuin/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/auth/service/AuthServiceTest.java
@@ -174,10 +174,16 @@ class AuthServiceTest {
 		given(cookieUtil.createCookie(anyString())).willReturn(new Cookie("Authorization", "reissueToken"));
 		given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
 		given(redisUtil.getValues(anyString())).willReturn("refreshToken");
-		given(tokenProvider.generateAccessToken(any(CustomOauth2User.class), any(Date.class))).willReturn(
-			"reissueToken");
-		given(tokenProvider.generateRefreshToken(any(CustomOauth2User.class), any(Date.class))).willReturn(
-			"reissueToken");
+		given(tokenProvider.generateAccessToken(
+			any(Member.class),
+			any(CustomOauth2User.class),
+			any(Date.class)))
+			.willReturn("reissueToken");
+		given(tokenProvider.generateRefreshToken(
+			any(Member.class),
+			any(CustomOauth2User.class),
+			any(Date.class)))
+			.willReturn("reissueToken");
 
 		// when
 		ReissueResponse response = authService.reissue(mockRequest, mockResponse);

--- a/src/test/java/com/dnd/gongmuin/common/support/ApiTestSupport.java
+++ b/src/test/java/com/dnd/gongmuin/common/support/ApiTestSupport.java
@@ -54,8 +54,8 @@ public abstract class ApiTestSupport extends TestContainerSupport {
 			savedMember.getSocialEmail(),
 			savedMember.getRole()
 		);
-		String token = tokenProvider.generateAccessToken(new CustomOauth2User(authInfo), new Date());
-		tokenProvider.generateRefreshToken(new CustomOauth2User(authInfo), new Date());
+		String token = tokenProvider.generateAccessToken(savedMember, new CustomOauth2User(authInfo), new Date());
+		tokenProvider.generateRefreshToken(savedMember, new CustomOauth2User(authInfo), new Date());
 		this.loginMember = savedMember;
 		this.accessToken = cookieUtil.createCookie(token);
 	}

--- a/src/test/java/com/dnd/gongmuin/security/jwt/TokenProviderTest.java
+++ b/src/test/java/com/dnd/gongmuin/security/jwt/TokenProviderTest.java
@@ -66,7 +66,7 @@ class TokenProviderTest {
 		CustomOauth2User authentication = new CustomOauth2User(authInfo);
 
 		// when
-		String accessToken = tokenProvider.generateAccessToken(authentication, now);
+		String accessToken = tokenProvider.generateAccessToken(MemberFixture.member(1L), authentication, now);
 		Claims claims = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(accessToken).getPayload();
 		Date expiration = claims.getExpiration();
 
@@ -85,7 +85,7 @@ class TokenProviderTest {
 		CustomOauth2User authentication = new CustomOauth2User(authInfo);
 
 		// when
-		String accessToken = tokenProvider.generateRefreshToken(authentication, now);
+		String accessToken = tokenProvider.generateRefreshToken(MemberFixture.member(1L), authentication, now);
 		Claims claims = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(accessToken).getPayload();
 		Date expiration = claims.getExpiration();
 
@@ -93,17 +93,17 @@ class TokenProviderTest {
 		assertThat(expiration.getTime()).isCloseTo(expectedExpirationTime, within(1000L));
 	}
 
-	@DisplayName("토큰 파싱을 통해 만들어진 인증 객체의 이메일은 토큰 정보의 이메일 값과 동일하다.")
+	@DisplayName("토큰 파싱을 통해 만들어진 인증 객체의 이메일은 회원 이메일과 동일하다.")
 	@Test
 	void getAuthentication() {
 		// given
 		Date now = new Date();
 
-		Member member = MemberFixture.member();
+		Member member = MemberFixture.member(1L);
 		CustomOauth2User customOauth2User = new CustomOauth2User(authInfo);
-		String accessToken = tokenProvider.generateAccessToken(customOauth2User, now);
+		String accessToken = tokenProvider.generateAccessToken(member, customOauth2User, now);
 
-		given(memberRepository.findBySocialEmail(anyString())).willReturn(Optional.ofNullable(member));
+		given(memberRepository.findById(anyLong())).willReturn(Optional.ofNullable(member));
 
 		// when
 		Authentication authentication = tokenProvider.getAuthentication(accessToken);
@@ -121,7 +121,7 @@ class TokenProviderTest {
 		Date past = new Date(124, 6, 30, 16, 0, 0);
 
 		CustomOauth2User customOauth2User = new CustomOauth2User(authInfo);
-		String accessToken = tokenProvider.generateRefreshToken(customOauth2User, past);
+		String accessToken = tokenProvider.generateRefreshToken(MemberFixture.member(1L), customOauth2User, past);
 
 		// when
 		boolean result = tokenProvider.validateToken(accessToken, new Date());


### PR DESCRIPTION
### 관련 이슈
- close #151 

### 📑 작업 상세 내용
- JWT 생성시 Subject를 구성하는 값 회원 소셜 이메일 -> 회원 PK 값으로 변경한다.
  -  변경 사유 : 토큰 탈취 시 개인정보 보호차원.
- 토큰 생성 로직 변경에 따른 상위 호출 메서드, 인증 객체 생성 메서드, 테스트 코드 수정

### 💫 작업 요약
- JWT Subject 구성 값 변경(회원 소셜 이메일 -> 회원 PK)
- 토큰 생성 로직 변경에 따른 상위 호출 메서드, 인증 객체 생성 메서드, 테스트 코드 수정

### 🔍 중점적으로 리뷰 할 부분
- 없습니다.
