### PR TITLE
[refactor#148] 답변 채택 API 성능 최적화

### DIFF
--- a/src/main/java/com/dnd/gongmuin/answer/controller/AnswerController.java
+++ b/src/main/java/com/dnd/gongmuin/answer/controller/AnswerController.java
@@ -58,15 +58,4 @@ public class AnswerController {
 		AnswerDetailResponse response = answerService.chooseAnswer(answerId, member);
 		return ResponseEntity.ok(response);
 	}
-
-	@Operation(summary = "답변 채택 API", description = "질문자가 답변을 채택한다.")
-	@ApiResponse(useReturnTypeSchema = true)
-	@PostMapping("/api/v2/question-posts/answers/{answerId}")
-	public ResponseEntity<AnswerDetailResponse> getAnswersByQuestionPostIdV2(
-		@PathVariable("answerId") Long answerId,
-		@AuthenticationPrincipal Member member
-	) {
-		AnswerDetailResponse response = answerService.chooseAnswerV2(answerId, member);
-		return ResponseEntity.ok(response);
-	}
 }

--- a/src/main/java/com/dnd/gongmuin/answer/controller/AnswerController.java
+++ b/src/main/java/com/dnd/gongmuin/answer/controller/AnswerController.java
@@ -52,10 +52,21 @@ public class AnswerController {
 	@ApiResponse(useReturnTypeSchema = true)
 	@PostMapping("/api/question-posts/answers/{answerId}")
 	public ResponseEntity<AnswerDetailResponse> getAnswersByQuestionPostId(
-		@PathVariable Long answerId,
+		@PathVariable("answerId") Long answerId,
 		@AuthenticationPrincipal Member member
 	) {
 		AnswerDetailResponse response = answerService.chooseAnswer(answerId, member);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "답변 채택 API", description = "질문자가 답변을 채택한다.")
+	@ApiResponse(useReturnTypeSchema = true)
+	@PostMapping("/api/v2/question-posts/answers/{answerId}")
+	public ResponseEntity<AnswerDetailResponse> getAnswersByQuestionPostIdV2(
+		@PathVariable("answerId") Long answerId,
+		@AuthenticationPrincipal Member member
+	) {
+		AnswerDetailResponse response = answerService.chooseAnswerV2(answerId, member);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/answer/dto/AnswerDetailResponse.java
+++ b/src/main/java/com/dnd/gongmuin/answer/dto/AnswerDetailResponse.java
@@ -1,6 +1,6 @@
 package com.dnd.gongmuin.answer.dto;
 
-import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
+import com.dnd.gongmuin.member.dto.response.MemberInfo;
 
 public record AnswerDetailResponse(
 	Long answerId,

--- a/src/main/java/com/dnd/gongmuin/answer/dto/AnswerMapper.java
+++ b/src/main/java/com/dnd/gongmuin/answer/dto/AnswerMapper.java
@@ -2,7 +2,7 @@ package com.dnd.gongmuin.answer.dto;
 
 import com.dnd.gongmuin.answer.domain.Answer;
 import com.dnd.gongmuin.member.domain.Member;
-import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
+import com.dnd.gongmuin.member.dto.response.MemberInfo;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/dnd/gongmuin/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/dnd/gongmuin/answer/repository/AnswerRepository.java
@@ -1,6 +1,7 @@
 package com.dnd.gongmuin.answer.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,4 +22,8 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 	@Modifying(flushAutomatically = true, clearAutomatically = true)
 	@Query("UPDATE Answer a SET a.member = :member WHERE a.member.id = :memberId")
 	void updateAnswersMember(Long memberId, Member member);
+
+	@Query("select a from Answer a "
+		+ "join fetch a.member where a.id = :answerId")
+	Optional<Answer> findByIdWithMember(Long answerId);
 }

--- a/src/main/java/com/dnd/gongmuin/answer/repository/AnswerSimpleQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/answer/repository/AnswerSimpleQueryRepository.java
@@ -1,0 +1,28 @@
+package com.dnd.gongmuin.answer.repository;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.dnd.gongmuin.answer.domain.Answer;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class AnswerSimpleQueryRepository {
+
+	private final EntityManager em;
+
+	public Optional<Answer> findAnswerById(Long answerId) {
+		Answer answer = em.createQuery(
+				"select a from Answer a" +
+					" join fetch a.member m" +
+					" where a.id = :answerId", Answer.class
+			)
+			.setParameter("answerId", answerId)
+			.getSingleResult();
+		return Optional.of(answer);
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
+++ b/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
@@ -13,7 +13,6 @@ import com.dnd.gongmuin.answer.dto.AnswerMapper;
 import com.dnd.gongmuin.answer.dto.RegisterAnswerRequest;
 import com.dnd.gongmuin.answer.exception.AnswerErrorCode;
 import com.dnd.gongmuin.answer.repository.AnswerRepository;
-import com.dnd.gongmuin.answer.repository.AnswerSimpleQueryRepository;
 import com.dnd.gongmuin.common.dto.PageMapper;
 import com.dnd.gongmuin.common.dto.PageResponse;
 import com.dnd.gongmuin.common.exception.runtime.NotFoundException;
@@ -24,7 +23,6 @@ import com.dnd.gongmuin.notification.dto.NotificationEvent;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.exception.QuestionPostErrorCode;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
-import com.dnd.gongmuin.question_post.repository.QuestionPostSimpleQueryRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,8 +34,6 @@ public class AnswerService {
 	private final AnswerRepository answerRepository;
 	private final CreditHistoryService creditHistoryService;
 	private final ApplicationEventPublisher eventPublisher;
-	private final QuestionPostSimpleQueryRepository questionPostSimpleQueryRepository;
-	private final AnswerSimpleQueryRepository answerSimpleQueryRepository;
 
 	private static void validateIfQuestioner(Member member, QuestionPost questionPost) {
 		if (!questionPost.isQuestioner(member.getId())) {
@@ -77,8 +73,8 @@ public class AnswerService {
 		Long answerId,
 		Member member
 	) {
-		Answer answer = getAnswerById(answerId);
-		QuestionPost questionPost = findQuestionPostById(answer.getQuestionPostId());
+		Answer answer = getAnswerWithMember(answerId);
+		QuestionPost questionPost = getQuestionPostWithMember(answer.getQuestionPostId());
 		validateIfQuestioner(member, questionPost);
 		chooseAnswer(questionPost, answer);
 
@@ -103,8 +99,8 @@ public class AnswerService {
 		}
 	}
 
-	private Answer getAnswerById(Long answerId) {
-		return answerSimpleQueryRepository.findAnswerById(answerId)
+	private Answer getAnswerWithMember(Long answerId) {
+		return answerRepository.findByIdWithMember(answerId)
 			.orElseThrow(() -> new NotFoundException(AnswerErrorCode.NOT_FOUND_ANSWER));
 	}
 
@@ -113,8 +109,8 @@ public class AnswerService {
 			.orElseThrow(() -> new NotFoundException(QuestionPostErrorCode.NOT_FOUND_QUESTION_POST));
 	}
 
-	private QuestionPost findQuestionPostById(Long questionPostId) {
-		return questionPostSimpleQueryRepository.findQuestionPostById(questionPostId)
+	private QuestionPost getQuestionPostWithMember(Long questionPostId) {
+		return questionPostRepository.findByIdWithMember(questionPostId)
 			.orElseThrow(() -> new NotFoundException(QuestionPostErrorCode.NOT_FOUND_QUESTION_POST));
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
+++ b/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
@@ -89,23 +89,6 @@ public class AnswerService {
 		return AnswerMapper.toAnswerDetailResponse(answer);
 	}
 
-	@Transactional
-	public AnswerDetailResponse chooseAnswerV2(
-		Long answerId,
-		Member member
-	) {
-		Answer answer = getAnswerByIdV2(answerId);
-		QuestionPost questionPost = findQuestionPostByIdV2(answer.getQuestionPostId());
-		validateIfQuestioner(member, questionPost);
-		chooseAnswer(questionPost, answer);
-
-		eventPublisher.publishEvent(new NotificationEvent(
-			CHOSEN, questionPost.getId(), member.getId(), answer.getMember()
-		));
-
-		return AnswerMapper.toAnswerDetailResponse(answer);
-	}
-
 	private void chooseAnswer(QuestionPost questionPost, Answer answer) {
 		questionPost.updateIsChosen(answer);
 		answer.getMember().increaseCredit(questionPost.getReward());
@@ -121,21 +104,11 @@ public class AnswerService {
 	}
 
 	private Answer getAnswerById(Long answerId) {
-		return answerRepository.findById(answerId)
-			.orElseThrow(() -> new NotFoundException(AnswerErrorCode.NOT_FOUND_ANSWER));
-	}
-
-	private QuestionPost findQuestionPostById(Long questionPostId) {
-		return questionPostRepository.findById(questionPostId)
-			.orElseThrow(() -> new NotFoundException(QuestionPostErrorCode.NOT_FOUND_QUESTION_POST));
-	}
-
-	private Answer getAnswerByIdV2(Long answerId) {
 		return answerSimpleQueryRepository.findAnswerById(answerId)
 			.orElseThrow(() -> new NotFoundException(AnswerErrorCode.NOT_FOUND_ANSWER));
 	}
 
-	private QuestionPost findQuestionPostByIdV2(Long questionPostId) {
+	private QuestionPost findQuestionPostById(Long questionPostId) {
 		return questionPostSimpleQueryRepository.findQuestionPostById(questionPostId)
 			.orElseThrow(() -> new NotFoundException(QuestionPostErrorCode.NOT_FOUND_QUESTION_POST));
 	}

--- a/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
+++ b/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
@@ -13,6 +13,7 @@ import com.dnd.gongmuin.answer.dto.AnswerMapper;
 import com.dnd.gongmuin.answer.dto.RegisterAnswerRequest;
 import com.dnd.gongmuin.answer.exception.AnswerErrorCode;
 import com.dnd.gongmuin.answer.repository.AnswerRepository;
+import com.dnd.gongmuin.answer.repository.AnswerSimpleQueryRepository;
 import com.dnd.gongmuin.common.dto.PageMapper;
 import com.dnd.gongmuin.common.dto.PageResponse;
 import com.dnd.gongmuin.common.exception.runtime.NotFoundException;
@@ -23,6 +24,7 @@ import com.dnd.gongmuin.notification.dto.NotificationEvent;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.exception.QuestionPostErrorCode;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
+import com.dnd.gongmuin.question_post.repository.QuestionPostSimpleQueryRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -34,6 +36,8 @@ public class AnswerService {
 	private final AnswerRepository answerRepository;
 	private final CreditHistoryService creditHistoryService;
 	private final ApplicationEventPublisher eventPublisher;
+	private final QuestionPostSimpleQueryRepository questionPostSimpleQueryRepository;
+	private final AnswerSimpleQueryRepository answerSimpleQueryRepository;
 
 	private static void validateIfQuestioner(Member member, QuestionPost questionPost) {
 		if (!questionPost.isQuestioner(member.getId())) {
@@ -85,6 +89,23 @@ public class AnswerService {
 		return AnswerMapper.toAnswerDetailResponse(answer);
 	}
 
+	@Transactional
+	public AnswerDetailResponse chooseAnswerV2(
+		Long answerId,
+		Member member
+	) {
+		Answer answer = getAnswerByIdV2(answerId);
+		QuestionPost questionPost = findQuestionPostByIdV2(answer.getQuestionPostId());
+		validateIfQuestioner(member, questionPost);
+		chooseAnswer(questionPost, answer);
+
+		eventPublisher.publishEvent(new NotificationEvent(
+			CHOSEN, questionPost.getId(), member.getId(), answer.getMember()
+		));
+
+		return AnswerMapper.toAnswerDetailResponse(answer);
+	}
+
 	private void chooseAnswer(QuestionPost questionPost, Answer answer) {
 		questionPost.updateIsChosen(answer);
 		answer.getMember().increaseCredit(questionPost.getReward());
@@ -106,6 +127,16 @@ public class AnswerService {
 
 	private QuestionPost findQuestionPostById(Long questionPostId) {
 		return questionPostRepository.findById(questionPostId)
+			.orElseThrow(() -> new NotFoundException(QuestionPostErrorCode.NOT_FOUND_QUESTION_POST));
+	}
+
+	private Answer getAnswerByIdV2(Long answerId) {
+		return answerSimpleQueryRepository.findAnswerById(answerId)
+			.orElseThrow(() -> new NotFoundException(AnswerErrorCode.NOT_FOUND_ANSWER));
+	}
+
+	private QuestionPost findQuestionPostByIdV2(Long questionPostId) {
+		return questionPostSimpleQueryRepository.findQuestionPostById(questionPostId)
 			.orElseThrow(() -> new NotFoundException(QuestionPostErrorCode.NOT_FOUND_QUESTION_POST));
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
+++ b/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
@@ -51,7 +51,7 @@ public class AnswerService {
 		RegisterAnswerRequest request,
 		Member member
 	) {
-		QuestionPost questionPost = findQuestionPostById(questionPostId);
+		QuestionPost questionPost = getQuestionPostById(questionPostId);
 		Answer answer = AnswerMapper.toAnswer(questionPostId, questionPost.isQuestioner(member.getId()), request,
 			member);
 		Answer savedAnswer = answerRepository.save(answer);
@@ -106,6 +106,11 @@ public class AnswerService {
 	private Answer getAnswerById(Long answerId) {
 		return answerSimpleQueryRepository.findAnswerById(answerId)
 			.orElseThrow(() -> new NotFoundException(AnswerErrorCode.NOT_FOUND_ANSWER));
+	}
+
+	private QuestionPost getQuestionPostById(Long questionPostId) {
+		return questionPostRepository.findById(questionPostId)
+			.orElseThrow(() -> new NotFoundException(QuestionPostErrorCode.NOT_FOUND_QUESTION_POST));
 	}
 
 	private QuestionPost findQuestionPostById(Long questionPostId) {

--- a/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
@@ -74,13 +74,13 @@ public class AuthService {
 			throw new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER);
 		}
 
-		memberRepository.save(member);
+		Member savedMember = memberRepository.save(member);
 
 		AuthInfo authInfo = AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole());
 		CustomOauth2User customOauth2User = new CustomOauth2User(authInfo);
 
-		tokenProvider.generateRefreshToken(customOauth2User, now);
-		String accessToken = tokenProvider.generateAccessToken(customOauth2User, now);
+		tokenProvider.generateRefreshToken(savedMember, customOauth2User, now);
+		String accessToken = tokenProvider.generateAccessToken(savedMember, customOauth2User, now);
 		response.addCookie(cookieUtil.createCookie(accessToken));
 
 		return new TempSignResponse(true);
@@ -98,8 +98,8 @@ public class AuthService {
 		AuthInfo authInfo = AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole());
 		CustomOauth2User customOauth2User = new CustomOauth2User(authInfo);
 
-		tokenProvider.generateRefreshToken(customOauth2User, now);
-		String accessToken = tokenProvider.generateAccessToken(customOauth2User, now);
+		tokenProvider.generateRefreshToken(member, customOauth2User, now);
+		String accessToken = tokenProvider.generateAccessToken(member, customOauth2User, now);
 		response.addCookie(cookieUtil.createCookie(accessToken));
 
 		return new TempSignResponse(true);
@@ -175,8 +175,8 @@ public class AuthService {
 
 		CustomOauth2User customUser = new CustomOauth2User(
 			AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole()));
-		String reissuedAccessToken = tokenProvider.generateAccessToken(customUser, new Date());
-		tokenProvider.generateRefreshToken(customUser, new Date());
+		String reissuedAccessToken = tokenProvider.generateAccessToken(member, customUser, new Date());
+		tokenProvider.generateRefreshToken(member, customUser, new Date());
 
 		response.addCookie(cookieUtil.createCookie(reissuedAccessToken));
 

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/controller/ChatInquiryController.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/controller/ChatInquiryController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dnd.gongmuin.chat_inquiry.dto.AcceptChatResponse;
+import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryDetailResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.CreateChatInquiryRequest;
 import com.dnd.gongmuin.chat_inquiry.dto.CreateChatInquiryResponse;
@@ -42,7 +43,17 @@ public class ChatInquiryController {
 		return ResponseEntity.ok(response);
 	}
 
-	@Operation(summary = "채팅방 요청 목록 조회 API", description = "회원의 채팅방 목록을 조회한다.")
+	@Operation(summary = "채팅 요청 상세 조회 API", description = "채팅방 요청을 조회한다.")
+	@GetMapping("/api/chat/inquiries/{chatInquiryId}")
+	public ResponseEntity<ChatInquiryDetailResponse> getChatInquiryById(
+		@PathVariable("chatInquiryId") Long chatInquiryId,
+		@AuthenticationPrincipal Member member
+	) {
+		ChatInquiryDetailResponse response = chatInquiryService.getChatInquiryById(chatInquiryId, member);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "채팅 요청 목록 조회 API", description = "회원의 채팅 목록을 조회한다.")
 	@GetMapping("/api/chat/inquiries")
 	public ResponseEntity<PageResponse<ChatInquiryResponse>> getChatInquiresByMember(
 		@AuthenticationPrincipal Member member,

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/domain/ChatInquiry.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/domain/ChatInquiry.java
@@ -31,7 +31,7 @@ public class ChatInquiry extends TimeBaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "chat_proposal_id", nullable = false)
+	@Column(name = "chat_inquiry_id", nullable = false)
 	private Long id;
 
 	@ManyToOne(fetch = LAZY)
@@ -89,5 +89,13 @@ public class ChatInquiry extends TimeBaseEntity {
 		}
 		status = InquiryStatus.REJECTED;
 		inquirer.increaseCredit(CHAT_REWARD);
+	}
+
+	public boolean isInquirer(Member member) {
+		return member.equals(this.inquirer);
+	}
+
+	public Member getChatPartner(Member member) {
+		return isInquirer(member) ? this.answerer : this.inquirer;
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryDetailResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryDetailResponse.java
@@ -2,10 +2,11 @@ package com.dnd.gongmuin.chat_inquiry.dto;
 
 import com.dnd.gongmuin.member.dto.response.MemberInfo;
 
-public record CreateChatInquiryResponse(
+public record ChatInquiryDetailResponse(
 	Long chatInquiryId,
 	String inquiryMessage,
 	String inquiryStatus,
+	boolean isInquirer,
 	MemberInfo chatPartner
 ) {
 }

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryMapper.java
@@ -4,8 +4,8 @@ import com.dnd.gongmuin.chat_inquiry.domain.ChatInquiry;
 import com.dnd.gongmuin.chat_inquiry.domain.InquiryStatus;
 import com.dnd.gongmuin.chatroom.domain.ChatRoom;
 import com.dnd.gongmuin.member.domain.Member;
+import com.dnd.gongmuin.member.dto.response.MemberInfo;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
-import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -40,6 +40,24 @@ public class ChatInquiryMapper {
 				answerer.getNickname(),
 				answerer.getJobGroup().getLabel(),
 				answerer.getProfileImageNo()
+			)
+		);
+	}
+
+	public static ChatInquiryDetailResponse toChatInquiryDetailResponse(
+		ChatInquiry chatInquiry,
+		Member chatPartner,
+		boolean isInquirer
+	) {
+		return new ChatInquiryDetailResponse(chatInquiry.getId(),
+			chatInquiry.getMessage(),
+			chatInquiry.getStatus().getLabel(),
+			isInquirer,
+			new MemberInfo(
+				chatPartner.getId(),
+				chatPartner.getNickname(),
+				chatPartner.getJobGroup().getLabel(),
+				chatPartner.getProfileImageNo()
 			)
 		);
 	}

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryResponse.java
@@ -1,8 +1,10 @@
 package com.dnd.gongmuin.chat_inquiry.dto;
 
+import com.dnd.gongmuin.chat_inquiry.domain.InquiryStatus;
+import com.dnd.gongmuin.member.domain.JobGroup;
+import com.dnd.gongmuin.member.dto.response.MemberInfo;
 import com.dnd.gongmuin.chat_inquiry.domain.ChatInquiry;
 import com.dnd.gongmuin.member.domain.Member;
-import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
 import com.querydsl.core.annotations.QueryProjection;
 
 public record ChatInquiryResponse(

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryResponse.java
@@ -1,10 +1,8 @@
 package com.dnd.gongmuin.chat_inquiry.dto;
 
-import com.dnd.gongmuin.chat_inquiry.domain.InquiryStatus;
-import com.dnd.gongmuin.member.domain.JobGroup;
-import com.dnd.gongmuin.member.dto.response.MemberInfo;
 import com.dnd.gongmuin.chat_inquiry.domain.ChatInquiry;
 import com.dnd.gongmuin.member.domain.Member;
+import com.dnd.gongmuin.member.dto.response.MemberInfo;
 import com.querydsl.core.annotations.QueryProjection;
 
 public record ChatInquiryResponse(

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryResponse.java
@@ -1,7 +1,7 @@
 package com.dnd.gongmuin.chat_inquiry.dto;
 
-import com.dnd.gongmuin.chat_inquiry.domain.InquiryStatus;
-import com.dnd.gongmuin.member.domain.JobGroup;
+import com.dnd.gongmuin.chat_inquiry.domain.ChatInquiry;
+import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
 import com.querydsl.core.annotations.QueryProjection;
 
@@ -10,30 +10,31 @@ public record ChatInquiryResponse(
 	String inquiryMessage,
 	String inquiryStatus,
 	boolean isInquirer,
-	MemberInfo chatPartner
+	MemberInfo chatPartner,
+	String createdAt
 ) {
 	@QueryProjection
 	public ChatInquiryResponse(
-		Long chatInquiryId,
-		String inquiryMessage,
-		InquiryStatus inquiryStatus,
-		boolean isInquirer,
-		Long partnerId,
-		String partnerNickname,
-		JobGroup partnerJobGroup,
-		int partnerProfileImageNo
+		ChatInquiry chatInquiry,
+		boolean isInquirer
 	) {
 		this(
-			chatInquiryId,
-			inquiryMessage,
-			inquiryStatus.getLabel(),
+			chatInquiry.getId(),
+			chatInquiry.getMessage(),
+			chatInquiry.getStatus().getLabel(),
 			isInquirer,
-			new MemberInfo(
-				partnerId,
-				partnerNickname,
-				partnerJobGroup.getLabel(),
-				partnerProfileImageNo
-			)
+			createPartnerInfo(isInquirer, chatInquiry),
+			chatInquiry.getCreatedAt().toString()
+		);
+	}
+
+	private static MemberInfo createPartnerInfo(boolean isInquirer, ChatInquiry chatInquiry) {
+		Member partner = isInquirer ? chatInquiry.getAnswerer() : chatInquiry.getInquirer();
+		return new MemberInfo(
+			partner.getId(),
+			partner.getNickname(),
+			partner.getJobGroup().getLabel(),
+			partner.getProfileImageNo()
 		);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepositoryImpl.java
@@ -26,29 +26,11 @@ public class ChatInquiryQueryRepositoryImpl implements ChatInquiryQueryRepositor
 	public Slice<ChatInquiryResponse> getChatInquiresByMember(Member member, Pageable pageable) {
 		List<ChatInquiryResponse> content = queryFactory
 			.select(new QChatInquiryResponse(
-				chatInquiry.id,
-				chatInquiry.message,
-				chatInquiry.status,
+				chatInquiry,
 				new CaseBuilder()
 					.when(chatInquiry.inquirer.id.eq(member.getId()))
 					.then(true)
-					.otherwise(false),
-				new CaseBuilder()
-					.when(chatInquiry.inquirer.id.eq(member.getId()))
-					.then(chatInquiry.answerer.id)
-					.otherwise(chatInquiry.inquirer.id),
-				new CaseBuilder()
-					.when(chatInquiry.inquirer.id.eq(member.getId()))
-					.then(chatInquiry.answerer.nickname)
-					.otherwise(chatInquiry.inquirer.nickname),
-				new CaseBuilder()
-					.when(chatInquiry.inquirer.id.eq(member.getId()))
-					.then(chatInquiry.answerer.jobGroup)
-					.otherwise(chatInquiry.inquirer.jobGroup),
-				new CaseBuilder()
-					.when(chatInquiry.inquirer.id.eq(member.getId()))
-					.then(chatInquiry.answerer.profileImageNo)
-					.otherwise(chatInquiry.inquirer.profileImageNo)
+					.otherwise(false)
 			))
 			.from(chatInquiry)
 			.where(chatInquiry.inquirer.id.eq(member.getId())

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.dnd.gongmuin.chat_inquiry.domain.ChatInquiry;
 import com.dnd.gongmuin.chat_inquiry.dto.AcceptChatResponse;
+import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryDetailResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryMapper;
 import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.CreateChatInquiryRequest;
@@ -68,6 +69,17 @@ public class ChatInquiryService {
 		creditHistoryService.saveChatCreditHistory(CreditType.CHAT_REQUEST, inquirer);
 
 		return ChatInquiryMapper.toCreateChatInquiryResponse(chatInquiry);
+	}
+
+	@Transactional(readOnly = true)
+	public ChatInquiryDetailResponse getChatInquiryById(Long chatInquiryId, Member member) {
+		ChatInquiry chatInquiry = getChatInquiryById(chatInquiryId);
+
+		return ChatInquiryMapper.toChatInquiryDetailResponse(
+			chatInquiry,
+			chatInquiry.getChatPartner(member),
+			chatInquiry.isInquirer(member)
+		);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/dnd/gongmuin/chatroom/domain/ChatRoom.java
+++ b/src/main/java/com/dnd/gongmuin/chatroom/domain/ChatRoom.java
@@ -58,4 +58,12 @@ public class ChatRoom extends TimeBaseEntity {
 	) {
 		return new ChatRoom(questionPost, inquirer, answerer);
 	}
+
+	public boolean isInquirer(Member member) {
+		return member.equals(this.inquirer);
+	}
+
+	public Member getChatPartner(Member member) {
+		return isInquirer(member) ? this.answerer : this.inquirer;
+	}
 }

--- a/src/main/java/com/dnd/gongmuin/chatroom/dto/ChatRoomMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chatroom/dto/ChatRoomMapper.java
@@ -6,8 +6,8 @@ import com.dnd.gongmuin.chatroom.dto.response.ChatRoomInfo;
 import com.dnd.gongmuin.chatroom.dto.response.ChatRoomSimpleResponse;
 import com.dnd.gongmuin.chatroom.dto.response.LatestChatMessage;
 import com.dnd.gongmuin.member.domain.Member;
+import com.dnd.gongmuin.member.dto.response.MemberInfo;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
-import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -29,10 +29,10 @@ public class ChatRoomMapper {
 
 	public static ChatRoomDetailResponse toChatRoomDetailResponse(
 		ChatRoom chatRoom,
-		Member chatPartner
+		Member chatPartner,
+		boolean isInquirer
 	) {
 		QuestionPost questionPost = chatRoom.getQuestionPost();
-		boolean isInquirer = !chatPartner.equals(chatRoom.getInquirer());
 		return new ChatRoomDetailResponse(
 			questionPost.getId(),
 			questionPost.getJobGroup().getLabel(),

--- a/src/main/java/com/dnd/gongmuin/chatroom/dto/response/ChatRoomDetailResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chatroom/dto/response/ChatRoomDetailResponse.java
@@ -1,6 +1,6 @@
 package com.dnd.gongmuin.chatroom.dto.response;
 
-import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
+import com.dnd.gongmuin.member.dto.response.MemberInfo;
 
 public record ChatRoomDetailResponse(
 	Long questionPostId,

--- a/src/main/java/com/dnd/gongmuin/chatroom/dto/response/ChatRoomSimpleResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chatroom/dto/response/ChatRoomSimpleResponse.java
@@ -1,6 +1,6 @@
 package com.dnd.gongmuin.chatroom.dto.response;
 
-import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
+import com.dnd.gongmuin.member.dto.response.MemberInfo;
 
 public record ChatRoomSimpleResponse(
 	Long chatRoomId,

--- a/src/main/java/com/dnd/gongmuin/chatroom/exception/ChatErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/chatroom/exception/ChatErrorCode.java
@@ -10,8 +10,7 @@ import lombok.RequiredArgsConstructor;
 public enum ChatErrorCode implements ErrorCode {
 
 	INVALID_MESSAGE_TYPE("메시지 타입을 올바르게 입력해주세요.", "CH_001"),
-	NOT_FOUND_CHAT_ROOM("해당 아이디의 채팅방이 존재하지 않습니다.", "CH_002"),
-	UNAUTHORIZED_CHAT_ROOM("채팅방 조회 권한이 없습니다.", "CH_003");
+	NOT_FOUND_CHAT_ROOM("해당 아이디의 채팅방이 존재하지 않습니다.", "CH_002");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/dnd/gongmuin/chatroom/service/ChatRoomService.java
@@ -25,7 +25,6 @@ import com.dnd.gongmuin.chatroom.repository.ChatRoomRepository;
 import com.dnd.gongmuin.common.dto.PageMapper;
 import com.dnd.gongmuin.common.dto.PageResponse;
 import com.dnd.gongmuin.common.exception.runtime.NotFoundException;
-import com.dnd.gongmuin.common.exception.runtime.ValidationException;
 import com.dnd.gongmuin.member.domain.Member;
 
 import lombok.RequiredArgsConstructor;
@@ -73,8 +72,12 @@ public class ChatRoomService {
 	@Transactional(readOnly = true)
 	public ChatRoomDetailResponse getChatRoomById(Long chatRoomId, Member member) {
 		ChatRoom chatRoom = getChatRoomById(chatRoomId);
-		Member chatPartner = getChatPartner(member, chatRoom);
-		return ChatRoomMapper.toChatRoomDetailResponse(chatRoom, chatPartner);
+
+		return ChatRoomMapper.toChatRoomDetailResponse(
+			chatRoom,
+			chatRoom.getChatPartner(member),
+			chatRoom.isInquirer(member)
+		);
 	}
 
 	private List<ChatRoomSimpleResponse> getChatRoomSimpleResponses(List<LatestChatMessage> latestChatMessages,
@@ -100,15 +103,5 @@ public class ChatRoomService {
 	private ChatRoom getChatRoomById(Long id) {
 		return chatRoomRepository.findById(id)
 			.orElseThrow(() -> new NotFoundException(ChatErrorCode.NOT_FOUND_CHAT_ROOM));
-	}
-
-	private Member getChatPartner(Member member, ChatRoom chatRoom) {
-		if (member.equals(chatRoom.getAnswerer())) {
-			return chatRoom.getInquirer();
-		}
-		if (member.equals(chatRoom.getInquirer())) {
-			return chatRoom.getAnswerer();
-		}
-		throw new ValidationException(ChatErrorCode.UNAUTHORIZED_CHAT_ROOM);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/member/dto/response/MemberInfo.java
+++ b/src/main/java/com/dnd/gongmuin/member/dto/response/MemberInfo.java
@@ -1,4 +1,4 @@
-package com.dnd.gongmuin.question_post.dto.response;
+package com.dnd.gongmuin.member.dto.response;
 
 public record MemberInfo(
 	Long memberId,

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
@@ -6,10 +6,10 @@ import java.util.List;
 
 import com.dnd.gongmuin.member.domain.JobGroup;
 import com.dnd.gongmuin.member.domain.Member;
+import com.dnd.gongmuin.member.dto.response.MemberInfo;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.domain.QuestionPostImage;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
-import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.RegisterQuestionPostResponse;
 import com.dnd.gongmuin.question_post.dto.response.UpdateQuestionPostResponse;

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostDetailResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostDetailResponse.java
@@ -2,6 +2,8 @@ package com.dnd.gongmuin.question_post.dto.response;
 
 import java.util.List;
 
+import com.dnd.gongmuin.member.dto.response.MemberInfo;
+
 public record QuestionPostDetailResponse(
 	Long questionPostId,
 	String title,

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/RegisterQuestionPostResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/RegisterQuestionPostResponse.java
@@ -2,6 +2,8 @@ package com.dnd.gongmuin.question_post.dto.response;
 
 import java.util.List;
 
+import com.dnd.gongmuin.member.dto.response.MemberInfo;
+
 public record RegisterQuestionPostResponse(
 	Long questionPostId,
 	String title,

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepository.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepository.java
@@ -1,6 +1,7 @@
 package com.dnd.gongmuin.question_post.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -16,7 +17,11 @@ public interface QuestionPostRepository extends JpaRepository<QuestionPost, Long
 
 	List<QuestionPost> findAllByMember(Member member);
 
+	@Query("select q from QuestionPost q "
+		+ "join fetch q.member where q.id = :questionPostId")
+	Optional<QuestionPost> findByIdWithMember(Long questionPostId);
+
 	@Modifying(flushAutomatically = true, clearAutomatically = true)
 	@Query("UPDATE QuestionPost q SET q.member = :member WHERE q.member.id = :memberId")
-	public void updateQuestionPostsMember(Long memberId, Member member);
+	void updateQuestionPostsMember(Long memberId, Member member);
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostSimpleQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostSimpleQueryRepository.java
@@ -1,0 +1,28 @@
+package com.dnd.gongmuin.question_post.repository;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.dnd.gongmuin.question_post.domain.QuestionPost;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class QuestionPostSimpleQueryRepository {
+
+	private final EntityManager em;
+
+	public Optional<QuestionPost> findQuestionPostById(Long questionPostId) {
+		QuestionPost questionPost = em.createQuery(
+				"select q from QuestionPost q" +
+					" join fetch q.member m" +
+					" where q.id = :questionPostId", QuestionPost.class
+			)
+			.setParameter("questionPostId", questionPostId)
+			.getSingleResult();
+		return Optional.of(questionPost);
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/security/handler/CustomOauth2SuccessHandler.java
+++ b/src/main/java/com/dnd/gongmuin/security/handler/CustomOauth2SuccessHandler.java
@@ -42,8 +42,8 @@ public class CustomOauth2SuccessHandler implements AuthenticationSuccessHandler 
 		Member findmember = memberRepository.findBySocialEmail(socialEmail)
 			.orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
 
-		String token = tokenProvider.generateAccessToken(customOauth2User, new Date());
-		tokenProvider.generateRefreshToken(customOauth2User, new Date());
+		String token = tokenProvider.generateAccessToken(findmember, customOauth2User, new Date());
+		tokenProvider.generateRefreshToken(findmember, customOauth2User, new Date());
 
 		response.addCookie(cookieUtil.createCookie(token));
 

--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenProvider.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenProvider.java
@@ -54,12 +54,12 @@ public class TokenProvider {
 		this.secretKey = Keys.hmacShaKeyFor(key.getBytes());
 	}
 
-	public String generateAccessToken(CustomOauth2User authentication, Date now) {
-		return generateToken(authentication, ACCESS_TOKEN_EXPIRE_TIME, now);
+	public String generateAccessToken(Member findMember, CustomOauth2User authentication, Date now) {
+		return generateToken(findMember, authentication, ACCESS_TOKEN_EXPIRE_TIME, now);
 	}
 
-	public String generateRefreshToken(CustomOauth2User authentication, Date now) {
-		String refreshToken = generateToken(authentication, REFRESH_TOKEN_EXPIRE_TIME, now);
+	public String generateRefreshToken(Member findMember, CustomOauth2User authentication, Date now) {
+		String refreshToken = generateToken(findMember, authentication, REFRESH_TOKEN_EXPIRE_TIME, now);
 
 		// redis Refresh 저장
 		redisUtil.setValues("RT:" + authentication.getEmail(), refreshToken,
@@ -67,12 +67,12 @@ public class TokenProvider {
 		return refreshToken;
 	}
 
-	private String generateToken(CustomOauth2User authentication, long tokenExpireTime, Date now) {
+	private String generateToken(Member findMember, CustomOauth2User authentication, long tokenExpireTime, Date now) {
 		Date expiredTime = createExpiredDateWithTokenType(now, tokenExpireTime);
 		String authorities = getAuthorities(authentication);
 
 		return Jwts.builder()
-			.subject(authentication.getEmail())
+			.subject(String.valueOf(findMember.getId()))
 			.claim(ROLE_KEY, authorities)
 			.issuedAt(now)
 			.expiration(expiredTime)
@@ -94,8 +94,8 @@ public class TokenProvider {
 		Claims claims = parseToken(token);
 		List<SimpleGrantedAuthority> authorities = getAuthorities(claims);
 
-		String socialEmail = claims.getSubject();
-		Member principal = memberRepository.findBySocialEmail(socialEmail)
+		String subject = claims.getSubject();
+		Member principal = memberRepository.findById(Long.valueOf(subject))
 			.orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
 
 		return new UsernamePasswordAuthenticationToken(principal, token, authorities);

--- a/src/test/java/com/dnd/gongmuin/answer/controller/AnswerControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/answer/controller/AnswerControllerTest.java
@@ -125,7 +125,6 @@ class AnswerControllerTest extends ApiTestSupport {
 			= questionPostRepository.save(QuestionPostFixture.questionPost(loginMember));
 		Member answerer = memberRepository.save(MemberFixture.member2());
 		Answer answer = answerRepository.save(AnswerFixture.answer(questionPost.getId(), answerer));
-		long startTime = System.currentTimeMillis();
 
 		mockMvc.perform(post("/api/question-posts/answers/{answerId}", answer.getId())
 				.cookie(accessToken)
@@ -138,7 +137,5 @@ class AnswerControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.memberInfo.nickname").value(answerer.getNickname()))
 			.andExpect(jsonPath("$.memberInfo.memberJobGroup").value(answerer.getJobGroup().getLabel())
 			);
-		long endTime = System.currentTimeMillis();
-		System.out.println("Execution time: " + (endTime - startTime) + " ms");
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/answer/controller/AnswerControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/answer/controller/AnswerControllerTest.java
@@ -125,6 +125,7 @@ class AnswerControllerTest extends ApiTestSupport {
 			= questionPostRepository.save(QuestionPostFixture.questionPost(loginMember));
 		Member answerer = memberRepository.save(MemberFixture.member2());
 		Answer answer = answerRepository.save(AnswerFixture.answer(questionPost.getId(), answerer));
+		long startTime = System.currentTimeMillis();
 
 		mockMvc.perform(post("/api/question-posts/answers/{answerId}", answer.getId())
 				.cookie(accessToken)
@@ -137,5 +138,31 @@ class AnswerControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.memberInfo.nickname").value(answerer.getNickname()))
 			.andExpect(jsonPath("$.memberInfo.memberJobGroup").value(answerer.getJobGroup().getLabel())
 			);
+		long endTime = System.currentTimeMillis();
+		System.out.println("Execution time: " + (endTime - startTime) + " ms");
+	}
+
+	@DisplayName("[질문자는 답변을 채택할 수 있다.V2]")
+	@Test
+	void chooseAnswerV2() throws Exception {
+		QuestionPost questionPost
+			= questionPostRepository.save(QuestionPostFixture.questionPost(loginMember));
+		Member answerer = memberRepository.save(MemberFixture.member2());
+		Answer answer = answerRepository.save(AnswerFixture.answer(questionPost.getId(), answerer));
+		long startTime = System.currentTimeMillis();
+
+		mockMvc.perform(post("/api/v2/question-posts/answers/{answerId}", answer.getId())
+				.cookie(accessToken)
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.content").value(answer.getContent()))
+			.andExpect(jsonPath("$.isChosen").value(true))
+			.andExpect(jsonPath("$.isQuestioner").value(false))
+			.andExpect(jsonPath("$.memberInfo.memberId").value(answerer.getId()))
+			.andExpect(jsonPath("$.memberInfo.nickname").value(answerer.getNickname()))
+			.andExpect(jsonPath("$.memberInfo.memberJobGroup").value(answerer.getJobGroup().getLabel())
+			);
+		long endTime = System.currentTimeMillis();
+		System.out.println("Execution time: " + (endTime - startTime) + " ms");
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/answer/controller/AnswerControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/answer/controller/AnswerControllerTest.java
@@ -141,28 +141,4 @@ class AnswerControllerTest extends ApiTestSupport {
 		long endTime = System.currentTimeMillis();
 		System.out.println("Execution time: " + (endTime - startTime) + " ms");
 	}
-
-	@DisplayName("[질문자는 답변을 채택할 수 있다.V2]")
-	@Test
-	void chooseAnswerV2() throws Exception {
-		QuestionPost questionPost
-			= questionPostRepository.save(QuestionPostFixture.questionPost(loginMember));
-		Member answerer = memberRepository.save(MemberFixture.member2());
-		Answer answer = answerRepository.save(AnswerFixture.answer(questionPost.getId(), answerer));
-		long startTime = System.currentTimeMillis();
-
-		mockMvc.perform(post("/api/v2/question-posts/answers/{answerId}", answer.getId())
-				.cookie(accessToken)
-			)
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.content").value(answer.getContent()))
-			.andExpect(jsonPath("$.isChosen").value(true))
-			.andExpect(jsonPath("$.isQuestioner").value(false))
-			.andExpect(jsonPath("$.memberInfo.memberId").value(answerer.getId()))
-			.andExpect(jsonPath("$.memberInfo.nickname").value(answerer.getNickname()))
-			.andExpect(jsonPath("$.memberInfo.memberJobGroup").value(answerer.getJobGroup().getLabel())
-			);
-		long endTime = System.currentTimeMillis();
-		System.out.println("Execution time: " + (endTime - startTime) + " ms");
-	}
 }

--- a/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,7 +29,6 @@ import com.dnd.gongmuin.answer.domain.Answer;
 import com.dnd.gongmuin.answer.dto.AnswerDetailResponse;
 import com.dnd.gongmuin.answer.dto.RegisterAnswerRequest;
 import com.dnd.gongmuin.answer.repository.AnswerRepository;
-import com.dnd.gongmuin.answer.repository.AnswerSimpleQueryRepository;
 import com.dnd.gongmuin.common.dto.PageResponse;
 import com.dnd.gongmuin.common.exception.runtime.ValidationException;
 import com.dnd.gongmuin.common.fixture.AnswerFixture;
@@ -41,7 +41,6 @@ import com.dnd.gongmuin.notification.service.NotificationService;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.exception.QuestionPostErrorCode;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
-import com.dnd.gongmuin.question_post.repository.QuestionPostSimpleQueryRepository;
 
 @DisplayName("[AnswerService 테스트]")
 @ExtendWith(MockitoExtension.class)
@@ -53,13 +52,7 @@ class AnswerServiceTest {
 	private QuestionPostRepository questionPostRepository;
 
 	@Mock
-	private QuestionPostSimpleQueryRepository questionPostSimpleQueryRepository;
-
-	@Mock
 	private AnswerRepository answerRepository;
-
-	@Mock
-	private AnswerSimpleQueryRepository answerSimpleQueryRepository;
 
 	@Mock
 	private CreditHistoryService creditHistoryService;
@@ -130,9 +123,9 @@ class AnswerServiceTest {
 		QuestionPost questionPost = QuestionPostFixture.questionPost(questionPostId, member);
 		Answer answer = AnswerFixture.answer(1L, questionPostId);
 
-		given(answerSimpleQueryRepository.findAnswerById(answer.getId()))
+		given(answerRepository.findByIdWithMember(answer.getId()))
 			.willReturn(Optional.of(answer));
-		given(questionPostSimpleQueryRepository.findQuestionPostById(questionPost.getId()))
+		given(questionPostRepository.findByIdWithMember(questionPost.getId()))
 			.willReturn(Optional.of(questionPost));
 
 		//when
@@ -152,9 +145,9 @@ class AnswerServiceTest {
 		ReflectionTestUtils.setField(questionPost, "reward", member.getCredit() + 1);
 		Answer answer = AnswerFixture.answer(1L, questionPostId);
 
-		given(answerSimpleQueryRepository.findAnswerById(answer.getId()))
+		given(answerRepository.findByIdWithMember(answer.getId()))
 			.willReturn(Optional.of(answer));
-		given(questionPostSimpleQueryRepository.findQuestionPostById(questionPost.getId()))
+		given(questionPostRepository.findByIdWithMember(questionPost.getId()))
 			.willReturn(Optional.of(questionPost));
 
 		//when & then
@@ -174,9 +167,9 @@ class AnswerServiceTest {
 		QuestionPost questionPost = QuestionPostFixture.questionPost(questionPostId, questioner);
 		Answer answer = AnswerFixture.answer(1L, questionPostId);
 
-		given(answerSimpleQueryRepository.findAnswerById(answer.getId()))
+		given(answerRepository.findByIdWithMember(answer.getId()))
 			.willReturn(Optional.of(answer));
-		given(questionPostSimpleQueryRepository.findQuestionPostById(questionPost.getId()))
+		given(questionPostRepository.findByIdWithMember(questionPost.getId()))
 			.willReturn(Optional.of(questionPost));
 
 		//when & then
@@ -185,6 +178,7 @@ class AnswerServiceTest {
 			.hasMessageContaining(QuestionPostErrorCode.NOT_AUTHORIZED.getMessage());
 	}
 
+	@Disabled
 	@DisplayName("[동시에 10_000개의 채택이 일어나 크레딧을 입금 받는다.]")
 	@Test
 	void creditHistoryWithOneHundred() throws Exception {
@@ -210,8 +204,8 @@ class AnswerServiceTest {
 			questionPosts.add(questionPost);
 			answers.add(answer1);
 
-			given(answerSimpleQueryRepository.findAnswerById(i)).willReturn(Optional.of(answer1));
-			given(questionPostSimpleQueryRepository.findQuestionPostById(questionPost.getId()))
+			given(answerRepository.findByIdWithMember(i)).willReturn(Optional.of(answer1));
+			given(questionPostRepository.findByIdWithMember(questionPost.getId()))
 				.willReturn(Optional.of(questionPost));
 		}
 

--- a/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
@@ -142,27 +142,6 @@ class AnswerServiceTest {
 		Assertions.assertThat(response.isChosen()).isTrue();
 	}
 
-	@DisplayName("[답변을 채택할 수 있다.]")
-	@Test
-	void chooseAnswerV2() {
-		//given
-		Long questionPostId = 1L;
-		Member member = MemberFixture.member(1L);
-		QuestionPost questionPost = QuestionPostFixture.questionPost(questionPostId, member);
-		Answer answer = AnswerFixture.answer(1L, questionPostId);
-
-		given(answerSimpleQueryRepository.findAnswerById(answer.getId()))
-			.willReturn(Optional.of(answer));
-		given(questionPostSimpleQueryRepository.findQuestionPostById(questionPost.getId()))
-			.willReturn(Optional.of(questionPost));
-
-		//when
-		AnswerDetailResponse response = answerService.chooseAnswerV2(answer.getId(), member);
-
-		//then
-		Assertions.assertThat(response.isChosen()).isTrue();
-	}
-
 	@DisplayName("[크레딧이 부족하면 답변을 채택할 수 없다.]")
 	@Test
 	void chooseAnswer_fail() {

--- a/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
@@ -130,9 +130,9 @@ class AnswerServiceTest {
 		QuestionPost questionPost = QuestionPostFixture.questionPost(questionPostId, member);
 		Answer answer = AnswerFixture.answer(1L, questionPostId);
 
-		given(answerRepository.findById(answer.getId()))
+		given(answerSimpleQueryRepository.findAnswerById(answer.getId()))
 			.willReturn(Optional.of(answer));
-		given(questionPostRepository.findById(questionPost.getId()))
+		given(questionPostSimpleQueryRepository.findQuestionPostById(questionPost.getId()))
 			.willReturn(Optional.of(questionPost));
 
 		//when
@@ -152,9 +152,9 @@ class AnswerServiceTest {
 		ReflectionTestUtils.setField(questionPost, "reward", member.getCredit() + 1);
 		Answer answer = AnswerFixture.answer(1L, questionPostId);
 
-		given(answerRepository.findById(answer.getId()))
+		given(answerSimpleQueryRepository.findAnswerById(answer.getId()))
 			.willReturn(Optional.of(answer));
-		given(questionPostRepository.findById(questionPost.getId()))
+		given(questionPostSimpleQueryRepository.findQuestionPostById(questionPost.getId()))
 			.willReturn(Optional.of(questionPost));
 
 		//when & then
@@ -174,9 +174,9 @@ class AnswerServiceTest {
 		QuestionPost questionPost = QuestionPostFixture.questionPost(questionPostId, questioner);
 		Answer answer = AnswerFixture.answer(1L, questionPostId);
 
-		given(answerRepository.findById(answer.getId()))
+		given(answerSimpleQueryRepository.findAnswerById(answer.getId()))
 			.willReturn(Optional.of(answer));
-		given(questionPostRepository.findById(questionPost.getId()))
+		given(questionPostSimpleQueryRepository.findQuestionPostById(questionPost.getId()))
 			.willReturn(Optional.of(questionPost));
 
 		//when & then
@@ -210,8 +210,9 @@ class AnswerServiceTest {
 			questionPosts.add(questionPost);
 			answers.add(answer1);
 
-			given(answerRepository.findById(i)).willReturn(Optional.of(answer1));
-			given(questionPostRepository.findById(questionPost.getId())).willReturn(Optional.of(questionPost));
+			given(answerSimpleQueryRepository.findAnswerById(i)).willReturn(Optional.of(answer1));
+			given(questionPostSimpleQueryRepository.findQuestionPostById(questionPost.getId()))
+				.willReturn(Optional.of(questionPost));
 		}
 
 		// when

--- a/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
@@ -4,8 +4,12 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -171,5 +175,56 @@ class AnswerServiceTest {
 		assertThatThrownBy(() -> answerService.chooseAnswer(answer.getId(), notQuestioner))
 			.isInstanceOf(ValidationException.class)
 			.hasMessageContaining(QuestionPostErrorCode.NOT_AUTHORIZED.getMessage());
+	}
+
+	@DisplayName("[동시간대에 100명의 사용자에게 입금을 받는다.]")
+	@Test
+	void creditHistoryWithOneHundred() throws Exception {
+		// given
+		final long threadCount = 10_000L;
+		final int writerCredit = 10_000_000;
+		ExecutorService executorService = Executors.newFixedThreadPool(32);
+		CountDownLatch latch = new CountDownLatch((int)threadCount);
+
+		Member writer = MemberFixture.member(1L);
+		Member answer = MemberFixture.member(2L);
+		ReflectionTestUtils.setField(writer, "credit", writerCredit);
+		ReflectionTestUtils.setField(answer, "credit", 0);
+
+		List<QuestionPost> questionPosts = new ArrayList<>();
+		List<Answer> answers = new ArrayList<>();
+
+		for (long i = 1L; i <= threadCount; i++) {
+			QuestionPost questionPost = QuestionPostFixture.questionPost(i, writer);
+
+			Answer answer1 = AnswerFixture.answer(questionPost.getId(), answer);
+			ReflectionTestUtils.setField(answer1, "id", i);
+			questionPosts.add(questionPost);
+			answers.add(answer1);
+
+			given(answerRepository.findById(i)).willReturn(Optional.of(answer1));
+			given(questionPostRepository.findById(questionPost.getId())).willReturn(Optional.of(questionPost));
+		}
+
+		// when
+		long startTime = System.currentTimeMillis();
+		for (long i = 0L; i < threadCount; i++) {
+			final int index = (int)i;
+			executorService.submit(() -> {
+				try {
+					answerService.chooseAnswer(answers.get(index).getId(), writer);
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+		latch.await();
+
+		long endTime = System.currentTimeMillis();
+
+		System.out.println("Execution time: " + (endTime - startTime) + " ms");
+
+		// then
+		assertEquals(answer.getCredit(), writerCredit);
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
@@ -28,6 +28,7 @@ import com.dnd.gongmuin.answer.domain.Answer;
 import com.dnd.gongmuin.answer.dto.AnswerDetailResponse;
 import com.dnd.gongmuin.answer.dto.RegisterAnswerRequest;
 import com.dnd.gongmuin.answer.repository.AnswerRepository;
+import com.dnd.gongmuin.answer.repository.AnswerSimpleQueryRepository;
 import com.dnd.gongmuin.common.dto.PageResponse;
 import com.dnd.gongmuin.common.exception.runtime.ValidationException;
 import com.dnd.gongmuin.common.fixture.AnswerFixture;
@@ -40,6 +41,7 @@ import com.dnd.gongmuin.notification.service.NotificationService;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.exception.QuestionPostErrorCode;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
+import com.dnd.gongmuin.question_post.repository.QuestionPostSimpleQueryRepository;
 
 @DisplayName("[AnswerService 테스트]")
 @ExtendWith(MockitoExtension.class)
@@ -51,7 +53,13 @@ class AnswerServiceTest {
 	private QuestionPostRepository questionPostRepository;
 
 	@Mock
+	private QuestionPostSimpleQueryRepository questionPostSimpleQueryRepository;
+
+	@Mock
 	private AnswerRepository answerRepository;
+
+	@Mock
+	private AnswerSimpleQueryRepository answerSimpleQueryRepository;
 
 	@Mock
 	private CreditHistoryService creditHistoryService;
@@ -134,6 +142,27 @@ class AnswerServiceTest {
 		Assertions.assertThat(response.isChosen()).isTrue();
 	}
 
+	@DisplayName("[답변을 채택할 수 있다.]")
+	@Test
+	void chooseAnswerV2() {
+		//given
+		Long questionPostId = 1L;
+		Member member = MemberFixture.member(1L);
+		QuestionPost questionPost = QuestionPostFixture.questionPost(questionPostId, member);
+		Answer answer = AnswerFixture.answer(1L, questionPostId);
+
+		given(answerSimpleQueryRepository.findAnswerById(answer.getId()))
+			.willReturn(Optional.of(answer));
+		given(questionPostSimpleQueryRepository.findQuestionPostById(questionPost.getId()))
+			.willReturn(Optional.of(questionPost));
+
+		//when
+		AnswerDetailResponse response = answerService.chooseAnswerV2(answer.getId(), member);
+
+		//then
+		Assertions.assertThat(response.isChosen()).isTrue();
+	}
+
 	@DisplayName("[크레딧이 부족하면 답변을 채택할 수 없다.]")
 	@Test
 	void chooseAnswer_fail() {
@@ -177,7 +206,7 @@ class AnswerServiceTest {
 			.hasMessageContaining(QuestionPostErrorCode.NOT_AUTHORIZED.getMessage());
 	}
 
-	@DisplayName("[동시간대에 100명의 사용자에게 입금을 받는다.]")
+	@DisplayName("[동시에 10_000개의 채택이 일어나 크레딧을 입금 받는다.]")
 	@Test
 	void creditHistoryWithOneHundred() throws Exception {
 		// given
@@ -221,7 +250,6 @@ class AnswerServiceTest {
 		latch.await();
 
 		long endTime = System.currentTimeMillis();
-
 		System.out.println("Execution time: " + (endTime - startTime) + " ms");
 
 		// then

--- a/src/test/java/com/dnd/gongmuin/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/auth/controller/AuthControllerTest.java
@@ -102,7 +102,7 @@ class AuthControllerTest extends ApiTestSupport {
 			savedMember.getSocialEmail(),
 			savedMember.getRole()
 		);
-		String token = tokenProvider.generateAccessToken(new CustomOauth2User(authInfo), new Date());
+		String token = tokenProvider.generateAccessToken(savedMember, new CustomOauth2User(authInfo), new Date());
 		this.loginMember = savedMember;
 		this.accessToken = new Cookie("Authorization", token);
 

--- a/src/test/java/com/dnd/gongmuin/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/auth/service/AuthServiceTest.java
@@ -174,10 +174,16 @@ class AuthServiceTest {
 		given(cookieUtil.createCookie(anyString())).willReturn(new Cookie("Authorization", "reissueToken"));
 		given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
 		given(redisUtil.getValues(anyString())).willReturn("refreshToken");
-		given(tokenProvider.generateAccessToken(any(CustomOauth2User.class), any(Date.class))).willReturn(
-			"reissueToken");
-		given(tokenProvider.generateRefreshToken(any(CustomOauth2User.class), any(Date.class))).willReturn(
-			"reissueToken");
+		given(tokenProvider.generateAccessToken(
+			any(Member.class),
+			any(CustomOauth2User.class),
+			any(Date.class)))
+			.willReturn("reissueToken");
+		given(tokenProvider.generateRefreshToken(
+			any(Member.class),
+			any(CustomOauth2User.class),
+			any(Date.class)))
+			.willReturn("reissueToken");
 
 		// when
 		ReissueResponse response = authService.reissue(mockRequest, mockResponse);

--- a/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat/service/ChatRoomServiceTest.java
@@ -24,12 +24,10 @@ import com.dnd.gongmuin.chatroom.dto.response.ChatRoomDetailResponse;
 import com.dnd.gongmuin.chatroom.dto.response.ChatRoomInfo;
 import com.dnd.gongmuin.chatroom.dto.response.ChatRoomSimpleResponse;
 import com.dnd.gongmuin.chatroom.dto.response.LatestChatMessage;
-import com.dnd.gongmuin.chatroom.exception.ChatErrorCode;
 import com.dnd.gongmuin.chatroom.repository.ChatMessageQueryRepository;
 import com.dnd.gongmuin.chatroom.repository.ChatMessageRepository;
 import com.dnd.gongmuin.chatroom.repository.ChatRoomRepository;
 import com.dnd.gongmuin.chatroom.service.ChatRoomService;
-import com.dnd.gongmuin.common.exception.runtime.ValidationException;
 import com.dnd.gongmuin.common.fixture.ChatMessageFixture;
 import com.dnd.gongmuin.common.fixture.ChatRoomFixture;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
@@ -157,25 +155,5 @@ class ChatRoomServiceTest {
 			() -> assertThat(response.chatPartner().memberId())
 				.isEqualTo(inquirer.getId())
 		);
-	}
-
-	@DisplayName("[채팅방에 속하지 않은 사람은 채팅방을 조회할 수 없다.]")
-	@Test
-	void getChatRoomById_Unauthorized() {
-		//given
-		Long chatRoomId = 1L;
-		Member inquirer = MemberFixture.member(1L);
-		Member answerer = MemberFixture.member(2L);
-		Member unrelatedMember = MemberFixture.member(3L);
-		QuestionPost questionPost = QuestionPostFixture.questionPost(inquirer);
-		ChatRoom chatRoom = ChatRoomFixture.chatRoom(questionPost, inquirer, answerer);
-
-		given(chatRoomRepository.findById(chatRoomId))
-			.willReturn(Optional.of(chatRoom));
-
-		//when & then
-		assertThatThrownBy(() -> chatRoomService.getChatRoomById(chatRoomId, unrelatedMember))
-			.isInstanceOf(ValidationException.class)
-			.hasMessageContaining(ChatErrorCode.UNAUTHORIZED_CHAT_ROOM.getMessage());
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/controller/ChatInquiryControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/controller/ChatInquiryControllerTest.java
@@ -57,6 +57,7 @@ class ChatInquiryControllerTest extends ApiTestSupport {
 		creditHistoryRepository.deleteAll();
 		memberRepository.deleteAll();
 		questionPostRepository.deleteAll();
+		chatInquiryRepository.deleteAll();
 		chatRoomRepository.deleteAll();
 		chatMessageRepository.deleteAll();
 	}
@@ -80,6 +81,32 @@ class ChatInquiryControllerTest extends ApiTestSupport {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.inquiryStatus").value(InquiryStatus.PENDING.getLabel())) // 내림차순
 			.andDo(MockMvcResultHandlers.print());
+	}
+
+	@DisplayName("[채팅 요청 아이디로 상세 채팅 요청을 조회할 수 있다.]")
+	@Test
+	void getChatInquiryById() throws Exception {
+		//given
+		Member chatPartner = memberRepository.save(MemberFixture.member5());
+		QuestionPost questionPost = questionPostRepository.save(QuestionPostFixture.questionPost(loginMember));
+		ChatInquiry chatInquiry = chatInquiryRepository.save(
+			ChatInquiryFixture.chatInquiry(questionPost, loginMember, chatPartner, INQUIRY_MESSAGE)
+		);
+
+		//when & then
+		mockMvc.perform(get("/api/chat/inquiries/{chatInquiryId}", chatInquiry.getId())
+				.cookie(accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.chatInquiryId")
+				.value(chatInquiry.getId()))
+			.andExpect(jsonPath("$.inquiryStatus")
+				.value(InquiryStatus.PENDING.getLabel()))
+			.andExpect(jsonPath("$.chatPartner.memberId")
+				.value(chatPartner.getId()))
+			.andExpect(jsonPath("$.isInquirer")
+				.value(chatInquiry.getInquirer().equals(loginMember)))
+			.andExpect(jsonPath("$.inquiryStatus")
+				.value(InquiryStatus.PENDING.getLabel()));
 	}
 
 	@DisplayName("[회원의 채팅 요청 목록을 조회할 수 있다.]")

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
@@ -141,10 +141,10 @@ class ChatInquiryServiceTest {
 		Long chatInquiryId = 1L;
 		Member targetMember = MemberFixture.member(1L);
 		Member partner = MemberFixture.member(2L);
-		ChatInquiryResponse chatInquiryResponse = new ChatInquiryResponse(
-			chatInquiryId, INQUIRY_MESSAGE, InquiryStatus.PENDING, true, partner.getId(),
-			partner.getNickname(), partner.getJobGroup(), partner.getProfileImageNo()
+		ChatInquiry chatInquiry = ChatInquiryFixture.chatInquiry(
+			1L, QuestionPostFixture.questionPost(targetMember), targetMember, partner, INQUIRY_MESSAGE
 		);
+		ChatInquiryResponse chatInquiryResponse = new ChatInquiryResponse(chatInquiry, true);
 		given(chatInquiryRepository.getChatInquiresByMember(targetMember, pageRequest))
 			.willReturn(new SliceImpl<>(List.of(chatInquiryResponse), pageRequest, false));
 

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.dnd.gongmuin.chat_inquiry.domain.ChatInquiry;
 import com.dnd.gongmuin.chat_inquiry.domain.InquiryStatus;
 import com.dnd.gongmuin.chat_inquiry.dto.AcceptChatResponse;
+import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryDetailResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.CreateChatInquiryRequest;
 import com.dnd.gongmuin.chat_inquiry.dto.CreateChatInquiryResponse;
@@ -134,6 +135,23 @@ class ChatInquiryServiceTest {
 			.hasMessageContaining(MemberErrorCode.NOT_ENOUGH_CREDIT.getMessage());
 	}
 
+	@DisplayName("[채팅 요청 아이디로 채팅 요청 상세를 조회할 수 있다.]")
+	@Test
+	void getChatInquiryById() {
+		//given
+		Member inquirer = MemberFixture.member(1L);
+		Member answerer = MemberFixture.member(2L);
+		given(chatInquiryRepository.findById(1L))
+			.willReturn(Optional.of(ChatInquiryFixture.chatInquiry(
+				1L, QuestionPostFixture.questionPost(inquirer), inquirer, answerer, INQUIRY_MESSAGE)
+			));
+		//when
+		ChatInquiryDetailResponse response = chatInquiryService.getChatInquiryById(1L, inquirer);
+
+		//then
+		assertThat(response.chatPartner().memberId()).isEqualTo(answerer.getId());
+	}
+
 	@DisplayName("[회원이 속한 채팅 요청 목록을 조회할 수 있다.]")
 	@Test
 	void getChatInquiresByMember() {
@@ -238,8 +256,7 @@ class ChatInquiryServiceTest {
 		RejectChatResponse response = chatInquiryService.rejectChat(chatInquiryId, answerer);
 
 		//then
-		assertThat(response.inquiryStatus())
-			.isEqualTo(InquiryStatus.REJECTED.getLabel());
+		assertThat(response.inquiryStatus()).isEqualTo(InquiryStatus.REJECTED.getLabel());
 	}
 
 	@DisplayName("[답변자가 채팅 요청을 거절할 때 채팅 거절 알림이 발행된다.]")

--- a/src/test/java/com/dnd/gongmuin/common/fixture/ChatInquiryFixture.java
+++ b/src/test/java/com/dnd/gongmuin/common/fixture/ChatInquiryFixture.java
@@ -1,5 +1,7 @@
 package com.dnd.gongmuin.common.fixture;
 
+import java.time.LocalDateTime;
+
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.dnd.gongmuin.chat_inquiry.domain.ChatInquiry;
@@ -40,6 +42,7 @@ public class ChatInquiryFixture {
 			message
 		);
 		ReflectionTestUtils.setField(chatInquiry, "id", id);
+		ReflectionTestUtils.setField(chatInquiry, "createdAt", LocalDateTime.now());
 		return chatInquiry;
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/common/support/ApiTestSupport.java
+++ b/src/test/java/com/dnd/gongmuin/common/support/ApiTestSupport.java
@@ -54,8 +54,8 @@ public abstract class ApiTestSupport extends TestContainerSupport {
 			savedMember.getSocialEmail(),
 			savedMember.getRole()
 		);
-		String token = tokenProvider.generateAccessToken(new CustomOauth2User(authInfo), new Date());
-		tokenProvider.generateRefreshToken(new CustomOauth2User(authInfo), new Date());
+		String token = tokenProvider.generateAccessToken(savedMember, new CustomOauth2User(authInfo), new Date());
+		tokenProvider.generateRefreshToken(savedMember, new CustomOauth2User(authInfo), new Date());
 		this.loginMember = savedMember;
 		this.accessToken = cookieUtil.createCookie(token);
 	}

--- a/src/test/java/com/dnd/gongmuin/security/jwt/TokenProviderTest.java
+++ b/src/test/java/com/dnd/gongmuin/security/jwt/TokenProviderTest.java
@@ -66,7 +66,7 @@ class TokenProviderTest {
 		CustomOauth2User authentication = new CustomOauth2User(authInfo);
 
 		// when
-		String accessToken = tokenProvider.generateAccessToken(authentication, now);
+		String accessToken = tokenProvider.generateAccessToken(MemberFixture.member(1L), authentication, now);
 		Claims claims = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(accessToken).getPayload();
 		Date expiration = claims.getExpiration();
 
@@ -85,7 +85,7 @@ class TokenProviderTest {
 		CustomOauth2User authentication = new CustomOauth2User(authInfo);
 
 		// when
-		String accessToken = tokenProvider.generateRefreshToken(authentication, now);
+		String accessToken = tokenProvider.generateRefreshToken(MemberFixture.member(1L), authentication, now);
 		Claims claims = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(accessToken).getPayload();
 		Date expiration = claims.getExpiration();
 
@@ -93,17 +93,17 @@ class TokenProviderTest {
 		assertThat(expiration.getTime()).isCloseTo(expectedExpirationTime, within(1000L));
 	}
 
-	@DisplayName("토큰 파싱을 통해 만들어진 인증 객체의 이메일은 토큰 정보의 이메일 값과 동일하다.")
+	@DisplayName("토큰 파싱을 통해 만들어진 인증 객체의 이메일은 회원 이메일과 동일하다.")
 	@Test
 	void getAuthentication() {
 		// given
 		Date now = new Date();
 
-		Member member = MemberFixture.member();
+		Member member = MemberFixture.member(1L);
 		CustomOauth2User customOauth2User = new CustomOauth2User(authInfo);
-		String accessToken = tokenProvider.generateAccessToken(customOauth2User, now);
+		String accessToken = tokenProvider.generateAccessToken(member, customOauth2User, now);
 
-		given(memberRepository.findBySocialEmail(anyString())).willReturn(Optional.ofNullable(member));
+		given(memberRepository.findById(anyLong())).willReturn(Optional.ofNullable(member));
 
 		// when
 		Authentication authentication = tokenProvider.getAuthentication(accessToken);
@@ -121,7 +121,7 @@ class TokenProviderTest {
 		Date past = new Date(124, 6, 30, 16, 0, 0);
 
 		CustomOauth2User customOauth2User = new CustomOauth2User(authInfo);
-		String accessToken = tokenProvider.generateRefreshToken(customOauth2User, past);
+		String accessToken = tokenProvider.generateRefreshToken(MemberFixture.member(1L), customOauth2User, past);
 
 		// when
 		boolean result = tokenProvider.validateToken(accessToken, new Date());


### PR DESCRIPTION
### 관련 이슈
- close #148 

### 📑 작업 상세 내용
- 성능 최적화를 위한 문제 찾기 시도
   - 쿼리 개수
   - N+1
   - 병목 등
- 답변 채택 시 크레딧 정합성 테스트 작성
  - 정합성 테스트 성공
- 답변 채택 비즈니스 로직 쿼리 개수 개선
  - questionPost, Answer 조회 시 fetch join을 이용한 Member를 한번에 가져와서 getMember() 시 발생하는 회원 조회 쿼리 제거
  - 기존 답변 채택 API 호출 -> 총 쿼리 개수 11개
  - V2 답변 채택 API 호출 -> 총 쿼리 개수 9개

### 💫 작업 요약
- 성능 최적화를 위한 문제 찾기 시도
- 답변 채택 시 크레딧 정합성 테스트 작성(정합성 일치)
- 답변 채택 비즈니스 로직 쿼리 개수 개선(11개 -> 9개)

### 🔍 중점적으로 리뷰 할 부분
- 기존 API와 V2 API 처리 속도가 그렇게 큰 차이는 보이지 않습니다. 다만, 크게보았을 때 네트워크 비용을 절감하거나 약간의 성능 개선 등 장점이 있다고 생각합니다.
