### PR TITLE
[refactor #156] 채팅 요청 목록 API에서 채팅 파트너 조회 로직 리팩토링

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryResponse.java
@@ -1,7 +1,7 @@
 package com.dnd.gongmuin.chat_inquiry.dto;
 
-import com.dnd.gongmuin.chat_inquiry.domain.InquiryStatus;
-import com.dnd.gongmuin.member.domain.JobGroup;
+import com.dnd.gongmuin.chat_inquiry.domain.ChatInquiry;
+import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.question_post.dto.response.MemberInfo;
 import com.querydsl.core.annotations.QueryProjection;
 
@@ -15,26 +15,26 @@ public record ChatInquiryResponse(
 ) {
 	@QueryProjection
 	public ChatInquiryResponse(
-		Long chatInquiryId,
-		String inquiryMessage,
-		InquiryStatus inquiryStatus,
-		boolean isInquirer,
-		Long partnerId,
-		String partnerNickname,
-		JobGroup partnerJobGroup,
-		int partnerProfileImageNo
+		ChatInquiry chatInquiry,
+		boolean isInquirer
 	) {
 		this(
-			chatInquiryId,
-			inquiryMessage,
-			inquiryStatus.getLabel(),
+			chatInquiry.getId(),
+			chatInquiry.getMessage(),
+			chatInquiry.getStatus().getLabel(),
 			isInquirer,
-			new MemberInfo(
-				partnerId,
-				partnerNickname,
-				partnerJobGroup.getLabel(),
-				partnerProfileImageNo
-			)
+			createPartnerInfo(isInquirer, chatInquiry),
+			chatInquiry.getCreatedAt().toString()
+		);
+	}
+
+	private static MemberInfo createPartnerInfo(boolean isInquirer, ChatInquiry chatInquiry) {
+		Member partner = isInquirer ? chatInquiry.getAnswerer(): chatInquiry.getInquirer();
+		return new MemberInfo(
+			partner.getId(),
+			partner.getNickname(),
+			partner.getJobGroup().getLabel(),
+			partner.getProfileImageNo()
 		);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryResponse.java
@@ -29,7 +29,7 @@ public record ChatInquiryResponse(
 	}
 
 	private static MemberInfo createPartnerInfo(boolean isInquirer, ChatInquiry chatInquiry) {
-		Member partner = isInquirer ? chatInquiry.getAnswerer(): chatInquiry.getInquirer();
+		Member partner = isInquirer ? chatInquiry.getAnswerer() : chatInquiry.getInquirer();
 		return new MemberInfo(
 			partner.getId(),
 			partner.getNickname(),

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryResponse.java
@@ -10,7 +10,8 @@ public record ChatInquiryResponse(
 	String inquiryMessage,
 	String inquiryStatus,
 	boolean isInquirer,
-	MemberInfo chatPartner
+	MemberInfo chatPartner,
+	String createdAt
 ) {
 	@QueryProjection
 	public ChatInquiryResponse(

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepositoryImpl.java
@@ -26,29 +26,11 @@ public class ChatInquiryQueryRepositoryImpl implements ChatInquiryQueryRepositor
 	public Slice<ChatInquiryResponse> getChatInquiresByMember(Member member, Pageable pageable) {
 		List<ChatInquiryResponse> content = queryFactory
 			.select(new QChatInquiryResponse(
-				chatInquiry.id,
-				chatInquiry.message,
-				chatInquiry.status,
+				chatInquiry,
 				new CaseBuilder()
 					.when(chatInquiry.inquirer.id.eq(member.getId()))
 					.then(true)
-					.otherwise(false),
-				new CaseBuilder()
-					.when(chatInquiry.inquirer.id.eq(member.getId()))
-					.then(chatInquiry.answerer.id)
-					.otherwise(chatInquiry.inquirer.id),
-				new CaseBuilder()
-					.when(chatInquiry.inquirer.id.eq(member.getId()))
-					.then(chatInquiry.answerer.nickname)
-					.otherwise(chatInquiry.inquirer.nickname),
-				new CaseBuilder()
-					.when(chatInquiry.inquirer.id.eq(member.getId()))
-					.then(chatInquiry.answerer.jobGroup)
-					.otherwise(chatInquiry.inquirer.jobGroup),
-				new CaseBuilder()
-					.when(chatInquiry.inquirer.id.eq(member.getId()))
-					.then(chatInquiry.answerer.profileImageNo)
-					.otherwise(chatInquiry.inquirer.profileImageNo)
+					.otherwise(false)
 			))
 			.from(chatInquiry)
 			.where(chatInquiry.inquirer.id.eq(member.getId())

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
@@ -142,7 +142,7 @@ class ChatInquiryServiceTest {
 		Member targetMember = MemberFixture.member(1L);
 		Member partner = MemberFixture.member(2L);
 		ChatInquiry chatInquiry = ChatInquiryFixture.chatInquiry(
-			QuestionPostFixture.questionPost(targetMember), targetMember, partner, INQUIRY_MESSAGE
+			1L, QuestionPostFixture.questionPost(targetMember), targetMember, partner, INQUIRY_MESSAGE
 		);
 		ChatInquiryResponse chatInquiryResponse = new ChatInquiryResponse(chatInquiry, true);
 		given(chatInquiryRepository.getChatInquiresByMember(targetMember, pageRequest))

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
@@ -141,10 +141,10 @@ class ChatInquiryServiceTest {
 		Long chatInquiryId = 1L;
 		Member targetMember = MemberFixture.member(1L);
 		Member partner = MemberFixture.member(2L);
-		ChatInquiryResponse chatInquiryResponse = new ChatInquiryResponse(
-			chatInquiryId, INQUIRY_MESSAGE, InquiryStatus.PENDING, true, partner.getId(),
-			partner.getNickname(), partner.getJobGroup(), partner.getProfileImageNo()
+		ChatInquiry chatInquiry = ChatInquiryFixture.chatInquiry(
+			QuestionPostFixture.questionPost(targetMember), targetMember, partner, INQUIRY_MESSAGE
 		);
+		ChatInquiryResponse chatInquiryResponse = new ChatInquiryResponse(chatInquiry, true);
 		given(chatInquiryRepository.getChatInquiresByMember(targetMember, pageRequest))
 			.willReturn(new SliceImpl<>(List.of(chatInquiryResponse), pageRequest, false));
 

--- a/src/test/java/com/dnd/gongmuin/common/fixture/ChatInquiryFixture.java
+++ b/src/test/java/com/dnd/gongmuin/common/fixture/ChatInquiryFixture.java
@@ -1,5 +1,7 @@
 package com.dnd.gongmuin.common.fixture;
 
+import java.time.LocalDateTime;
+
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.dnd.gongmuin.chat_inquiry.domain.ChatInquiry;
@@ -40,6 +42,7 @@ public class ChatInquiryFixture {
 			message
 		);
 		ReflectionTestUtils.setField(chatInquiry, "id", id);
+		ReflectionTestUtils.setField(chatInquiry, "createdAt", LocalDateTime.now());
 		return chatInquiry;
 	}
 }


### PR DESCRIPTION
### 관련 이슈
- close #156 

### 📑 작업 상세 내용
- 채팅 요청 조회 시 repository에서 caseBuilder 한번만 사용 
  - isInquirer 조회 후 DTO에서 chatPartner 찾기
- 채팅 요청 response에 createdAt 필드 추가 -> 테스트 반영

### 💫 작업 요약
- 채팅 파트너 조회 로직 리팩토링

### 🔍 중점적으로 리뷰 할 부분
- 
