### PR TITLE
[fix #163] 추가 정보 기입 시 닉네임 2차 검증 누락 해결

### DIFF
--- a/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
@@ -3,6 +3,7 @@ package com.dnd.gongmuin.auth.service;
 import java.time.Duration;
 import java.util.Date;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -49,6 +50,9 @@ public class AuthService {
 	private static final String LOGOUT = "logout";
 	private static final String DELETE = "delete";
 	private static final String ANONYMOUS = "ROLE_ANONYMOUS";
+	private static final Pattern nicknamePattern = Pattern.compile("^[a-zA-Z0-9가-힣]+$");
+	private static final Pattern spaceUnicodePattern =
+		Pattern.compile("[\\\\s\\\\u00A0\\\\u3000\\\\u2000-\\\\u200B\\\\uFEFF]");
 	private final TokenProvider tokenProvider;
 	private final MemberRepository memberRepository;
 	private final CookieUtil cookieUtil;
@@ -121,11 +125,23 @@ public class AuthService {
 			throw new NotFoundException(MemberErrorCode.NOT_FOUND_NEW_MEMBER);
 		}
 
-		updateAdditionalInfo(request, foundMember);
+		checkNickName(request.nickname());
 
+		updateAdditionalInfo(request, foundMember);
 		cookieUtil.deleteCookie(response);
 
 		return new SignUpResponse(foundMember.getNickname());
+	}
+
+	private void checkNickName(String nickname) {
+		boolean isDuplicated = memberRepository.existsByNickname(nickname);
+		if (isDuplicated) {
+			throw new NotFoundException(MemberErrorCode.DUPLICATED_NICKNAME);
+		}
+
+		if (!nicknamePattern.matcher(nickname).matches()) {
+			throw new NotFoundException(MemberErrorCode.INVALID_NICKNAME);
+		}
 	}
 
 	public LogoutResponse logout(HttpServletRequest request, HttpServletResponse response) {

--- a/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
@@ -51,8 +51,6 @@ public class AuthService {
 	private static final String DELETE = "delete";
 	private static final String ANONYMOUS = "ROLE_ANONYMOUS";
 	private static final Pattern nicknamePattern = Pattern.compile("^[a-zA-Z0-9가-힣]+$");
-	private static final Pattern spaceUnicodePattern =
-		Pattern.compile("[\\\\s\\\\u00A0\\\\u3000\\\\u2000-\\\\u200B\\\\uFEFF]");
 	private final TokenProvider tokenProvider;
 	private final MemberRepository memberRepository;
 	private final CookieUtil cookieUtil;

--- a/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
@@ -123,7 +123,7 @@ public class AuthService {
 			throw new NotFoundException(MemberErrorCode.NOT_FOUND_NEW_MEMBER);
 		}
 
-		checkNickName(request.nickname());
+		checkNickname(request.nickname());
 
 		updateAdditionalInfo(request, foundMember);
 		cookieUtil.deleteCookie(response);
@@ -131,7 +131,7 @@ public class AuthService {
 		return new SignUpResponse(foundMember.getNickname());
 	}
 
-	private void checkNickName(String nickname) {
+	private void checkNickname(String nickname) {
 		boolean isDuplicated = memberRepository.existsByNickname(nickname);
 		if (isDuplicated) {
 			throw new NotFoundException(MemberErrorCode.DUPLICATED_NICKNAME);

--- a/src/main/java/com/dnd/gongmuin/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/member/exception/MemberErrorCode.java
@@ -17,7 +17,9 @@ public enum MemberErrorCode implements ErrorCode {
 	QUESTION_POSTS_BY_MEMBER_FAILED("마이페이지 게시글 목록을 불러오는데 실패했습니다", "MEMBER_006"),
 	NOT_FOUND_JOB_GROUP("직군을 올바르게 입력해주세요.", "MEMBER_007"),
 	NOT_FOUND_JOB_CATEGORY("직렬을 올바르게 입력해주세요.", "MEMBER_008"),
-	DELETE_FAILED("회원탈퇴를 실패했습니다.", "MEMBER_009");
+	DELETE_FAILED("회원탈퇴를 실패했습니다.", "MEMBER_009"),
+	DUPLICATED_NICKNAME("중복된 닉네임입니다.", "MEMBER_010"),
+	INVALID_NICKNAME("유효하지 않은 닉네임입니다.", "MEMBER_011");
 
 	private final String message;
 	private final String code;

--- a/src/test/java/com/dnd/gongmuin/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/auth/service/AuthServiceTest.java
@@ -34,6 +34,7 @@ import com.dnd.gongmuin.credit_history.repository.CreditHistoryRepository;
 import com.dnd.gongmuin.member.domain.JobCategory;
 import com.dnd.gongmuin.member.domain.JobGroup;
 import com.dnd.gongmuin.member.domain.Member;
+import com.dnd.gongmuin.member.exception.MemberErrorCode;
 import com.dnd.gongmuin.member.repository.MemberRepository;
 import com.dnd.gongmuin.notification.repository.NotificationRepository;
 import com.dnd.gongmuin.post_interaction.repository.InteractionRepository;
@@ -127,6 +128,63 @@ class AuthServiceTest {
 				JobGroup.ENG,
 				JobCategory.GME
 			);
+	}
+
+	@DisplayName("추가정보 업데이트할 때 닉네임이 중복이라면 예외가 발생한다.")
+	@Test
+	void throwExceptionWhenSignUpWithDuplicatedNickName() {
+		// given
+		AdditionalInfoRequest request = new AdditionalInfoRequest("abc123@korea.com", "김신규", "공업", "일반기계");
+		MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+
+		Member member = MemberFixture.member3();
+
+		given(memberRepository.findBySocialEmail(member.getSocialEmail())).willReturn(
+			Optional.of(member));
+		given(memberRepository.existsByNickname(request.nickname())).willReturn(Boolean.TRUE);
+
+		// when		// then
+		assertThatThrownBy(() -> authService.signUp(request, member.getSocialEmail(), mockResponse))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessage(MemberErrorCode.DUPLICATED_NICKNAME.getMessage());
+	}
+
+	@DisplayName("추가정보 업데이트할 때 공백이 포함된 닉네임이라면 예외가 발생한다.")
+	@Test
+	void throwExceptionWhenSignUpWithWhiteSpaceNickName() {
+		// given
+		AdditionalInfoRequest request = new AdditionalInfoRequest("abc123@korea.com", "　김신규", "공업", "일반기계");
+		MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+
+		Member member = MemberFixture.member3();
+
+		given(memberRepository.findBySocialEmail(member.getSocialEmail())).willReturn(
+			Optional.of(member));
+		given(memberRepository.existsByNickname(request.nickname())).willReturn(Boolean.FALSE);
+
+		// when		// then
+		assertThatThrownBy(() -> authService.signUp(request, member.getSocialEmail(), mockResponse))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessage(MemberErrorCode.INVALID_NICKNAME.getMessage());
+	}
+
+	@DisplayName("추가정보 업데이트할 때 유효하지 않은 닉네임이라면 예외가 발생한다.")
+	@Test
+	void throwExceptionWhenSignUpWithInvalidNickName() {
+		// given
+		AdditionalInfoRequest request = new AdditionalInfoRequest("abc123@korea.com", "abcㄱㄴ123", "공업", "일반기계");
+		MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+
+		Member member = MemberFixture.member3();
+
+		given(memberRepository.findBySocialEmail(member.getSocialEmail())).willReturn(
+			Optional.of(member));
+		given(memberRepository.existsByNickname(request.nickname())).willReturn(Boolean.FALSE);
+
+		// when		// then
+		assertThatThrownBy(() -> authService.signUp(request, member.getSocialEmail(), mockResponse))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessage(MemberErrorCode.INVALID_NICKNAME.getMessage());
 	}
 
 	@DisplayName("로그인 회원은 로그아웃 할 수 있다.")


### PR DESCRIPTION
### 관련 이슈
- close #163 

### 📑 작업 상세 내용
- 추가정보 비즈니스 로직 내부 2차 검증 로직 누락 문제 발견

- 닉네임 검증 로직 추가(`checkNickname()`)
  - 2차 닉네임 중복 검증
  - 닉네임 유효 문자열 검증

- 닉네임 검증 단위 테스트 작성

  - 유효하지 않은 문자열(닉네임)일 때 예외가 발생한다.
  - 유니코드 문자 공백이 추가된 문자열(닉네임)일 때 예외가 발생한다.
  - 중복된 닉네임일 때 예외가 발생한다.

### 💫 작업 요약
- 닉네임 2차 검증 로직 추가하여 문제 해결
  - 닉네임 검증 로직 추가(`checkNickname()`)
  - 닉네임 검증 예외 발생 단위테스트 작성

### 🔍 중점적으로 리뷰 할 부분
- 
