### PR TITLE
[feat #167] 질문 게시글 작성 로직 변경

### DIFF
--- a/src/main/java/com/dnd/gongmuin/answer/exception/AnswerErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/answer/exception/AnswerErrorCode.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 public enum AnswerErrorCode implements ErrorCode {
 
 	NOT_FOUND_ANSWER("해당 아이디의 답변이 존재하지 않습니다.", "ANS_001"),
-	ALREADY_CHOSEN_ANSWER_EXISTS("채택한 답변이 존재합니다.", "ANS_02");
+	ALREADY_CHOSEN_ANSWER_EXISTS("채택한 답변이 존재합니다.", "ANS_02"),
+	NOT_REGISTER_ANSWER("답변을 등록할 수 없습니다.", "ANS_003");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/answer/exception/AnswerErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/answer/exception/AnswerErrorCode.java
@@ -11,7 +11,7 @@ public enum AnswerErrorCode implements ErrorCode {
 
 	NOT_FOUND_ANSWER("해당 아이디의 답변이 존재하지 않습니다.", "ANS_001"),
 	ALREADY_CHOSEN_ANSWER_EXISTS("채택한 답변이 존재합니다.", "ANS_02"),
-	NOT_REGISTER_ANSWER("답변을 등록할 수 없습니다.", "ANS_003");
+	CANNOT_REGISTER_ANSWER("답변을 등록할 수 없습니다.", "ANS_003");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
+++ b/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
@@ -49,7 +49,9 @@ public class AnswerService {
 		Member member
 	) {
 		QuestionPost questionPost = getQuestionPostById(questionPostId);
-		questionPost.updateStatus(QuestionPostStatus.CHOSEN_WAITING);
+		if (isAnswerWaitingStatus(questionPost)) {
+			questionPost.updateStatus(QuestionPostStatus.CHOSEN_WAITING);
+		}
 
 		Answer answer = AnswerMapper.toAnswer(questionPostId, questionPost.isQuestioner(member.getId()), request,
 			member);
@@ -60,6 +62,10 @@ public class AnswerService {
 		));
 
 		return AnswerMapper.toAnswerDetailResponse(savedAnswer);
+	}
+
+	private boolean isAnswerWaitingStatus(QuestionPost questionPost) {
+		return QuestionPostStatus.ANSWER_WAITING.equals(questionPost.getQuestionPostStatus());
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
+++ b/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
@@ -49,6 +49,11 @@ public class AnswerService {
 		Member member
 	) {
 		QuestionPost questionPost = getQuestionPostById(questionPostId);
+
+		if (questionPost.isAnswerClose()) {
+			throw new NotFoundException(AnswerErrorCode.NOT_REGISTER_ANSWER);
+		}
+
 		if (isAnswerWaitingStatus(questionPost)) {
 			questionPost.updateStatus(QuestionPostStatus.CHOSEN_WAITING);
 		}

--- a/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
+++ b/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
@@ -21,6 +21,7 @@ import com.dnd.gongmuin.credit_history.service.CreditHistoryService;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.notification.dto.NotificationEvent;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
+import com.dnd.gongmuin.question_post.domain.QuestionPostStatus;
 import com.dnd.gongmuin.question_post.exception.QuestionPostErrorCode;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 
@@ -48,6 +49,8 @@ public class AnswerService {
 		Member member
 	) {
 		QuestionPost questionPost = getQuestionPostById(questionPostId);
+		questionPost.updateStatus(QuestionPostStatus.CHOSEN_WAITING);
+
 		Answer answer = AnswerMapper.toAnswer(questionPostId, questionPost.isQuestioner(member.getId()), request,
 			member);
 		Answer savedAnswer = answerRepository.save(answer);
@@ -87,8 +90,8 @@ public class AnswerService {
 
 	private void chooseAnswer(QuestionPost questionPost, Answer answer) {
 		questionPost.updateIsChosen(answer);
+		questionPost.updateStatus(QuestionPostStatus.CHOSEN_COMPLETE);
 		answer.getMember().increaseCredit(questionPost.getReward());
-		questionPost.getMember().decreaseCredit(questionPost.getReward());
 		creditHistoryService.saveChosenCreditHistory(questionPost, answer);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
+++ b/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
@@ -50,27 +50,28 @@ public class AnswerService {
 	) {
 		QuestionPost questionPost = getQuestionPostById(questionPostId);
 
-		if (questionPost.isAnswerClose()) {
+		if (questionPost.isAnswerClosed()) {
 			throw new NotFoundException(AnswerErrorCode.CANNOT_REGISTER_ANSWER);
 		}
 
-		if (isAnswerWaitingStatus(questionPost)) {
+		if (questionPost.isAnswerWaiting()) {
 			questionPost.updateStatus(QuestionPostStatus.CHOSEN_WAITING);
 		}
 
-		Answer answer = AnswerMapper.toAnswer(questionPostId, questionPost.isQuestioner(member.getId()), request,
-			member);
-		Answer savedAnswer = answerRepository.save(answer);
+		Answer savedAnswer = answerRepository.save(
+			AnswerMapper.toAnswer(
+				questionPostId,
+				questionPost.isQuestioner(member.getId()),
+				request,
+				member
+			)
+		);
 
 		eventPublisher.publishEvent(new NotificationEvent(
 			ANSWER, questionPost.getId(), member.getId(), questionPost.getMember()
 		));
 
 		return AnswerMapper.toAnswerDetailResponse(savedAnswer);
-	}
-
-	private boolean isAnswerWaitingStatus(QuestionPost questionPost) {
-		return QuestionPostStatus.ANSWER_WAITING.equals(questionPost.getQuestionPostStatus());
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
+++ b/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
@@ -51,7 +51,7 @@ public class AnswerService {
 		QuestionPost questionPost = getQuestionPostById(questionPostId);
 
 		if (questionPost.isAnswerClose()) {
-			throw new NotFoundException(AnswerErrorCode.NOT_REGISTER_ANSWER);
+			throw new NotFoundException(AnswerErrorCode.CANNOT_REGISTER_ANSWER);
 		}
 
 		if (isAnswerWaitingStatus(questionPost)) {

--- a/src/main/java/com/dnd/gongmuin/credit_history/domain/CreditType.java
+++ b/src/main/java/com/dnd/gongmuin/credit_history/domain/CreditType.java
@@ -13,7 +13,9 @@ public enum CreditType {
 	CHOSEN("채택받기", "입금"),
 	CHAT_REQUEST("채팅 요청", "출금"),
 	CHAT_ACCEPT("채팅 수락", "입금"),
-	CHAT_REFUND("채팅 환급", "입금");
+	CHAT_REFUND("채팅 환급", "입금"),
+	WRITE_QUESTION_POST("질문글 작성", "출금"),
+	REFUND_QUESTION_POST("질문글 환급", "입금");
 
 	private final String label;
 	private final String detail;

--- a/src/main/java/com/dnd/gongmuin/credit_history/domain/CreditType.java
+++ b/src/main/java/com/dnd/gongmuin/credit_history/domain/CreditType.java
@@ -2,7 +2,6 @@ package com.dnd.gongmuin.credit_history.domain;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +31,7 @@ public enum CreditType {
 	public static List<CreditType> fromDetail(String detail) {
 		return Arrays.stream(values())
 			.filter(type -> type.isDetailEqual(detail))
-			.collect(Collectors.toList());
+			.toList();
 	}
 
 	private boolean isEqual(String input) {

--- a/src/main/java/com/dnd/gongmuin/credit_history/domain/CreditType.java
+++ b/src/main/java/com/dnd/gongmuin/credit_history/domain/CreditType.java
@@ -1,6 +1,8 @@
 package com.dnd.gongmuin.credit_history.domain;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -27,11 +29,10 @@ public enum CreditType {
 			.orElseThrow(IllegalArgumentException::new);
 	}
 
-	public static CreditType fromDetail(String detail) {
+	public static List<CreditType> fromDetail(String detail) {
 		return Arrays.stream(values())
 			.filter(type -> type.isDetailEqual(detail))
-			.findAny()
-			.orElseThrow(IllegalArgumentException::new);
+			.collect(Collectors.toList());
 	}
 
 	private boolean isEqual(String input) {

--- a/src/main/java/com/dnd/gongmuin/credit_history/service/CreditHistoryService.java
+++ b/src/main/java/com/dnd/gongmuin/credit_history/service/CreditHistoryService.java
@@ -51,4 +51,10 @@ public class CreditHistoryService {
 			CreditHistoryMapper.toCreditHistory(CreditType.WRITE_QUESTION_POST, reward, member)
 		);
 	}
+
+	public void saveRefundQuestionPostCreditHistory(int reward, Member member) {
+		creditHistoryRepository.save(
+			CreditHistoryMapper.toCreditHistory(CreditType.REFUND_QUESTION_POST, reward, member)
+		);
+	}
 }

--- a/src/main/java/com/dnd/gongmuin/credit_history/service/CreditHistoryService.java
+++ b/src/main/java/com/dnd/gongmuin/credit_history/service/CreditHistoryService.java
@@ -45,4 +45,10 @@ public class CreditHistoryService {
 			.toList();
 		creditHistoryRepository.saveAll(histories);
 	}
+
+	public void saveQuestionPostCreditHistory(int reward, Member member) {
+		creditHistoryRepository.save(
+			CreditHistoryMapper.toCreditHistory(CreditType.WRITE_QUESTION_POST, reward, member)
+		);
+	}
 }

--- a/src/main/java/com/dnd/gongmuin/credit_history/service/CreditHistoryService.java
+++ b/src/main/java/com/dnd/gongmuin/credit_history/service/CreditHistoryService.java
@@ -25,10 +25,9 @@ public class CreditHistoryService {
 
 	@Transactional
 	public void saveChosenCreditHistory(QuestionPost questionPost, Answer answer) {
-		creditHistoryRepository.saveAll(List.of(
-			CreditHistoryMapper.toCreditHistory(CreditType.CHOSEN, questionPost.getReward(), answer.getMember()),
-			CreditHistoryMapper.toCreditHistory(CreditType.CHOOSE, questionPost.getReward(), questionPost.getMember())
-		));
+		creditHistoryRepository.save(
+			CreditHistoryMapper.toCreditHistory(CreditType.CHOSEN, questionPost.getReward(), answer.getMember())
+		);
 	}
 
 	@Transactional

--- a/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
@@ -134,4 +134,8 @@ public class QuestionPost extends TimeBaseEntity {
 	public void updateStatus(QuestionPostStatus status) {
 		this.questionPostStatus = status;
 	}
+
+	public boolean isAnswerClose() {
+		return QuestionPostStatus.ANSWER_CLOSE.equals(this.questionPostStatus);
+	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
@@ -135,7 +135,7 @@ public class QuestionPost extends TimeBaseEntity {
 		this.questionPostStatus = status;
 	}
 
-	public boolean isAnswerClose() {
+	public boolean isAnswerClosed() {
 		return QuestionPostStatus.ANSWER_CLOSE.equals(this.questionPostStatus);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
@@ -138,4 +138,8 @@ public class QuestionPost extends TimeBaseEntity {
 	public boolean isAnswerClosed() {
 		return QuestionPostStatus.ANSWER_CLOSE.equals(this.questionPostStatus);
 	}
+
+	public boolean isAnswerWaiting() {
+		return QuestionPostStatus.ANSWER_WAITING.equals(this.questionPostStatus);
+	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
@@ -56,6 +56,9 @@ public class QuestionPost extends TimeBaseEntity {
 	@Column(name = "is_chosen", nullable = false)
 	private Boolean isChosen;
 
+	@Column(name = "status", nullable = false)
+	private QuestionPostStatus questionPostStatus;
+
 	@OneToMany(mappedBy = "questionPost", cascade = CascadeType.ALL)
 	private List<QuestionPostImage> images = new ArrayList<>();
 
@@ -68,6 +71,7 @@ public class QuestionPost extends TimeBaseEntity {
 	private QuestionPost(String title, String content, int reward, JobGroup jobGroup,
 		List<QuestionPostImage> images, Member member) {
 		this.isChosen = false;
+		this.questionPostStatus = QuestionPostStatus.ANSWER_WAITING;
 		this.title = title;
 		this.content = content;
 		this.reward = reward;

--- a/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
@@ -130,4 +130,8 @@ public class QuestionPost extends TimeBaseEntity {
 	public void updateMember(Member anonymous) {
 		this.member = anonymous;
 	}
+
+	public void updateStatus(QuestionPostStatus status) {
+		this.questionPostStatus = status;
+	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPostStatus.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPostStatus.java
@@ -1,0 +1,28 @@
+package com.dnd.gongmuin.question_post.domain;
+
+import java.util.Arrays;
+
+import com.dnd.gongmuin.common.exception.runtime.NotFoundException;
+import com.dnd.gongmuin.question_post.exception.QuestionPostErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum QuestionPostStatus {
+
+	ANSWER_WAITING("답변대기"),
+	ANSWER_CLOSE("답변마감"),
+	CHOSEN_WAITING("채택대기"),
+	CHOSEN_COMPLETE("채택완료");
+
+	private final String status;
+
+	public static QuestionPostStatus from(String status) {
+		return Arrays.stream(values())
+			.filter(questionPostStatus -> questionPostStatus.getStatus().equalsIgnoreCase(status))
+			.findFirst()
+			.orElseThrow(() -> new NotFoundException(QuestionPostErrorCode.NOT_FOUND_QUESTION_POST_STATUS));
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
@@ -41,6 +41,7 @@ public class QuestionPostMapper {
 			imagesToUrls(questionPost.getImages()),
 			questionPost.getReward(),
 			questionPost.getJobGroup().getLabel(),
+			questionPost.getQuestionPostStatus().getStatus(),
 			new MemberInfo(
 				member.getId(),
 				member.getNickname(),

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
@@ -66,6 +66,7 @@ public class QuestionPostMapper {
 			imagesToUrls(questionPost.getImages()),
 			questionPost.getReward(),
 			questionPost.getJobGroup().getLabel(),
+			questionPost.getQuestionPostStatus().getStatus(),
 			new MemberInfo(
 				member.getId(),
 				member.getNickname(),

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/RefundQuestionPostDto.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/RefundQuestionPostDto.java
@@ -1,0 +1,21 @@
+package com.dnd.gongmuin.question_post.dto;
+
+import com.dnd.gongmuin.member.domain.Member;
+import com.dnd.gongmuin.question_post.domain.QuestionPost;
+import com.querydsl.core.annotations.QueryProjection;
+
+public record RefundQuestionPostDto(
+	Long questionPostId,
+	int reward,
+	Member member
+) {
+	@QueryProjection
+	public RefundQuestionPostDto(
+		QuestionPost questionPost
+	) {
+		this(questionPost.getId(),
+			questionPost.getReward(),
+			questionPost.getMember()
+		);
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostDetailResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostDetailResponse.java
@@ -11,6 +11,7 @@ public record QuestionPostDetailResponse(
 	List<String> imageUrls,
 	int reward,
 	String targetJobGroup,
+	String status,
 	MemberInfo memberInfo,
 	boolean isSaved,
 	boolean isRecommended,

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/RegisterQuestionPostResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/RegisterQuestionPostResponse.java
@@ -11,6 +11,7 @@ public record RegisterQuestionPostResponse(
 	List<String> imageUrls,
 	int reward,
 	String targetJobGroup,
+	String status,
 	MemberInfo memberInfo,
 	String createdAt
 ) {

--- a/src/main/java/com/dnd/gongmuin/question_post/exception/QuestionPostErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/exception/QuestionPostErrorCode.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 public enum QuestionPostErrorCode implements ErrorCode {
 
 	NOT_FOUND_QUESTION_POST("해당 아이디의 질문 포스트가 존재하지 않습니다.", "QP_001"),
-	NOT_AUTHORIZED("질문글에서 해당 작업 권한이 없습니다.", "QP_002");
+	NOT_AUTHORIZED("질문글에서 해당 작업 권한이 없습니다.", "QP_002"),
+	NOT_FOUND_QUESTION_POST_STATUS("해당 질문글의 상태를 찾을 수 없습니다.", "QP_002");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/question_post/exception/QuestionPostErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/exception/QuestionPostErrorCode.java
@@ -11,7 +11,7 @@ public enum QuestionPostErrorCode implements ErrorCode {
 
 	NOT_FOUND_QUESTION_POST("해당 아이디의 질문 포스트가 존재하지 않습니다.", "QP_001"),
 	NOT_AUTHORIZED("질문글에서 해당 작업 권한이 없습니다.", "QP_002"),
-	NOT_FOUND_QUESTION_POST_STATUS("해당 질문글의 상태를 찾을 수 없습니다.", "QP_002");
+	NOT_FOUND_QUESTION_POST_STATUS("해당 질문글의 상태를 찾을 수 없습니다.", "QP_003");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepository.java
@@ -1,9 +1,12 @@
 package com.dnd.gongmuin.question_post.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import com.dnd.gongmuin.member.domain.JobGroup;
+import com.dnd.gongmuin.question_post.dto.RefundQuestionPostDto;
 import com.dnd.gongmuin.question_post.dto.request.QuestionPostSearchCondition;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostSimpleResponse;
 import com.dnd.gongmuin.question_post.dto.response.RecQuestionPostResponse;
@@ -17,4 +20,8 @@ public interface QuestionPostQueryRepository {
 		JobGroup targetJobGroup,
 		Pageable pageable
 	);
+
+	List<RefundQuestionPostDto> getRefundQuestionPostDtos();
+
+	void getAutoChangeStatus();
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepository.java
@@ -23,5 +23,5 @@ public interface QuestionPostQueryRepository {
 
 	List<RefundQuestionPostDto> getRefundQuestionPostDtos();
 
-	void getAutoChangeStatus();
+	void updateQuestionPostStatusAnswerClosed();
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepositoryImpl.java
@@ -107,30 +107,26 @@ public class QuestionPostQueryRepositoryImpl implements QuestionPostQueryReposit
 
 	@Override
 	public List<RefundQuestionPostDto> getRefundQuestionPostDtos() {
-		LocalDateTime fourteenDaysAgo = LocalDateTime.now().minusDays(14);
-
 		return queryFactory
 			.select(new QRefundQuestionPostDto(
 				questionPost
 			))
 			.from(questionPost)
 			.where(
-				questionPost.questionPostStatus.eq(QuestionPostStatus.ANSWER_WAITING),
-				questionPost.createdAt.before(fourteenDaysAgo)
+				questionPost.createdAt.loe(LocalDateTime.now().minusWeeks(2)),
+				questionPost.questionPostStatus.eq(QuestionPostStatus.ANSWER_WAITING)
 			)
 			.fetch();
 	}
 
 	@Override
 	public void getAutoChangeStatus() {
-		LocalDateTime fourteenDaysAgo = LocalDateTime.now().minusDays(14);
-
 		queryFactory
 			.update(questionPost)
 			.set(questionPost.questionPostStatus, QuestionPostStatus.ANSWER_CLOSE)
 			.where(
-				questionPost.questionPostStatus.eq(QuestionPostStatus.ANSWER_WAITING),
-				questionPost.createdAt.before(fourteenDaysAgo)
+				questionPost.createdAt.loe(LocalDateTime.now().minusWeeks(2)),
+				questionPost.questionPostStatus.eq(QuestionPostStatus.ANSWER_WAITING)
 			)
 			.execute();
 	}

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.dnd.gongmuin.question_post.repository;
 
 import static com.dnd.gongmuin.question_post.domain.QQuestionPost.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
@@ -13,6 +14,9 @@ import com.dnd.gongmuin.member.domain.JobGroup;
 import com.dnd.gongmuin.post_interaction.domain.InteractionType;
 import com.dnd.gongmuin.post_interaction.domain.QInteractionCount;
 import com.dnd.gongmuin.question_post.domain.QQuestionPost;
+import com.dnd.gongmuin.question_post.domain.QuestionPostStatus;
+import com.dnd.gongmuin.question_post.dto.QRefundQuestionPostDto;
+import com.dnd.gongmuin.question_post.dto.RefundQuestionPostDto;
 import com.dnd.gongmuin.question_post.dto.request.QuestionPostSearchCondition;
 import com.dnd.gongmuin.question_post.dto.response.QQuestionPostSimpleResponse;
 import com.dnd.gongmuin.question_post.dto.response.QRecQuestionPostResponse;
@@ -99,6 +103,36 @@ public class QuestionPostQueryRepositoryImpl implements QuestionPostQueryReposit
 			.fetch();
 		boolean hasNext = hasNext(pageable.getPageSize(), content);
 		return new SliceImpl<>(content, pageable, hasNext);
+	}
+
+	@Override
+	public List<RefundQuestionPostDto> getRefundQuestionPostDtos() {
+		LocalDateTime fourteenDaysAgo = LocalDateTime.now().minusDays(14);
+
+		return queryFactory
+			.select(new QRefundQuestionPostDto(
+				questionPost
+			))
+			.from(questionPost)
+			.where(
+				questionPost.questionPostStatus.eq(QuestionPostStatus.ANSWER_WAITING),
+				questionPost.createdAt.before(fourteenDaysAgo)
+			)
+			.fetch();
+	}
+
+	@Override
+	public void getAutoChangeStatus() {
+		LocalDateTime fourteenDaysAgo = LocalDateTime.now().minusDays(14);
+
+		queryFactory
+			.update(questionPost)
+			.set(questionPost.questionPostStatus, QuestionPostStatus.ANSWER_CLOSE)
+			.where(
+				questionPost.questionPostStatus.eq(QuestionPostStatus.ANSWER_WAITING),
+				questionPost.createdAt.before(fourteenDaysAgo)
+			)
+			.execute();
 	}
 
 	private BooleanExpression isChosenEq(Boolean isChosen) {

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepositoryImpl.java
@@ -120,7 +120,7 @@ public class QuestionPostQueryRepositoryImpl implements QuestionPostQueryReposit
 	}
 
 	@Override
-	public void getAutoChangeStatus() {
+	public void updateQuestionPostStatusAnswerClosed() {
 		queryFactory
 			.update(questionPost)
 			.set(questionPost.questionPostStatus, QuestionPostStatus.ANSWER_CLOSE)

--- a/src/main/java/com/dnd/gongmuin/question_post/scheduler/QuestionPostScheduler.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/scheduler/QuestionPostScheduler.java
@@ -17,6 +17,6 @@ public class QuestionPostScheduler {
 	@Transactional
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	public void closeQuestionPost() {
-		questionPostService.changeStatusAuto();
+		questionPostService.changeQuestionPostStatusAnswerClosed();
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/scheduler/QuestionPostScheduler.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/scheduler/QuestionPostScheduler.java
@@ -1,0 +1,22 @@
+package com.dnd.gongmuin.question_post.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dnd.gongmuin.question_post.service.QuestionPostService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class QuestionPostScheduler {
+
+	private final QuestionPostService questionPostService;
+
+	@Transactional
+	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+	public void changeToAnswerCloseStatusFromAnswerWaiting() {
+		questionPostService.changeStatusAuto();
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/question_post/scheduler/QuestionPostScheduler.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/scheduler/QuestionPostScheduler.java
@@ -16,7 +16,7 @@ public class QuestionPostScheduler {
 
 	@Transactional
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
-	public void changeToAnswerCloseStatusFromAnswerWaiting() {
+	public void closeQuestionPost() {
 		questionPostService.changeStatusAuto();
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -20,6 +20,7 @@ import com.dnd.gongmuin.post_interaction.repository.InteractionCountRepository;
 import com.dnd.gongmuin.post_interaction.repository.InteractionRepository;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.dto.QuestionPostMapper;
+import com.dnd.gongmuin.question_post.dto.RefundQuestionPostDto;
 import com.dnd.gongmuin.question_post.dto.request.QuestionPostSearchCondition;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.request.UpdateQuestionPostRequest;
@@ -138,5 +139,15 @@ public class QuestionPostService {
 			.findByQuestionPostIdAndType(questionPostId, type)
 			.map(InteractionCount::getCount)
 			.orElse(0);
+	}
+
+	public void changeStatusAuto() {
+		List<RefundQuestionPostDto> refundQuestionPostDtos = questionPostRepository.getRefundQuestionPostDtos();
+		refundQuestionPostDtos.forEach(refundQuestionPostDto -> {
+			refundQuestionPostDto.member().increaseCredit(refundQuestionPostDto.reward());
+			memberRepository.save(refundQuestionPostDto.member());
+		});
+
+		questionPostRepository.getAutoChangeStatus();
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -60,14 +60,18 @@ public class QuestionPostService {
 		RegisterQuestionPostRequest request,
 		Member member
 	) {
-		member.decreaseCredit(request.reward());
-		memberRepository.save(member);
+		decreaseMemberCredit(request, member);
 		creditHistoryService.saveQuestionPostCreditHistory(request.reward(), member);
 
 		QuestionPost questionPost = QuestionPostMapper.toQuestionPost(request, member);
 		return QuestionPostMapper.toRegisterQuestionPostResponse(
 			questionPostRepository.save(questionPost)
 		);
+	}
+
+	private void decreaseMemberCredit(RegisterQuestionPostRequest request, Member member) {
+		member.decreaseCredit(request.reward());
+		memberRepository.save(member);
 	}
 
 	@Transactional(readOnly = true)
@@ -142,7 +146,12 @@ public class QuestionPostService {
 	}
 
 	@Transactional
-	public void changeStatusAuto() {
+	public void changeQuestionPostStatusAnswerClosed() {
+		refundQuestionPostCredit();
+		questionPostRepository.updateQuestionPostStatusAnswerClosed();
+	}
+
+	private void refundQuestionPostCredit() {
 		List<RefundQuestionPostDto> refundQuestionPostDtos = questionPostRepository.getRefundQuestionPostDtos();
 		refundQuestionPostDtos.forEach(refundQuestionPostDto -> {
 			refundQuestionPostDto.member().increaseCredit(refundQuestionPostDto.reward());
@@ -153,7 +162,5 @@ public class QuestionPostService {
 				refundQuestionPostDto.member()
 			);
 		});
-
-		questionPostRepository.getAutoChangeStatus();
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -146,6 +146,11 @@ public class QuestionPostService {
 		refundQuestionPostDtos.forEach(refundQuestionPostDto -> {
 			refundQuestionPostDto.member().increaseCredit(refundQuestionPostDto.reward());
 			memberRepository.save(refundQuestionPostDto.member());
+
+			creditHistoryService.saveRefundQuestionPostCreditHistory(
+				refundQuestionPostDto.reward(),
+				refundQuestionPostDto.member()
+			);
 		});
 
 		questionPostRepository.getAutoChangeStatus();

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -10,10 +10,9 @@ import org.springframework.transaction.annotation.Transactional;
 import com.dnd.gongmuin.common.dto.PageMapper;
 import com.dnd.gongmuin.common.dto.PageResponse;
 import com.dnd.gongmuin.common.exception.runtime.NotFoundException;
-import com.dnd.gongmuin.common.exception.runtime.ValidationException;
 import com.dnd.gongmuin.member.domain.JobGroup;
 import com.dnd.gongmuin.member.domain.Member;
-import com.dnd.gongmuin.member.exception.MemberErrorCode;
+import com.dnd.gongmuin.member.repository.MemberRepository;
 import com.dnd.gongmuin.post_interaction.domain.InteractionCount;
 import com.dnd.gongmuin.post_interaction.domain.InteractionType;
 import com.dnd.gongmuin.post_interaction.repository.InteractionCountRepository;
@@ -42,6 +41,7 @@ public class QuestionPostService {
 	private final InteractionRepository interactionRepository;
 	private final InteractionCountRepository interactionCountRepository;
 	private final QuestionPostImageRepository questionPostImageRepository;
+	private final MemberRepository memberRepository;
 
 	private static void updateQuestionPost(UpdateQuestionPostRequest request, QuestionPost questionPost) {
 		questionPost.updateQuestionPost(
@@ -57,9 +57,9 @@ public class QuestionPostService {
 		RegisterQuestionPostRequest request,
 		Member member
 	) {
-		if (member.getCredit() < request.reward()) {
-			throw new ValidationException(MemberErrorCode.NOT_ENOUGH_CREDIT);
-		}
+		member.decreaseCredit(request.reward());
+		memberRepository.save(member);
+
 		QuestionPost questionPost = QuestionPostMapper.toQuestionPost(request, member);
 		return QuestionPostMapper.toRegisterQuestionPostResponse(
 			questionPostRepository.save(questionPost)

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -141,6 +141,7 @@ public class QuestionPostService {
 			.orElse(0);
 	}
 
+	@Transactional
 	public void changeStatusAuto() {
 		List<RefundQuestionPostDto> refundQuestionPostDtos = questionPostRepository.getRefundQuestionPostDtos();
 		refundQuestionPostDtos.forEach(refundQuestionPostDto -> {

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.dnd.gongmuin.common.dto.PageMapper;
 import com.dnd.gongmuin.common.dto.PageResponse;
 import com.dnd.gongmuin.common.exception.runtime.NotFoundException;
+import com.dnd.gongmuin.credit_history.service.CreditHistoryService;
 import com.dnd.gongmuin.member.domain.JobGroup;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.repository.MemberRepository;
@@ -42,6 +43,7 @@ public class QuestionPostService {
 	private final InteractionCountRepository interactionCountRepository;
 	private final QuestionPostImageRepository questionPostImageRepository;
 	private final MemberRepository memberRepository;
+	private final CreditHistoryService creditHistoryService;
 
 	private static void updateQuestionPost(UpdateQuestionPostRequest request, QuestionPost questionPost) {
 		questionPost.updateQuestionPost(
@@ -59,6 +61,7 @@ public class QuestionPostService {
 	) {
 		member.decreaseCredit(request.reward());
 		memberRepository.save(member);
+		creditHistoryService.saveQuestionPostCreditHistory(request.reward(), member);
 
 		QuestionPost questionPost = QuestionPostMapper.toQuestionPost(request, member);
 		return QuestionPostMapper.toRegisterQuestionPostResponse(

--- a/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
@@ -28,8 +28,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.dnd.gongmuin.answer.domain.Answer;
 import com.dnd.gongmuin.answer.dto.AnswerDetailResponse;
 import com.dnd.gongmuin.answer.dto.RegisterAnswerRequest;
+import com.dnd.gongmuin.answer.exception.AnswerErrorCode;
 import com.dnd.gongmuin.answer.repository.AnswerRepository;
 import com.dnd.gongmuin.common.dto.PageResponse;
+import com.dnd.gongmuin.common.exception.runtime.NotFoundException;
 import com.dnd.gongmuin.common.exception.runtime.ValidationException;
 import com.dnd.gongmuin.common.fixture.AnswerFixture;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
@@ -112,6 +114,24 @@ class AnswerServiceTest {
 		//then
 		Assertions.assertThat(response.content()).isEqualTo(request.content());
 		Assertions.assertThat(questionPost.getQuestionPostStatus()).isEqualTo(QuestionPostStatus.CHOSEN_COMPLETE);
+	}
+
+	@DisplayName("[답변마감 상태인 질문글에 답변을 등록할 때 예외가 발생한다.]")
+	@Test
+	void throwExceptionWhenQuestionPostStatusIsAnswerClose() {
+		//given
+		QuestionPost questionPost = QuestionPostFixture.questionPost(1L);
+		ReflectionTestUtils.setField(questionPost, "questionPostStatus", QuestionPostStatus.ANSWER_CLOSE);
+		RegisterAnswerRequest request = new RegisterAnswerRequest("답변 내용");
+
+		given(questionPostRepository.findById(questionPost.getId())).willReturn(Optional.of(questionPost));
+
+		//when  //then
+		assertThatThrownBy(
+			() -> answerService.registerAnswer(questionPost.getId(), request, MemberFixture.member(1L))
+		)
+			.isInstanceOf(NotFoundException.class)
+			.hasMessage(AnswerErrorCode.NOT_REGISTER_ANSWER.getMessage());
 	}
 
 	@DisplayName("[질문글 아이디로 답변을 모두 조회할 수 있다.]")

--- a/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
@@ -39,6 +39,7 @@ import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.exception.MemberErrorCode;
 import com.dnd.gongmuin.notification.service.NotificationService;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
+import com.dnd.gongmuin.question_post.domain.QuestionPostStatus;
 import com.dnd.gongmuin.question_post.exception.QuestionPostErrorCode;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 
@@ -70,22 +71,47 @@ class AnswerServiceTest {
 	@Test
 	void registerAnswer() {
 		//given
-		Long questionPostId = 1L;
-		Answer answer = AnswerFixture.answer(1L, questionPostId);
+		QuestionPost questionPost = QuestionPostFixture.questionPost(1L);
+		Answer answer = AnswerFixture.answer(1L, questionPost.getId());
 		RegisterAnswerRequest request =
 			new RegisterAnswerRequest("답변 내용");
 
-		given(questionPostRepository.findById(questionPostId))
-			.willReturn(Optional.of(QuestionPostFixture.questionPost(questionPostId)));
+		given(questionPostRepository.findById(questionPost.getId()))
+			.willReturn(Optional.of(questionPost));
 		given(answerRepository.save(any(Answer.class)))
 			.willReturn(answer);
 
 		//when
 		AnswerDetailResponse response
-			= answerService.registerAnswer(questionPostId, request, MemberFixture.member(1L));
+			= answerService.registerAnswer(questionPost.getId(), request, MemberFixture.member(1L));
 
 		//then
 		Assertions.assertThat(response.content()).isEqualTo(request.content());
+		Assertions.assertThat(questionPost.getQuestionPostStatus()).isEqualTo(QuestionPostStatus.CHOSEN_WAITING);
+	}
+
+	@DisplayName("[답변대기 상태가 아닌 질문글에 답변을 등록할 때 질문글 상태가 변하지 않는다.]")
+	@Test
+	void notChangeQuestionPostStatusWhenRegisterAnswerAndQuestionPostStatusIsNotAnswerWaiting() {
+		//given
+		QuestionPost questionPost = QuestionPostFixture.questionPost(1L);
+		ReflectionTestUtils.setField(questionPost, "questionPostStatus", QuestionPostStatus.CHOSEN_COMPLETE);
+		Answer answer = AnswerFixture.answer(1L, questionPost.getId());
+		RegisterAnswerRequest request =
+			new RegisterAnswerRequest("답변 내용");
+
+		given(questionPostRepository.findById(questionPost.getId()))
+			.willReturn(Optional.of(questionPost));
+		given(answerRepository.save(any(Answer.class)))
+			.willReturn(answer);
+
+		//when
+		AnswerDetailResponse response
+			= answerService.registerAnswer(questionPost.getId(), request, MemberFixture.member(1L));
+
+		//then
+		Assertions.assertThat(response.content()).isEqualTo(request.content());
+		Assertions.assertThat(questionPost.getQuestionPostStatus()).isEqualTo(QuestionPostStatus.CHOSEN_COMPLETE);
 	}
 
 	@DisplayName("[질문글 아이디로 답변을 모두 조회할 수 있다.]")

--- a/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
@@ -131,7 +131,7 @@ class AnswerServiceTest {
 			() -> answerService.registerAnswer(questionPost.getId(), request, MemberFixture.member(1L))
 		)
 			.isInstanceOf(NotFoundException.class)
-			.hasMessage(AnswerErrorCode.NOT_REGISTER_ANSWER.getMessage());
+			.hasMessage(AnswerErrorCode.CANNOT_REGISTER_ANSWER.getMessage());
 	}
 
 	@DisplayName("[질문글 아이디로 답변을 모두 조회할 수 있다.]")

--- a/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
@@ -161,6 +161,7 @@ class AnswerServiceTest {
 		Assertions.assertThat(response.isChosen()).isTrue();
 	}
 
+	@Disabled
 	@DisplayName("[크레딧이 부족하면 답변을 채택할 수 없다.]")
 	@Test
 	void chooseAnswer_fail() {

--- a/src/test/java/com/dnd/gongmuin/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/auth/controller/AuthControllerTest.java
@@ -161,7 +161,8 @@ class AuthControllerTest extends ApiTestSupport {
 		Answer answer2 = AnswerFixture.answer(questionPost2.getId(), loginMember);
 		answerRepository.saveAll(List.of(answer1, answer2));
 
-		CreditHistory creditHistory = CreditHistoryFixture.creditHistory(CreditType.CHOOSE, 1000, loginMember);
+		CreditHistory creditHistory = CreditHistoryFixture
+			.creditHistory(CreditType.WRITE_QUESTION_POST, 1000, loginMember);
 		creditHistoryRepository.save(creditHistory);
 
 		Interaction interaction1 = InteractionFixture.interaction(InteractionType.RECOMMEND, loginMember.getId(),

--- a/src/test/java/com/dnd/gongmuin/credit_history/service/CreditHistoryServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/credit_history/service/CreditHistoryServiceTest.java
@@ -43,11 +43,7 @@ class CreditHistoryServiceTest {
 		QuestionPost questionPost = QuestionPostFixture.questionPost(MemberFixture.member(1L));
 		Answer answer = AnswerFixture.answer(questionPost.getId(), MemberFixture.member(2L));
 
-		List<CreditHistory> creditHistories = List.of(
-			CreditHistoryFixture.creditHistory(CreditType.CHOOSE, questionPost.getReward(), questionPost.getMember()),
-			CreditHistoryFixture.creditHistory(CreditType.CHOSEN, questionPost.getReward(), answer.getMember())
-		);
-		given(creditHistoryRepository.saveAll(anyList())).willReturn(creditHistories);
+		given(creditHistoryRepository.save(any(CreditHistory.class))).willReturn(any(CreditHistory.class));
 
 		creditHistoryService.saveChosenCreditHistory(questionPost, answer);
 	}

--- a/src/test/java/com/dnd/gongmuin/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/member/controller/MemberControllerTest.java
@@ -227,11 +227,13 @@ class MemberControllerTest extends ApiTestSupport {
 		Answer answer2 = AnswerFixture.answer(questionPost2.getId(), loginMember);
 		answerRepository.saveAll(List.of(answer1, answer2));
 
-		CreditHistory ch1 = CreditHistoryFixture.creditHistory(CreditType.CHOOSE, questionPost1.getReward(),
+		CreditHistory ch1 = CreditHistoryFixture.creditHistory(CreditType.WRITE_QUESTION_POST,
+			questionPost1.getReward(),
 			questionPost1.getMember());
 		CreditHistory ch2 = CreditHistoryFixture.creditHistory(CreditType.CHOSEN, questionPost1.getReward(),
 			answer1.getMember());
-		CreditHistory ch3 = CreditHistoryFixture.creditHistory(CreditType.CHOOSE, questionPost1.getReward(),
+		CreditHistory ch3 = CreditHistoryFixture.creditHistory(CreditType.WRITE_QUESTION_POST,
+			questionPost1.getReward(),
 			questionPost2.getMember());
 		CreditHistory ch4 = CreditHistoryFixture.creditHistory(CreditType.CHOSEN, questionPost1.getReward(),
 			answer2.getMember());
@@ -270,11 +272,13 @@ class MemberControllerTest extends ApiTestSupport {
 		Answer answer2 = AnswerFixture.answer(questionPost2.getId(), loginMember);
 		answerRepository.saveAll(List.of(answer1, answer2));
 
-		CreditHistory ch1 = CreditHistoryFixture.creditHistory(CreditType.CHOOSE, questionPost1.getReward(),
+		CreditHistory ch1 = CreditHistoryFixture.creditHistory(CreditType.WRITE_QUESTION_POST,
+			questionPost1.getReward(),
 			questionPost1.getMember());
 		CreditHistory ch2 = CreditHistoryFixture.creditHistory(CreditType.CHOSEN, questionPost1.getReward(),
 			answer1.getMember());
-		CreditHistory ch3 = CreditHistoryFixture.creditHistory(CreditType.CHOOSE, questionPost1.getReward(),
+		CreditHistory ch3 = CreditHistoryFixture.creditHistory(CreditType.WRITE_QUESTION_POST,
+			questionPost1.getReward(),
 			questionPost2.getMember());
 		CreditHistory ch4 = CreditHistoryFixture.creditHistory(CreditType.CHOSEN, questionPost1.getReward(),
 			answer2.getMember());
@@ -309,11 +313,13 @@ class MemberControllerTest extends ApiTestSupport {
 		Answer answer2 = AnswerFixture.answer(questionPost2.getId(), loginMember);
 		answerRepository.saveAll(List.of(answer1, answer2));
 
-		CreditHistory ch1 = CreditHistoryFixture.creditHistory(CreditType.CHOOSE, questionPost1.getReward(),
+		CreditHistory ch1 = CreditHistoryFixture.creditHistory(CreditType.WRITE_QUESTION_POST,
+			questionPost1.getReward(),
 			questionPost1.getMember());
 		CreditHistory ch2 = CreditHistoryFixture.creditHistory(CreditType.CHOSEN, questionPost1.getReward(),
 			answer1.getMember());
-		CreditHistory ch3 = CreditHistoryFixture.creditHistory(CreditType.CHOOSE, questionPost1.getReward(),
+		CreditHistory ch3 = CreditHistoryFixture.creditHistory(CreditType.WRITE_QUESTION_POST,
+			questionPost1.getReward(),
 			questionPost2.getMember());
 		CreditHistory ch4 = CreditHistoryFixture.creditHistory(CreditType.CHOSEN, questionPost1.getReward(),
 			answer2.getMember());

--- a/src/test/java/com/dnd/gongmuin/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/member/repository/MemberRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.dnd.gongmuin.member.repository;
 
+import static com.dnd.gongmuin.credit_history.domain.CreditType.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -24,7 +25,6 @@ import com.dnd.gongmuin.common.fixture.MemberFixture;
 import com.dnd.gongmuin.common.fixture.QuestionPostFixture;
 import com.dnd.gongmuin.common.support.DataJpaTestSupport;
 import com.dnd.gongmuin.credit_history.domain.CreditHistory;
-import com.dnd.gongmuin.credit_history.domain.CreditType;
 import com.dnd.gongmuin.credit_history.repository.CreditHistoryRepository;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.dto.response.AnsweredQuestionPostsResponse;
@@ -417,13 +417,13 @@ class MemberRepositoryTest extends DataJpaTestSupport {
 		QuestionPost questionPost2 = QuestionPostFixture.questionPost(member2);
 		Answer answer2 = AnswerFixture.answer(questionPost2.getId(), member1);
 
-		CreditHistory ch1 = CreditHistoryFixture.creditHistory(CreditType.CHOOSE, questionPost1.getReward(),
+		CreditHistory ch1 = CreditHistoryFixture.creditHistory(WRITE_QUESTION_POST, questionPost1.getReward(),
 			questionPost1.getMember());
-		CreditHistory ch2 = CreditHistoryFixture.creditHistory(CreditType.CHOSEN, questionPost1.getReward(),
+		CreditHistory ch2 = CreditHistoryFixture.creditHistory(CHOSEN, questionPost1.getReward(),
 			answer1.getMember());
-		CreditHistory ch3 = CreditHistoryFixture.creditHistory(CreditType.CHOOSE, questionPost1.getReward(),
+		CreditHistory ch3 = CreditHistoryFixture.creditHistory(WRITE_QUESTION_POST, questionPost1.getReward(),
 			questionPost2.getMember());
-		CreditHistory ch4 = CreditHistoryFixture.creditHistory(CreditType.CHOSEN, questionPost1.getReward(),
+		CreditHistory ch4 = CreditHistoryFixture.creditHistory(CHOSEN, questionPost1.getReward(),
 			answer2.getMember());
 		creditHistoryRepository.saveAll(List.of(ch1, ch2, ch3, ch4));
 
@@ -476,19 +476,15 @@ class MemberRepositoryTest extends DataJpaTestSupport {
 		QuestionPost questionPost2 = QuestionPostFixture.questionPost(member2);
 		Answer answer2 = AnswerFixture.answer(questionPost2.getId(), member1);
 
-		CreditHistory ch1 = CreditHistoryFixture.creditHistory(CreditType.CHOOSE, questionPost1.getReward(),
+		CreditHistory ch1 = CreditHistoryFixture.creditHistory(WRITE_QUESTION_POST, questionPost1.getReward(),
 			questionPost1.getMember());
-		CreditHistory ch2 = CreditHistoryFixture.creditHistory(CreditType.CHOSEN, questionPost1.getReward(),
+		CreditHistory ch2 = CreditHistoryFixture.creditHistory(CHOSEN, questionPost1.getReward(),
 			answer1.getMember());
-		CreditHistory ch3 = CreditHistoryFixture.creditHistory(CreditType.CHOOSE, questionPost1.getReward(),
+		CreditHistory ch3 = CreditHistoryFixture.creditHistory(WRITE_QUESTION_POST, questionPost1.getReward(),
 			questionPost2.getMember());
-		CreditHistory ch4 = CreditHistoryFixture.creditHistory(CreditType.CHOSEN, questionPost1.getReward(),
+		CreditHistory ch4 = CreditHistoryFixture.creditHistory(CHOSEN, questionPost1.getReward(),
 			answer2.getMember());
-		List<CreditHistory> creditHistories = creditHistoryRepository.saveAll(List.of(ch1, ch2, ch3, ch4));
-		for (CreditHistory ch : creditHistories) {
-			System.out.println("ch.getId() = " + ch.getId());
-			System.out.println("ch.getType().getDetail() = " + ch.getType().getDetail());
-		}
+		creditHistoryRepository.saveAll(List.of(ch1, ch2, ch3, ch4));
 
 		// when
 		Slice<CreditHistoryResponse> creditHistoryByMember = memberRepository.getCreditHistoryByMember(
@@ -528,13 +524,13 @@ class MemberRepositoryTest extends DataJpaTestSupport {
 		QuestionPost questionPost2 = QuestionPostFixture.questionPost(member2);
 		Answer answer2 = AnswerFixture.answer(questionPost2.getId(), member1);
 
-		CreditHistory ch1 = CreditHistoryFixture.creditHistory(CreditType.CHOOSE, questionPost1.getReward(),
+		CreditHistory ch1 = CreditHistoryFixture.creditHistory(WRITE_QUESTION_POST, questionPost1.getReward(),
 			questionPost1.getMember());
-		CreditHistory ch2 = CreditHistoryFixture.creditHistory(CreditType.CHOSEN, questionPost1.getReward(),
+		CreditHistory ch2 = CreditHistoryFixture.creditHistory(CHOSEN, questionPost1.getReward(),
 			answer1.getMember());
-		CreditHistory ch3 = CreditHistoryFixture.creditHistory(CreditType.CHOOSE, questionPost1.getReward(),
+		CreditHistory ch3 = CreditHistoryFixture.creditHistory(WRITE_QUESTION_POST, questionPost1.getReward(),
 			questionPost2.getMember());
-		CreditHistory ch4 = CreditHistoryFixture.creditHistory(CreditType.CHOSEN, questionPost1.getReward(),
+		CreditHistory ch4 = CreditHistoryFixture.creditHistory(CHOSEN, questionPost1.getReward(),
 			answer2.getMember());
 		creditHistoryRepository.saveAll(List.of(ch1, ch2, ch3, ch4));
 

--- a/src/test/java/com/dnd/gongmuin/question_post/controller/QuestionPostControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/controller/QuestionPostControllerTest.java
@@ -20,6 +20,7 @@ import com.dnd.gongmuin.common.fixture.InteractionFixture;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
 import com.dnd.gongmuin.common.fixture.QuestionPostFixture;
 import com.dnd.gongmuin.common.support.ApiTestSupport;
+import com.dnd.gongmuin.credit_history.repository.CreditHistoryRepository;
 import com.dnd.gongmuin.member.domain.JobGroup;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.exception.MemberErrorCode;
@@ -47,10 +48,14 @@ class QuestionPostControllerTest extends ApiTestSupport {
 	private InteractionCountRepository interactionCountRepository;
 
 	@Autowired
+	private CreditHistoryRepository creditHistoryRepository;
+
+	@Autowired
 	private InteractionService interactionService;
 
 	@AfterEach
 	void teardown() {
+		creditHistoryRepository.deleteAll();
 		memberRepository.deleteAll();
 		questionPostRepository.deleteAll();
 		interactionRepository.deleteAll();

--- a/src/test/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepositoryTest.java
@@ -1,10 +1,11 @@
 package com.dnd.gongmuin.question_post.repository;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,8 @@ import com.dnd.gongmuin.post_interaction.domain.InteractionType;
 import com.dnd.gongmuin.post_interaction.repository.InteractionCountRepository;
 import com.dnd.gongmuin.post_interaction.repository.InteractionRepository;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
+import com.dnd.gongmuin.question_post.domain.QuestionPostStatus;
+import com.dnd.gongmuin.question_post.dto.RefundQuestionPostDto;
 import com.dnd.gongmuin.question_post.dto.request.QuestionPostSearchCondition;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostSimpleResponse;
 import com.dnd.gongmuin.question_post.dto.response.RecQuestionPostResponse;
@@ -76,7 +79,7 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 			.getContent();
 
 		//then
-		Assertions.assertAll(
+		assertAll(
 			() -> assertThat(responses).hasSize(2),
 			() -> assertThat(responses.get(0).questionPostId()).isEqualTo(questionPost2.getId()),
 			() -> assertThat(responses.get(1).questionPostId()).isEqualTo(questionPost1.getId())
@@ -105,7 +108,7 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 			.getContent();
 
 		//then
-		Assertions.assertAll(
+		assertAll(
 			() -> assertThat(responses).hasSize(2),
 			() -> assertThat(responses.get(0).questionPostId()).isEqualTo(questionPost2.getId()),
 			() -> assertThat(responses.get(1).questionPostId()).isEqualTo(questionPost1.getId())
@@ -134,7 +137,7 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 			.getContent();
 
 		//then
-		Assertions.assertAll(
+		assertAll(
 			() -> assertThat(responses).hasSize(1),
 			() -> assertThat(responses.get(0).questionPostId()).isEqualTo(questionPost1.getId())
 		);
@@ -162,7 +165,7 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 			.getContent();
 		System.out.println(responses);
 		//then
-		Assertions.assertAll(
+		assertAll(
 			() -> assertThat(responses).hasSize(1),
 			() -> assertThat(responses.get(0).questionPostId()).isEqualTo(questionPost.getId()),
 			() -> assertThat(responses.get(0).savedCount()).isEqualTo(1),
@@ -186,7 +189,7 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 			.getContent();
 
 		//then
-		Assertions.assertAll(
+		assertAll(
 			() -> assertThat(responses).hasSize(1),
 
 			() -> assertThat(responses.get(0).questionPostId())
@@ -210,7 +213,7 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 			.getContent();
 
 		//then
-		Assertions.assertAll(
+		assertAll(
 			() -> assertThat(responses).hasSize(2),
 
 			() -> assertThat(responses.get(0).questionPostId())
@@ -238,7 +241,7 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 			.getContent();
 
 		//then
-		Assertions.assertAll(
+		assertAll(
 			() -> assertThat(responses).hasSize(3),
 
 			() -> assertThat(responses.get(0).questionPostId())
@@ -248,6 +251,63 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 			() -> assertThat(responses.get(2).questionPostId())
 				.isEqualTo(questionPost1.getId())
 		);
+	}
+
+	@DisplayName("답변대기 상태로 14일이 지난 질문글을 찾는다.")
+	@Test
+	void getRefundQuestionPostDtos() {
+		// given
+		QuestionPost questionPost1 = QuestionPostFixture.questionPost(1L, member);
+		QuestionPost questionPost2 = QuestionPostFixture.questionPost(2L, member);
+		QuestionPost questionPost3 = QuestionPostFixture.questionPost(3L, member);
+		ReflectionTestUtils.setField(questionPost1, "createdAt", LocalDateTime.now().minusWeeks(2));
+		ReflectionTestUtils.setField(questionPost2, "createdAt", LocalDateTime.now().minusWeeks(2));
+		ReflectionTestUtils.setField(questionPost3, "createdAt", LocalDateTime.now().minusWeeks(2));
+		questionPostRepository.saveAll(List.of(questionPost1, questionPost2, questionPost3));
+
+		// when
+		List<RefundQuestionPostDto> refundQuestionPostDtos = questionPostRepository.getRefundQuestionPostDtos();
+
+		// then
+		assertAll(
+			() -> assertThat(refundQuestionPostDtos).hasSize(3),
+			() -> assertThat(refundQuestionPostDtos).extracting(RefundQuestionPostDto::questionPostId)
+				.containsExactly(
+					1L,
+					2L,
+					3L
+				)
+		);
+	}
+
+	@DisplayName("답변대기 상태로 14일이 지난 질문글의 상태를 답변마감 상태로 변경한다.")
+	@Test
+	void getAutoChangeStatus() {
+		// given
+		QuestionPost questionPost1 = QuestionPostFixture.questionPost(1L, member);
+		QuestionPost questionPost2 = QuestionPostFixture.questionPost(2L, member);
+		QuestionPost questionPost3 = QuestionPostFixture.questionPost(3L, member);
+		questionPostRepository.saveAll(List.of(questionPost1, questionPost2, questionPost3));
+		ReflectionTestUtils.setField(questionPost1, "createdAt", LocalDateTime.now().minusWeeks(1));
+		ReflectionTestUtils.setField(questionPost2, "createdAt", LocalDateTime.now().minusWeeks(1));
+		ReflectionTestUtils.setField(questionPost3, "createdAt", LocalDateTime.now().minusWeeks(1));
+
+		// when
+		questionPostRepository.getAutoChangeStatus();
+
+		em.flush();
+		em.clear();
+
+		// then
+		QuestionPost findQuestionPost1 = questionPostRepository.findById(1L).orElseThrow();
+		QuestionPost findQuestionPost2 = questionPostRepository.findById(2L).orElseThrow();
+		QuestionPost findQuestionPost3 = questionPostRepository.findById(3L).orElseThrow();
+		assertAll(
+			() -> assertThat(findQuestionPost1.getQuestionPostStatus()).isEqualTo(QuestionPostStatus.ANSWER_CLOSE),
+			() -> assertThat(findQuestionPost2.getQuestionPostStatus()).isEqualTo(QuestionPostStatus.ANSWER_CLOSE),
+			() -> assertThat(findQuestionPost3.getQuestionPostStatus()).isEqualTo(QuestionPostStatus.ANSWER_CLOSE)
+		);
+
 	}
 
 	private void interactPost(Long questionPostId, InteractionType type) {

--- a/src/test/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepositoryTest.java
@@ -257,13 +257,12 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 	@Test
 	void getRefundQuestionPostDtos() {
 		// given
-		QuestionPost questionPost1 = QuestionPostFixture.questionPost(1L, member);
-		QuestionPost questionPost2 = QuestionPostFixture.questionPost(2L, member);
-		QuestionPost questionPost3 = QuestionPostFixture.questionPost(3L, member);
+		QuestionPost questionPost1 = questionPostRepository.save(QuestionPostFixture.questionPost(member));
+		QuestionPost questionPost2 = questionPostRepository.save(QuestionPostFixture.questionPost(member));
+		QuestionPost questionPost3 = questionPostRepository.save(QuestionPostFixture.questionPost(member));
 		ReflectionTestUtils.setField(questionPost1, "createdAt", LocalDateTime.now().minusWeeks(2));
 		ReflectionTestUtils.setField(questionPost2, "createdAt", LocalDateTime.now().minusWeeks(2));
 		ReflectionTestUtils.setField(questionPost3, "createdAt", LocalDateTime.now().minusWeeks(2));
-		questionPostRepository.saveAll(List.of(questionPost1, questionPost2, questionPost3));
 
 		// when
 		List<RefundQuestionPostDto> refundQuestionPostDtos = questionPostRepository.getRefundQuestionPostDtos();
@@ -273,9 +272,9 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 			() -> assertThat(refundQuestionPostDtos).hasSize(3),
 			() -> assertThat(refundQuestionPostDtos).extracting(RefundQuestionPostDto::questionPostId)
 				.containsExactly(
-					1L,
-					2L,
-					3L
+					questionPost1.getId(),
+					questionPost2.getId(),
+					questionPost3.getId()
 				)
 		);
 	}
@@ -284,13 +283,12 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 	@Test
 	void getAutoChangeStatus() {
 		// given
-		QuestionPost questionPost1 = QuestionPostFixture.questionPost(1L, member);
-		QuestionPost questionPost2 = QuestionPostFixture.questionPost(2L, member);
-		QuestionPost questionPost3 = QuestionPostFixture.questionPost(3L, member);
-		questionPostRepository.saveAll(List.of(questionPost1, questionPost2, questionPost3));
-		ReflectionTestUtils.setField(questionPost1, "createdAt", LocalDateTime.now().minusWeeks(1));
-		ReflectionTestUtils.setField(questionPost2, "createdAt", LocalDateTime.now().minusWeeks(1));
-		ReflectionTestUtils.setField(questionPost3, "createdAt", LocalDateTime.now().minusWeeks(1));
+		QuestionPost questionPost1 = questionPostRepository.save(QuestionPostFixture.questionPost(member));
+		QuestionPost questionPost2 = questionPostRepository.save(QuestionPostFixture.questionPost(member));
+		QuestionPost questionPost3 = questionPostRepository.save(QuestionPostFixture.questionPost(member));
+		ReflectionTestUtils.setField(questionPost1, "createdAt", LocalDateTime.now().minusWeeks(2));
+		ReflectionTestUtils.setField(questionPost2, "createdAt", LocalDateTime.now().minusWeeks(2));
+		ReflectionTestUtils.setField(questionPost3, "createdAt", LocalDateTime.now().minusWeeks(2));
 
 		// when
 		questionPostRepository.getAutoChangeStatus();
@@ -299,9 +297,9 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 		em.clear();
 
 		// then
-		QuestionPost findQuestionPost1 = questionPostRepository.findById(1L).orElseThrow();
-		QuestionPost findQuestionPost2 = questionPostRepository.findById(2L).orElseThrow();
-		QuestionPost findQuestionPost3 = questionPostRepository.findById(3L).orElseThrow();
+		QuestionPost findQuestionPost1 = questionPostRepository.findById(questionPost1.getId()).orElseThrow();
+		QuestionPost findQuestionPost2 = questionPostRepository.findById(questionPost2.getId()).orElseThrow();
+		QuestionPost findQuestionPost3 = questionPostRepository.findById(questionPost3.getId()).orElseThrow();
 		assertAll(
 			() -> assertThat(findQuestionPost1.getQuestionPostStatus()).isEqualTo(QuestionPostStatus.ANSWER_CLOSE),
 			() -> assertThat(findQuestionPost2.getQuestionPostStatus()).isEqualTo(QuestionPostStatus.ANSWER_CLOSE),

--- a/src/test/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepositoryTest.java
@@ -291,7 +291,7 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 		ReflectionTestUtils.setField(questionPost3, "createdAt", LocalDateTime.now().minusWeeks(2));
 
 		// when
-		questionPostRepository.getAutoChangeStatus();
+		questionPostRepository.updateQuestionPostStatusAnswerClosed();
 
 		em.flush();
 		em.clear();

--- a/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.dnd.gongmuin.common.fixture.InteractionCountFixture;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
 import com.dnd.gongmuin.common.fixture.QuestionPostFixture;
+import com.dnd.gongmuin.credit_history.service.CreditHistoryService;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.repository.MemberRepository;
 import com.dnd.gongmuin.post_interaction.domain.InteractionCount;
@@ -56,6 +57,9 @@ class QuestionPostServiceTest {
 	@Mock
 	private MemberRepository memberRepository;
 
+	@Mock
+	private CreditHistoryService creditHistoryService;
+
 	@InjectMocks
 	private QuestionPostService questionPostService;
 
@@ -76,6 +80,7 @@ class QuestionPostServiceTest {
 
 		given(questionPostRepository.save(any(QuestionPost.class))).willReturn(questionPost);
 		given(memberRepository.save(any(Member.class))).willReturn(member);
+		doNothing().when(creditHistoryService).saveQuestionPostCreditHistory(anyInt(), any(Member.class));
 
 		//when
 		RegisterQuestionPostResponse response = questionPostService.registerQuestionPost(request, member);

--- a/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
@@ -19,12 +19,14 @@ import com.dnd.gongmuin.common.fixture.InteractionCountFixture;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
 import com.dnd.gongmuin.common.fixture.QuestionPostFixture;
 import com.dnd.gongmuin.member.domain.Member;
+import com.dnd.gongmuin.member.repository.MemberRepository;
 import com.dnd.gongmuin.post_interaction.domain.InteractionCount;
 import com.dnd.gongmuin.post_interaction.domain.InteractionType;
 import com.dnd.gongmuin.post_interaction.repository.InteractionCountRepository;
 import com.dnd.gongmuin.post_interaction.repository.InteractionRepository;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.domain.QuestionPostImage;
+import com.dnd.gongmuin.question_post.domain.QuestionPostStatus;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.request.UpdateQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
@@ -51,6 +53,9 @@ class QuestionPostServiceTest {
 	@Mock
 	private InteractionCountRepository interactionCountRepository;
 
+	@Mock
+	private MemberRepository memberRepository;
+
 	@InjectMocks
 	private QuestionPostService questionPostService;
 
@@ -59,6 +64,7 @@ class QuestionPostServiceTest {
 	void registerQuestionPost() {
 		//given
 		QuestionPost questionPost = QuestionPostFixture.questionPost(1L);
+
 		RegisterQuestionPostRequest request =
 			new RegisterQuestionPostRequest(
 				"제목",
@@ -68,8 +74,8 @@ class QuestionPostServiceTest {
 				"공업"
 			);
 
-		given(questionPostRepository.save(any(QuestionPost.class)))
-			.willReturn(questionPost);
+		given(questionPostRepository.save(any(QuestionPost.class))).willReturn(questionPost);
+		given(memberRepository.save(any(Member.class))).willReturn(member);
 
 		//when
 		RegisterQuestionPostResponse response = questionPostService.registerQuestionPost(request, member);
@@ -79,7 +85,8 @@ class QuestionPostServiceTest {
 			() -> assertThat(response.title()).isEqualTo(request.title()),
 			() -> assertThat(response.content()).isEqualTo(request.content()),
 			() -> assertThat(response.reward()).isEqualTo(request.reward()),
-			() -> assertThat(response.targetJobGroup()).isEqualTo(request.targetJobGroup())
+			() -> assertThat(response.targetJobGroup()).isEqualTo(request.targetJobGroup()),
+			() -> assertThat(response.status()).isEqualTo(QuestionPostStatus.ANSWER_WAITING.getStatus())
 		);
 	}
 
@@ -110,7 +117,8 @@ class QuestionPostServiceTest {
 		assertAll(
 			() -> assertThat(response.questionPostId()).isEqualTo(questionPost.getId()),
 			() -> assertThat(response.recommendCount()).isZero(),
-			() -> assertThat(response.savedCount()).isZero()
+			() -> assertThat(response.savedCount()).isZero(),
+			() -> assertThat(response.status()).isEqualTo(QuestionPostStatus.ANSWER_WAITING.getStatus())
 		);
 	}
 
@@ -143,12 +151,10 @@ class QuestionPostServiceTest {
 			= questionPostService.getQuestionPostById(questionPost.getId(), member);
 		//then
 		assertAll(
-			() -> assertThat(response.questionPostId())
-				.isEqualTo(questionPost.getId()),
-			() -> assertThat(response.recommendCount())
-				.isEqualTo(recommendCount.getCount()).isEqualTo(1),
-			() -> assertThat(response.savedCount())
-				.isEqualTo(savedCount.getCount()).isEqualTo(1)
+			() -> assertThat(response.questionPostId()).isEqualTo(questionPost.getId()),
+			() -> assertThat(response.recommendCount()).isEqualTo(recommendCount.getCount()).isEqualTo(1),
+			() -> assertThat(response.savedCount()).isEqualTo(savedCount.getCount()).isEqualTo(1),
+			() -> assertThat(response.status()).isEqualTo(QuestionPostStatus.ANSWER_WAITING.getStatus())
 		);
 	}
 
@@ -199,7 +205,8 @@ class QuestionPostServiceTest {
 				.isEqualTo(questionPost.getId()),
 			() -> assertThat(response.savedCount()).isZero(),
 			() -> assertThat(response.recommendCount())
-				.isEqualTo(recommendCount.getCount()).isEqualTo(1)
+				.isEqualTo(recommendCount.getCount()).isEqualTo(1),
+			() -> assertThat(response.status()).isEqualTo(QuestionPostStatus.ANSWER_WAITING.getStatus())
 		);
 	}
 


### PR DESCRIPTION
### 관련 이슈
- close #167 

### 📑 작업 상세 내용
- 게시글 작성 시 크레딧을 바로 인출시키고 크레딧 내역을 저장한다.
- 게시글은 다음과 같은 상태 필드로 관리된다.
  - 답변 대기(14일 이전 답변 없음), 답변 마감(14일 이후로도 답변없음), 채택 대기(답변 있음), 채택 완료(채택 완료)
- 답변 작성 시 게시글 상태가 '답변대기'일 때 '채택 대기'상태로 변경된다.
- '답변마감'상태 작성글에는 답변을 작성할 수 없도록 예외를 발생시킨다.
- 채택 시 작성자의 크레딧 차감 및 출금 내역 로직을 제거한다.
- 14일간 답변이 달리지 않은 게시글은 크레딧이 반환된다.

[FIx]
- 크레딧 내역에서 입금/출금 조회 시 1분류의 크레딧 타입만 조회되는 버그 발견하고 이를 수정.

### 💫 작업 요약
- 게시글 작성 시 크레딧 차감
  - 크레딧 차감 내역 생성
  - 답변 채택 시 크레딧 차감 및 크레딧 차감 내역 생성 로직 제거
- 게시글 상태 필드 추가
  - 답변 대기(14일 이전 답변 없음), 답변 마감(14일 이후로도 답변없음), 채택 대기(답변 있음), 채택 완료(채택 완료)
- 답변 대기 상태 + 14일 지난 질문글 환불 스케쥴러 

**[Fix]**
- 크레딧 내역에서 입금/출금 조회 시 1분류의 크레딧 타입만 조회되는 버그 발견하고 이를 수정.

### 🔍 중점적으로 리뷰 할 부분
- 변경하면서 연결된 로직 일부분들도 고쳤습니다. 혹시 누락되거나 제거되지 못한 부분이 있다면 코멘트 부탁드립니다.
- 질문글 상태 필드 Enum(QuestionPostStatus)에서 '채택대기/채택완료 ' 상태를 포함하고 있는데 isChosen 필드와 중복이 되는 것 같아서 고민이네요