### PR TITLE
[fix #171] status enum 타입 String으로 변경

### DIFF
--- a/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
+++ b/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
@@ -102,7 +102,7 @@ public class AnswerService {
 
 	private void chooseAnswer(QuestionPost questionPost, Answer answer) {
 		questionPost.updateIsChosen(answer);
-		questionPost.updateStatus(QuestionPostStatus.CHOSEN_COMPLETE);
+		questionPost.updateStatus(QuestionPostStatus.CHOSEN_COMPLETED);
 		answer.getMember().increaseCredit(questionPost.getReward());
 		creditHistoryService.saveChosenCreditHistory(questionPost, answer);
 	}

--- a/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
@@ -1,6 +1,7 @@
 package com.dnd.gongmuin.question_post.domain;
 
 import static jakarta.persistence.ConstraintMode.*;
+import static jakarta.persistence.EnumType.*;
 import static jakarta.persistence.FetchType.*;
 
 import java.util.ArrayList;
@@ -58,7 +59,7 @@ public class QuestionPost extends TimeBaseEntity {
 
 	@Enumerated(STRING)
 	@Column(name = "status", nullable = false)
-	private QuestionPostStatus questionPostStatus;
+	private QuestionPostStatus status;
 
 	@OneToMany(mappedBy = "questionPost", cascade = CascadeType.ALL)
 	private List<QuestionPostImage> images = new ArrayList<>();
@@ -72,7 +73,7 @@ public class QuestionPost extends TimeBaseEntity {
 	private QuestionPost(String title, String content, int reward, JobGroup jobGroup,
 		List<QuestionPostImage> images, Member member) {
 		this.isChosen = false;
-		this.questionPostStatus = QuestionPostStatus.ANSWER_WAITING;
+		this.status = QuestionPostStatus.ANSWER_WAITING;
 		this.title = title;
 		this.content = content;
 		this.reward = reward;
@@ -133,14 +134,14 @@ public class QuestionPost extends TimeBaseEntity {
 	}
 
 	public void updateStatus(QuestionPostStatus status) {
-		this.questionPostStatus = status;
+		this.status = status;
 	}
 
 	public boolean isAnswerClosed() {
-		return QuestionPostStatus.ANSWER_CLOSE.equals(this.questionPostStatus);
+		return QuestionPostStatus.ANSWER_CLOSED.equals(this.status);
 	}
 
 	public boolean isAnswerWaiting() {
-		return QuestionPostStatus.ANSWER_WAITING.equals(this.questionPostStatus);
+		return QuestionPostStatus.ANSWER_WAITING.equals(this.status);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPost.java
@@ -56,6 +56,7 @@ public class QuestionPost extends TimeBaseEntity {
 	@Column(name = "is_chosen", nullable = false)
 	private Boolean isChosen;
 
+	@Enumerated(STRING)
 	@Column(name = "status", nullable = false)
 	private QuestionPostStatus questionPostStatus;
 

--- a/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPostStatus.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/domain/QuestionPostStatus.java
@@ -13,9 +13,9 @@ import lombok.RequiredArgsConstructor;
 public enum QuestionPostStatus {
 
 	ANSWER_WAITING("답변대기"),
-	ANSWER_CLOSE("답변마감"),
+	ANSWER_CLOSED("답변마감"),
 	CHOSEN_WAITING("채택대기"),
-	CHOSEN_COMPLETE("채택완료");
+	CHOSEN_COMPLETED("채택완료");
 
 	private final String status;
 

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
@@ -41,7 +41,7 @@ public class QuestionPostMapper {
 			imagesToUrls(questionPost.getImages()),
 			questionPost.getReward(),
 			questionPost.getJobGroup().getLabel(),
-			questionPost.getQuestionPostStatus().getStatus(),
+			questionPost.getStatus().getStatus(),
 			new MemberInfo(
 				member.getId(),
 				member.getNickname(),
@@ -67,7 +67,7 @@ public class QuestionPostMapper {
 			imagesToUrls(questionPost.getImages()),
 			questionPost.getReward(),
 			questionPost.getJobGroup().getLabel(),
-			questionPost.getQuestionPostStatus().getStatus(),
+			questionPost.getStatus().getStatus(),
 			new MemberInfo(
 				member.getId(),
 				member.getNickname(),

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepositoryImpl.java
@@ -114,7 +114,7 @@ public class QuestionPostQueryRepositoryImpl implements QuestionPostQueryReposit
 			.from(questionPost)
 			.where(
 				questionPost.createdAt.loe(LocalDateTime.now().minusWeeks(2)),
-				questionPost.questionPostStatus.eq(QuestionPostStatus.ANSWER_WAITING)
+				questionPost.status.eq(QuestionPostStatus.ANSWER_WAITING)
 			)
 			.fetch();
 	}
@@ -123,10 +123,10 @@ public class QuestionPostQueryRepositoryImpl implements QuestionPostQueryReposit
 	public void updateQuestionPostStatusAnswerClosed() {
 		queryFactory
 			.update(questionPost)
-			.set(questionPost.questionPostStatus, QuestionPostStatus.ANSWER_CLOSE)
+			.set(questionPost.status, QuestionPostStatus.ANSWER_CLOSED)
 			.where(
 				questionPost.createdAt.loe(LocalDateTime.now().minusWeeks(2)),
-				questionPost.questionPostStatus.eq(QuestionPostStatus.ANSWER_WAITING)
+				questionPost.status.eq(QuestionPostStatus.ANSWER_WAITING)
 			)
 			.execute();
 	}

--- a/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/answer/service/AnswerServiceTest.java
@@ -89,7 +89,7 @@ class AnswerServiceTest {
 
 		//then
 		Assertions.assertThat(response.content()).isEqualTo(request.content());
-		Assertions.assertThat(questionPost.getQuestionPostStatus()).isEqualTo(QuestionPostStatus.CHOSEN_WAITING);
+		Assertions.assertThat(questionPost.getStatus()).isEqualTo(QuestionPostStatus.CHOSEN_WAITING);
 	}
 
 	@DisplayName("[답변대기 상태가 아닌 질문글에 답변을 등록할 때 질문글 상태가 변하지 않는다.]")
@@ -97,7 +97,7 @@ class AnswerServiceTest {
 	void notChangeQuestionPostStatusWhenRegisterAnswerAndQuestionPostStatusIsNotAnswerWaiting() {
 		//given
 		QuestionPost questionPost = QuestionPostFixture.questionPost(1L);
-		ReflectionTestUtils.setField(questionPost, "questionPostStatus", QuestionPostStatus.CHOSEN_COMPLETE);
+		ReflectionTestUtils.setField(questionPost, "status", QuestionPostStatus.CHOSEN_COMPLETED);
 		Answer answer = AnswerFixture.answer(1L, questionPost.getId());
 		RegisterAnswerRequest request =
 			new RegisterAnswerRequest("답변 내용");
@@ -113,7 +113,7 @@ class AnswerServiceTest {
 
 		//then
 		Assertions.assertThat(response.content()).isEqualTo(request.content());
-		Assertions.assertThat(questionPost.getQuestionPostStatus()).isEqualTo(QuestionPostStatus.CHOSEN_COMPLETE);
+		Assertions.assertThat(questionPost.getStatus()).isEqualTo(QuestionPostStatus.CHOSEN_COMPLETED);
 	}
 
 	@DisplayName("[답변마감 상태인 질문글에 답변을 등록할 때 예외가 발생한다.]")
@@ -121,7 +121,7 @@ class AnswerServiceTest {
 	void throwExceptionWhenQuestionPostStatusIsAnswerClose() {
 		//given
 		QuestionPost questionPost = QuestionPostFixture.questionPost(1L);
-		ReflectionTestUtils.setField(questionPost, "questionPostStatus", QuestionPostStatus.ANSWER_CLOSE);
+		ReflectionTestUtils.setField(questionPost, "status", QuestionPostStatus.ANSWER_CLOSED);
 		RegisterAnswerRequest request = new RegisterAnswerRequest("답변 내용");
 
 		given(questionPostRepository.findById(questionPost.getId())).willReturn(Optional.of(questionPost));

--- a/src/test/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepositoryTest.java
@@ -301,9 +301,9 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 		QuestionPost findQuestionPost2 = questionPostRepository.findById(questionPost2.getId()).orElseThrow();
 		QuestionPost findQuestionPost3 = questionPostRepository.findById(questionPost3.getId()).orElseThrow();
 		assertAll(
-			() -> assertThat(findQuestionPost1.getQuestionPostStatus()).isEqualTo(QuestionPostStatus.ANSWER_CLOSE),
-			() -> assertThat(findQuestionPost2.getQuestionPostStatus()).isEqualTo(QuestionPostStatus.ANSWER_CLOSE),
-			() -> assertThat(findQuestionPost3.getQuestionPostStatus()).isEqualTo(QuestionPostStatus.ANSWER_CLOSE)
+			() -> assertThat(findQuestionPost1.getStatus()).isEqualTo(QuestionPostStatus.ANSWER_CLOSED),
+			() -> assertThat(findQuestionPost2.getStatus()).isEqualTo(QuestionPostStatus.ANSWER_CLOSED),
+			() -> assertThat(findQuestionPost3.getStatus()).isEqualTo(QuestionPostStatus.ANSWER_CLOSED)
 		);
 
 	}


### PR DESCRIPTION
### 관련 이슈
- close #171 

### 📑 작업 상세 내용
- 추가된 questionpost 상태필드의 enum 타입 수정
  - ordinal->String
- 다른 엔티티와 일관성 위해 status로 변경
- enum 내 상수들 형용사로 통일

### 💫 작업 요약
- 

### 🔍 중점적으로 리뷰 할 부분
- 
