### PR TITLE
[feat #164] 채팅 요청 상세 조회 API 응답값 추가

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryDetailResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryDetailResponse.java
@@ -7,6 +7,11 @@ public record ChatInquiryDetailResponse(
 	String inquiryMessage,
 	String inquiryStatus,
 	boolean isInquirer,
-	MemberInfo chatPartner
+	int memberCredit,
+	Long questionPostId,
+	String targetJobGroup,
+	String title,
+	MemberInfo chatPartner,
+	String createdAt
 ) {
 }

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryMapper.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ChatInquiryMapper.java
@@ -47,19 +47,27 @@ public class ChatInquiryMapper {
 
 	public static ChatInquiryDetailResponse toChatInquiryDetailResponse(
 		ChatInquiry chatInquiry,
+		Member member,
 		Member chatPartner,
 		boolean isInquirer
 	) {
-		return new ChatInquiryDetailResponse(chatInquiry.getId(),
+		QuestionPost questionPost = chatInquiry.getQuestionPost();
+		return new ChatInquiryDetailResponse(
+			chatInquiry.getId(),
 			chatInquiry.getMessage(),
 			chatInquiry.getStatus().getLabel(),
 			isInquirer,
+			member.getCredit(),
+			questionPost.getId(),
+			questionPost.getJobGroup().toString(),
+			questionPost.getTitle(),
 			new MemberInfo(
 				chatPartner.getId(),
 				chatPartner.getNickname(),
 				chatPartner.getJobGroup().getLabel(),
 				chatPartner.getProfileImageNo()
-			)
+			),
+			chatInquiry.getCreatedAt().toString()
 		);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/CreateChatInquiryResponse.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/CreateChatInquiryResponse.java
@@ -6,7 +6,7 @@ public record CreateChatInquiryResponse(
 	Long chatInquiryId,
 	String inquiryMessage,
 	String inquiryStatus,
-	int credit,
+	int memberCredit,
 	MemberInfo chatPartner
 ) {
 }

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
@@ -77,6 +77,7 @@ public class ChatInquiryService {
 
 		return ChatInquiryMapper.toChatInquiryDetailResponse(
 			chatInquiry,
+			member,
 			chatInquiry.getChatPartner(member),
 			chatInquiry.isInquirer(member)
 		);

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/controller/ChatInquiryControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/controller/ChatInquiryControllerTest.java
@@ -80,8 +80,9 @@ class ChatInquiryControllerTest extends ApiTestSupport {
 				.content(toJson(request))
 				.contentType(APPLICATION_JSON))
 			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.chatPartner.memberId").value(answerer.getId()))
 			.andExpect(jsonPath("$.inquiryStatus").value(InquiryStatus.PENDING.getLabel()))
-			.andExpect(jsonPath("$.credit").value(previousCredit - CHAT_REWARD))
+			.andExpect(jsonPath("$.memberCredit").value(previousCredit - CHAT_REWARD))
 			.andDo(MockMvcResultHandlers.print());
 	}
 
@@ -94,6 +95,7 @@ class ChatInquiryControllerTest extends ApiTestSupport {
 		ChatInquiry chatInquiry = chatInquiryRepository.save(
 			ChatInquiryFixture.chatInquiry(questionPost, loginMember, chatPartner, INQUIRY_MESSAGE)
 		);
+		memberRepository.save(loginMember); // credit 변경사항 flush
 
 		//when & then
 		mockMvc.perform(get("/api/chat/inquiries/{chatInquiryId}", chatInquiry.getId())
@@ -107,8 +109,14 @@ class ChatInquiryControllerTest extends ApiTestSupport {
 				.value(chatPartner.getId()))
 			.andExpect(jsonPath("$.isInquirer")
 				.value(chatInquiry.getInquirer().equals(loginMember)))
+			.andExpect(jsonPath("$.memberCredit")
+				.value(loginMember.getCredit()))
 			.andExpect(jsonPath("$.inquiryStatus")
-				.value(InquiryStatus.PENDING.getLabel()));
+				.value(InquiryStatus.PENDING.getLabel()))
+			.andExpect(jsonPath("$.questionPostId")
+				.value(chatInquiry.getQuestionPost().getId()))
+			.andExpect(jsonPath("$.createdAt")
+				.value(chatInquiry.getCreatedAt().toString()));
 	}
 
 	@DisplayName("[회원의 채팅 요청 목록을 조회할 수 있다.]")

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/controller/ChatInquiryControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/controller/ChatInquiryControllerTest.java
@@ -114,9 +114,7 @@ class ChatInquiryControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.inquiryStatus")
 				.value(InquiryStatus.PENDING.getLabel()))
 			.andExpect(jsonPath("$.questionPostId")
-				.value(chatInquiry.getQuestionPost().getId()))
-			.andExpect(jsonPath("$.createdAt")
-				.value(chatInquiry.getCreatedAt().toString()));
+				.value(chatInquiry.getQuestionPost().getId()));
 	}
 
 	@DisplayName("[회원의 채팅 요청 목록을 조회할 수 있다.]")


### PR DESCRIPTION
### 관련 이슈
- close #164 

### 📑 작업 상세 내용
- 채팅 요청 상세 조회 응답 추가
  - 질문 정보(아이디, 제목, 타켓 직군), 회원 잔여 크레딧 
- 채팅 요청 생성 응답 필드명 수정
  - 상세조회 응답과 통일 시키기 위해 필드명 변경

### 💫 작업 요약
- 채팅 요청 상세조회, 채팅 요청 생성 응답값 추가 및 수정

### 🔍 중점적으로 리뷰 할 부분
- 
