### PR TITLE
[fix #161] 채팅 요청 시 크레딧 감소 안되는 오류 해결

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryMapper.java
@@ -35,6 +35,7 @@ public class ChatInquiryMapper {
 			chatInquiry.getId(),
 			chatInquiry.getMessage(),
 			InquiryStatus.PENDING.getLabel(),
+			chatInquiry.getInquirer().getCredit(),
 			new MemberInfo(
 				answerer.getId(),
 				answerer.getNickname(),

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/CreateChatInquiryResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/CreateChatInquiryResponse.java
@@ -6,6 +6,7 @@ public record CreateChatInquiryResponse(
 	Long chatInquiryId,
 	String inquiryMessage,
 	String inquiryStatus,
+	int credit,
 	MemberInfo chatPartner
 ) {
 }

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
@@ -58,15 +58,14 @@ public class ChatInquiryService {
 	public CreateChatInquiryResponse createChatInquiry(CreateChatInquiryRequest request, Member inquirer) {
 		QuestionPost questionPost = getQuestionPostById(request.questionPostId());
 		Member answerer = getMemberById(request.answererId());
-
 		ChatInquiry chatInquiry = chatInquiryRepository.save(
 			ChatInquiryMapper.toChatInquiry(questionPost, inquirer, answerer, request.inquiryMessage())
 		);
-
+		memberRepository.save(inquirer);
+		creditHistoryService.saveChatCreditHistory(CreditType.CHAT_REQUEST, inquirer);
 		eventPublisher.publishEvent(
 			new NotificationEvent(NotificationType.CHAT_REQUEST, chatInquiry.getId(), inquirer.getId(), answerer)
 		);
-		creditHistoryService.saveChatCreditHistory(CreditType.CHAT_REQUEST, inquirer);
 
 		return ChatInquiryMapper.toCreateChatInquiryResponse(chatInquiry);
 	}

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/controller/ChatInquiryControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/controller/ChatInquiryControllerTest.java
@@ -66,6 +66,7 @@ class ChatInquiryControllerTest extends ApiTestSupport {
 	@Test
 	void createChatInquiry() throws Exception {
 		//given
+		int previousCredit = loginMember.getCredit();
 		Member answerer = memberRepository.save(MemberFixture.member5());
 		QuestionPost questionPost = questionPostRepository.save(QuestionPostFixture.questionPost(loginMember));
 		CreateChatInquiryRequest request = new CreateChatInquiryRequest(
@@ -79,7 +80,8 @@ class ChatInquiryControllerTest extends ApiTestSupport {
 				.content(toJson(request))
 				.contentType(APPLICATION_JSON))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.inquiryStatus").value(InquiryStatus.PENDING.getLabel())) // 내림차순
+			.andExpect(jsonPath("$.inquiryStatus").value(InquiryStatus.PENDING.getLabel()))
+			.andExpect(jsonPath("$.credit").value(previousCredit-CHAT_REWARD))
 			.andDo(MockMvcResultHandlers.print());
 	}
 

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/controller/ChatInquiryControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/controller/ChatInquiryControllerTest.java
@@ -81,7 +81,7 @@ class ChatInquiryControllerTest extends ApiTestSupport {
 				.contentType(APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.inquiryStatus").value(InquiryStatus.PENDING.getLabel()))
-			.andExpect(jsonPath("$.credit").value(previousCredit-CHAT_REWARD))
+			.andExpect(jsonPath("$.credit").value(previousCredit - CHAT_REWARD))
 			.andDo(MockMvcResultHandlers.print());
 	}
 


### PR DESCRIPTION
### 관련 이슈
- close #161 

### 📑 작업 상세 내용
- 크레딧 감소 안되는 문제 해결
  - 원인: Member를 파라미터로 담아서 영속성 컨텍스트에서 관리가 안됨 -> 변경 감지 대상 x
- 채팅 요청 생성 응답에 요청자의 잔여 크레딧 추가

### 💫 작업 요약
- 채팅 요청 시 크레딧 감소되도록 수정
