### PR TITLE
[feat #153] 채팅 요청 자동 거절 알림 생성

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/RejectChatInquiryDto.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/RejectChatInquiryDto.java
@@ -1,0 +1,22 @@
+package com.dnd.gongmuin.chat_inquiry.dto;
+
+import com.dnd.gongmuin.chat_inquiry.domain.ChatInquiry;
+import com.dnd.gongmuin.member.domain.Member;
+import com.querydsl.core.annotations.QueryProjection;
+
+public record RejectChatInquiryDto(
+	Long chatInquiryId,
+	Member inquirer,
+	Member answer
+) {
+	@QueryProjection
+	public RejectChatInquiryDto(
+		ChatInquiry chatInquiry
+	) {
+		this(
+			chatInquiry.getId(),
+			chatInquiry.getInquirer(),
+			chatInquiry.getAnswerer()
+		);
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/RejectedChatInquiryDto.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/RejectedChatInquiryDto.java
@@ -4,13 +4,13 @@ import com.dnd.gongmuin.chat_inquiry.domain.ChatInquiry;
 import com.dnd.gongmuin.member.domain.Member;
 import com.querydsl.core.annotations.QueryProjection;
 
-public record RejectChatInquiryDto(
+public record RejectedChatInquiryDto(
 	Long chatInquiryId,
 	Member inquirer,
 	Member answer
 ) {
 	@QueryProjection
-	public RejectChatInquiryDto(
+	public RejectedChatInquiryDto(
 		ChatInquiry chatInquiry
 	) {
 		this(

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryResponse;
+import com.dnd.gongmuin.chat_inquiry.dto.RejectChatInquiryDto;
 import com.dnd.gongmuin.member.domain.Member;
 
 public interface ChatInquiryQueryRepository {
@@ -14,4 +15,6 @@ public interface ChatInquiryQueryRepository {
 	List<Long> getAutoRejectedInquirerIds();
 
 	void updateChatInquiryStatusRejected();
+
+	List<RejectChatInquiryDto> getAutoRejectedChatInquiry();
 }

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryResponse;
-import com.dnd.gongmuin.chat_inquiry.dto.RejectChatInquiryDto;
+import com.dnd.gongmuin.chat_inquiry.dto.RejectedChatInquiryDto;
 import com.dnd.gongmuin.member.domain.Member;
 
 public interface ChatInquiryQueryRepository {
@@ -16,5 +16,5 @@ public interface ChatInquiryQueryRepository {
 
 	void updateChatInquiryStatusRejected();
 
-	List<RejectChatInquiryDto> getAutoRejectedChatInquiry();
+	List<RejectedChatInquiryDto> getAutoRejectedChatInquiries();
 }

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepositoryImpl.java
@@ -12,6 +12,8 @@ import org.springframework.data.domain.SliceImpl;
 import com.dnd.gongmuin.chat_inquiry.domain.InquiryStatus;
 import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.QChatInquiryResponse;
+import com.dnd.gongmuin.chat_inquiry.dto.QRejectChatInquiryDto;
+import com.dnd.gongmuin.chat_inquiry.dto.RejectChatInquiryDto;
 import com.dnd.gongmuin.member.domain.Member;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -46,6 +48,19 @@ public class ChatInquiryQueryRepositoryImpl implements ChatInquiryQueryRepositor
 	public List<Long> getAutoRejectedInquirerIds() {
 		return queryFactory
 			.select(chatInquiry.inquirer.id)
+			.from(chatInquiry)
+			.where(
+				chatInquiry.createdAt.loe(LocalDateTime.now().minusWeeks(1)),
+				chatInquiry.status.eq(InquiryStatus.PENDING)
+			)
+			.fetch();
+	}
+
+	public List<RejectChatInquiryDto> getAutoRejectedChatInquiry() {
+		return queryFactory
+			.select(new QRejectChatInquiryDto(
+				chatInquiry
+			))
 			.from(chatInquiry)
 			.where(
 				chatInquiry.createdAt.loe(LocalDateTime.now().minusWeeks(1)),

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepositoryImpl.java
@@ -12,8 +12,8 @@ import org.springframework.data.domain.SliceImpl;
 import com.dnd.gongmuin.chat_inquiry.domain.InquiryStatus;
 import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.QChatInquiryResponse;
-import com.dnd.gongmuin.chat_inquiry.dto.QRejectChatInquiryDto;
-import com.dnd.gongmuin.chat_inquiry.dto.RejectChatInquiryDto;
+import com.dnd.gongmuin.chat_inquiry.dto.QRejectedChatInquiryDto;
+import com.dnd.gongmuin.chat_inquiry.dto.RejectedChatInquiryDto;
 import com.dnd.gongmuin.member.domain.Member;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -56,9 +56,9 @@ public class ChatInquiryQueryRepositoryImpl implements ChatInquiryQueryRepositor
 			.fetch();
 	}
 
-	public List<RejectChatInquiryDto> getAutoRejectedChatInquiry() {
+	public List<RejectedChatInquiryDto> getAutoRejectedChatInquiries() {
 		return queryFactory
-			.select(new QRejectChatInquiryDto(
+			.select(new QRejectedChatInquiryDto(
 				chatInquiry
 			))
 			.from(chatInquiry)

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
@@ -16,8 +16,8 @@ import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryMapper;
 import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.CreateChatInquiryRequest;
 import com.dnd.gongmuin.chat_inquiry.dto.CreateChatInquiryResponse;
-import com.dnd.gongmuin.chat_inquiry.dto.RejectChatInquiryDto;
 import com.dnd.gongmuin.chat_inquiry.dto.RejectChatResponse;
+import com.dnd.gongmuin.chat_inquiry.dto.RejectedChatInquiryDto;
 import com.dnd.gongmuin.chat_inquiry.exception.ChatInquiryErrorCode;
 import com.dnd.gongmuin.chat_inquiry.repository.ChatInquiryRepository;
 import com.dnd.gongmuin.chatroom.domain.ChatRoom;
@@ -129,25 +129,25 @@ public class ChatInquiryService {
 
 	@Transactional
 	public void rejectChatAuto() {
-		List<RejectChatInquiryDto> rejectChatInquiryDtos = chatInquiryRepository.getAutoRejectedChatInquiry();
-		List<Long> rejectedInquirerIds = getRejectedInquirerIds(rejectChatInquiryDtos);
+		List<RejectedChatInquiryDto> rejectedChatInquiryDtos = chatInquiryRepository.getAutoRejectedChatInquiries();
+		List<Long> rejectedInquirerIds = getRejectedInquirerIds(rejectedChatInquiryDtos);
 		chatInquiryRepository.updateChatInquiryStatusRejected();
 		memberRepository.refundInMemberIds(rejectedInquirerIds, CHAT_REWARD);
 		creditHistoryService.saveCreditHistoryInMemberIds(
 			rejectedInquirerIds, CreditType.CHAT_REFUND, CHAT_REWARD
 		);
 
-		autoRejectedChatInquiryNotification(rejectChatInquiryDtos);
+		autoRejectedChatInquiryNotification(rejectedChatInquiryDtos);
 	}
 
-	private List<Long> getRejectedInquirerIds(List<RejectChatInquiryDto> rejectChatInquiryDtos) {
-		return rejectChatInquiryDtos.stream()
+	private List<Long> getRejectedInquirerIds(List<RejectedChatInquiryDto> rejectedChatInquiryDtos) {
+		return rejectedChatInquiryDtos.stream()
 			.map(dto -> dto.inquirer().getId())
 			.toList();
 	}
 
-	private void autoRejectedChatInquiryNotification(List<RejectChatInquiryDto> rejectChatInquiryDtos) {
-		for (RejectChatInquiryDto rejectChatInquiry : rejectChatInquiryDtos) {
+	private void autoRejectedChatInquiryNotification(List<RejectedChatInquiryDto> rejectedChatInquiryDtos) {
+		for (RejectedChatInquiryDto rejectChatInquiry : rejectedChatInquiryDtos) {
 			eventPublisher.publishEvent(    // 채팅 요청자 알림
 				new NotificationEvent(
 					NotificationType.AUTO_CHAT_REJECT,

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
@@ -129,8 +129,8 @@ public class ChatInquiryService {
 
 	@Transactional
 	public void rejectChatAuto() {
-		List<Long> rejectedInquirerIds = chatInquiryRepository.getAutoRejectedInquirerIds();
 		List<RejectChatInquiryDto> rejectChatInquiryDtos = chatInquiryRepository.getAutoRejectedChatInquiry();
+		List<Long> rejectedInquirerIds = getRejectedInquirerIds(rejectChatInquiryDtos);
 		chatInquiryRepository.updateChatInquiryStatusRejected();
 		memberRepository.refundInMemberIds(rejectedInquirerIds, CHAT_REWARD);
 		creditHistoryService.saveCreditHistoryInMemberIds(
@@ -138,6 +138,12 @@ public class ChatInquiryService {
 		);
 
 		autoRejectedChatInquiryNotification(rejectChatInquiryDtos);
+	}
+
+	private List<Long> getRejectedInquirerIds(List<RejectChatInquiryDto> rejectChatInquiryDtos) {
+		return rejectChatInquiryDtos.stream()
+			.map(dto -> dto.inquirer().getId())
+			.toList();
 	}
 
 	private void autoRejectedChatInquiryNotification(List<RejectChatInquiryDto> rejectChatInquiryDtos) {

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
@@ -16,6 +16,7 @@ import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryMapper;
 import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.CreateChatInquiryRequest;
 import com.dnd.gongmuin.chat_inquiry.dto.CreateChatInquiryResponse;
+import com.dnd.gongmuin.chat_inquiry.dto.RejectChatInquiryDto;
 import com.dnd.gongmuin.chat_inquiry.dto.RejectChatResponse;
 import com.dnd.gongmuin.chat_inquiry.exception.ChatInquiryErrorCode;
 import com.dnd.gongmuin.chat_inquiry.repository.ChatInquiryRepository;
@@ -129,11 +130,33 @@ public class ChatInquiryService {
 	@Transactional
 	public void rejectChatAuto() {
 		List<Long> rejectedInquirerIds = chatInquiryRepository.getAutoRejectedInquirerIds();
+		List<RejectChatInquiryDto> rejectChatInquiryDtos = chatInquiryRepository.getAutoRejectedChatInquiry();
 		chatInquiryRepository.updateChatInquiryStatusRejected();
 		memberRepository.refundInMemberIds(rejectedInquirerIds, CHAT_REWARD);
 		creditHistoryService.saveCreditHistoryInMemberIds(
 			rejectedInquirerIds, CreditType.CHAT_REFUND, CHAT_REWARD
 		);
+
+		autoRejectedChatInquiryNotification(rejectChatInquiryDtos);
+	}
+
+	private void autoRejectedChatInquiryNotification(List<RejectChatInquiryDto> rejectChatInquiryDtos) {
+		for (RejectChatInquiryDto rejectChatInquiry : rejectChatInquiryDtos) {
+			eventPublisher.publishEvent(    // 채팅 요청자 알림
+				new NotificationEvent(
+					NotificationType.AUTO_CHAT_REJECT,
+					rejectChatInquiry.chatInquiryId(),
+					rejectChatInquiry.inquirer().getId(),
+					rejectChatInquiry.inquirer())
+			);
+			eventPublisher.publishEvent(
+				new NotificationEvent(        // 채팅 답변자 알림
+					NotificationType.AUTO_CHAT_REJECT,
+					rejectChatInquiry.chatInquiryId(),
+					rejectChatInquiry.answer().getId(),
+					rejectChatInquiry.answer())
+			);
+		}
 	}
 
 	private ChatInquiry getChatInquiryById(Long id) {

--- a/src/main/java/com/dnd/gongmuin/notification/domain/NotificationType.java
+++ b/src/main/java/com/dnd/gongmuin/notification/domain/NotificationType.java
@@ -16,7 +16,8 @@ public enum NotificationType {
 	CHOSEN("채택"),
 	CHAT_REQUEST("채팅신청"),
 	CHAT_REJECT("채팅거절"),
-	CHAT_ACCEPT("채팅수락");
+	CHAT_ACCEPT("채팅수락"),
+	AUTO_CHAT_REJECT("채팅자동거절");
 
 	private final String label;
 

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
@@ -26,6 +26,7 @@ import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.CreateChatInquiryRequest;
 import com.dnd.gongmuin.chat_inquiry.dto.CreateChatInquiryResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.RejectChatResponse;
+import com.dnd.gongmuin.chat_inquiry.dto.RejectedChatInquiryDto;
 import com.dnd.gongmuin.chat_inquiry.repository.ChatInquiryRepository;
 import com.dnd.gongmuin.chatroom.domain.ChatRoom;
 import com.dnd.gongmuin.chatroom.repository.ChatMessageRepository;
@@ -286,15 +287,21 @@ class ChatInquiryServiceTest {
 	@Test
 	void rejectChatAuto() {
 		// given
-		List<Long> rejectedInquirerIds = List.of(1L, 2L);
-		given(chatInquiryRepository.getAutoRejectedInquirerIds())
-			.willReturn(rejectedInquirerIds);
+		List<RejectedChatInquiryDto> rejectedChatInquiryDtos = List.of(
+			new RejectedChatInquiryDto(1L, MemberFixture.member(1L), MemberFixture.member(2L)),
+			new RejectedChatInquiryDto(2L, MemberFixture.member(3L), MemberFixture.member(4L))
+		);
+		List<Long> rejectedInquirerIds = rejectedChatInquiryDtos.stream()
+			.map(dto -> dto.inquirer().getId())
+			.toList();
+
+		given(chatInquiryRepository.getAutoRejectedChatInquiries()).willReturn(rejectedChatInquiryDtos);
 
 		// when
 		chatInquiryService.rejectChatAuto();
 
 		// then
-		verify(chatInquiryRepository).getAutoRejectedInquirerIds();
+		verify(chatInquiryRepository).getAutoRejectedChatInquiries();
 		verify(chatInquiryRepository).updateChatInquiryStatusRejected();
 		verify(memberRepository).refundInMemberIds(rejectedInquirerIds, CHAT_REWARD);
 		verify(creditHistoryService).saveCreditHistoryInMemberIds(


### PR DESCRIPTION
### 관련 이슈
- close #153 

### 📑 작업 상세 내용
- 요청된 채팅이 시간이 지나 스케줄러에 의해 자동 거절 되었을 때, 요청자/답변자에게 알림이 생성된다.
  - 알림 생성 시 필요한 값(`RejectChatInquiryDto`)
    - 자동 거절된 요청 채팅 Id
    - 생성 알림 주인(회원)
  - 조회 쿼리 추가
 - for-each문을 통해 요청자/ 답변자 알림 생성 추가

### 💫 작업 요약
- 채팅 요청 자동거절 알림 생성

### 🔍 중점적으로 리뷰 할 부분
- 알림 생성 시 알림을 만든 `triggerMemberId`가 필요합니다. 답변자가 채팅 요청에 대해 응답하지 않아 자동 거절된거니 답변자를 trigger로 생각했었지만, 자동 거절한 주체는 '시스템'이라고 생각되었습니다. 하지만 시스템은 memberId가 없기에 trigger를 자기 자신으로 넣어놓긴 했습니다. 
