### PR TITLE
[chore #173] 운영 서버 / 개발 서버 분리

### DIFF
--- a/.github/workflows/cd_dev.yml
+++ b/.github/workflows/cd_dev.yml
@@ -3,8 +3,6 @@ name: Dev Server Deploy
 on:
   push:
     branches: ["dev"]
-  pull_request:
-    branches: [ "main", "dev" ]
 
 permissions:
   contents: read

--- a/.github/workflows/cd_dev.yml
+++ b/.github/workflows/cd_dev.yml
@@ -3,6 +3,8 @@ name: 개발 서버 자동 배포
 on:
   push:
     branches: ["dev"]
+  pull_request:
+    branches: [ "main", "dev" ]
 
 permissions:
   contents: read
@@ -45,13 +47,13 @@ jobs:
       - name: 도커 허브 로그인
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME_DEV }}
+          password: ${{ secrets.DOCKERHUB_TOKEN_DEV }}
 
       - name: 도커 이미지 빌드 및 푸시
         run: |
-          docker build -f Dockerfile -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_NAME }} .
-          docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_NAME }}
+          docker build -f Dockerfile -t ${{ secrets.DOCKERHUB_USERNAME_DEV }}/${{ secrets.DOCKERHUB_APP_NAME }} .
+          docker push ${{ secrets.DOCKERHUB_USERNAME_DEV }}/${{ secrets.DOCKERHUB_APP_NAME }}
 
   deploy:
     needs: build-and-push-image
@@ -60,13 +62,13 @@ jobs:
       - name: 이미지 pull 받아서 백그라운드 실행
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ secrets.EC2_HOST }}
+          host: ${{ secrets.EC2_HOST_DEV }}
           username: ${{ secrets.EC2_USERNAME }}
-          key: ${{ secrets.EC2_KEY }}
+          key: ${{ secrets.EC2_KEY_DEV }}
           port: ${{ secrets.EC2_PORT }}
           script: |
             cd compose
             docker rm -f $(docker ps -qa)
-            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_NAME }} 
+            docker pull ${{ secrets.DOCKERHUB_USERNAME_DEV }}/${{ secrets.DOCKERHUB_APP_NAME }} 
             docker-compose up -d
             docker system prune -f

--- a/.github/workflows/cd_dev.yml
+++ b/.github/workflows/cd_dev.yml
@@ -1,4 +1,4 @@
-name: 개발 서버 자동 배포
+name: Dev Server Deploy
 
 on:
   push:
@@ -25,7 +25,7 @@ jobs:
       - name: main 경로 application.yml 파일 생성
         run: |
           mkdir -p ./src/main/resources
-          echo "${{ secrets.MAIN_APPLICATION_YML }}" | base64 -d > ./src/main/resources/application.yml
+          echo "${{ secrets.APPLICATION_YML_DEV }}" | base64 -d > ./src/main/resources/application.yml
 
       - name: gradle 권한 부여
         run: chmod +x ./gradlew

--- a/.github/workflows/cd_dev.yml
+++ b/.github/workflows/cd_dev.yml
@@ -3,6 +3,8 @@ name: 개발 서버 자동 배포
 on:
   push:
     branches: ["dev"]
+  pull_request:
+    branches: [ "main", "dev" ]
 
 permissions:
   contents: read

--- a/.github/workflows/cd_dev.yml
+++ b/.github/workflows/cd_dev.yml
@@ -1,8 +1,8 @@
-name: CD Backend
+name: 개발 서버 자동 배포
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: ["dev"]
 
 permissions:
   contents: read
@@ -14,26 +14,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      # 자바 버전 설정
-      - name: Set up JDK 17
+      - name: 자바 버전 설정
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
 
-      # main 경로 application.yml 파일 생성
-      - name: Generate application.yml
+      - name: main 경로 application.yml 파일 생성
         run: |
           mkdir -p ./src/main/resources
           echo "${{ secrets.MAIN_APPLICATION_YML }}" | base64 -d > ./src/main/resources/application.yml
 
-      # gradle 권한 부여
-      - name: Grant execute permission for gradlew
+      - name: gradle 권한 부여
         run: chmod +x ./gradlew
         shell: bash
 
-      # 빌드 시 캐시 적용
-      - name: Gradle Caching
+      - name: 빌드 시 캐시 적용
         uses: actions/cache@v3
         with:
           path: |
@@ -43,19 +39,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # 빌드
-      - name: Build with Gradle
+      - name: 빌드
         run: ./gradlew build -x test
 
-      # 도커 허브 로그인
-      - name: Docker Hub Login
+      - name: 도커 허브 로그인
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # 도커 이미지 빌드 및 푸시
-      - name: docker image build and push
+      - name: 도커 이미지 빌드 및 푸시
         run: |
           docker build -f Dockerfile -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_NAME }} .
           docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_NAME }}
@@ -64,8 +57,7 @@ jobs:
     needs: build-and-push-image
     runs-on: ubuntu-latest
     steps:
-      # 서버 백그라운드 실행
-      - name: pull image and run container
+      - name: 이미지 pull 받아서 백그라운드 실행
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.EC2_HOST }}

--- a/.github/workflows/cd_dev.yml
+++ b/.github/workflows/cd_dev.yml
@@ -3,8 +3,6 @@ name: 개발 서버 자동 배포
 on:
   push:
     branches: ["dev"]
-  pull_request:
-    branches: [ "main", "dev" ]
 
 permissions:
   contents: read

--- a/.github/workflows/cd_prod.yml
+++ b/.github/workflows/cd_prod.yml
@@ -3,6 +3,8 @@ name: 운영 서버 자동 배포
 on:
   push:
     branches: ["prod"]
+  pull_request:
+    branches: ["dev"]
 
 permissions:
   contents: read

--- a/.github/workflows/cd_prod.yml
+++ b/.github/workflows/cd_prod.yml
@@ -1,0 +1,72 @@
+name: 운영 서버 자동 배포
+
+on:
+  push:
+    branches: ["prod"]
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: 자바 버전 설정
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: main 경로 application.yml 파일 생성
+        run: |
+          mkdir -p ./src/main/resources
+          echo "${{ secrets.PROD_APPLICATION_YML }}" | base64 -d > ./src/main/resources/application.yml
+
+      - name: gradle 권한 부여
+        run: chmod +x ./gradlew
+        shell: bash
+
+      - name: 빌드 시 캐시 적용
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: 빌드
+        run: ./gradlew build -x test
+
+      - name: 도커 허브 로그인
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME_PROD }}
+          password: ${{ secrets.DOCKERHUB_TOKEN_PROD }}
+
+      - name: 도커 이미지 빌드 및 푸시
+        run: |
+          docker build -f Dockerfile -t ${{ secrets.DOCKERHUB_USERNAME_PROD }}/${{ secrets.DOCKERHUB_APP_NAME }} .
+          docker push ${{ secrets.DOCKERHUB_USERNAME_PROD }}/${{ secrets.DOCKERHUB_APP_NAME }}
+
+  deploy:
+    needs: build-and-push-image
+    runs-on: ubuntu-latest
+    steps:
+      - name: 이미지 pull 받아서 백그라운드 실행
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.EC2_HOST_PROD }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_KEY_PROD }}
+          port: ${{ secrets.EC2_PORT }}
+          script: |
+            cd compose
+            docker rm -f $(docker ps -qa)
+            docker pull ${{ secrets.DOCKERHUB_USERNAME_PROD }}/${{ secrets.DOCKERHUB_APP_NAME }} 
+            docker-compose up -d
+            docker system prune -f

--- a/.github/workflows/cd_prod.yml
+++ b/.github/workflows/cd_prod.yml
@@ -3,6 +3,8 @@ name: 운영 서버 자동 배포
 on:
   push:
     branches: ["prod"]
+  pull_request:
+    branches: [ "main", "dev" ]
 
 permissions:
   contents: read

--- a/.github/workflows/cd_prod.yml
+++ b/.github/workflows/cd_prod.yml
@@ -1,4 +1,4 @@
-name: 운영 서버 자동 배포
+name: Prod Server Deploy
 
 on:
   push:
@@ -25,7 +25,7 @@ jobs:
       - name: main 경로 application.yml 파일 생성
         run: |
           mkdir -p ./src/main/resources
-          echo "${{ secrets.PROD_APPLICATION_YML }}" | base64 -d > ./src/main/resources/application.yml
+          echo "${{ secrets.APPLICATION_YML_PROD }}" | base64 -d > ./src/main/resources/application.yml
 
       - name: gradle 권한 부여
         run: chmod +x ./gradlew

--- a/.github/workflows/cd_prod.yml
+++ b/.github/workflows/cd_prod.yml
@@ -3,8 +3,6 @@ name: Prod Server Deploy
 on:
   push:
     branches: ["prod"]
-  pull_request:
-    branches: [ "main", "dev" ]
 
 permissions:
   contents: read

--- a/.github/workflows/cd_prod.yml
+++ b/.github/workflows/cd_prod.yml
@@ -3,8 +3,6 @@ name: 운영 서버 자동 배포
 on:
   push:
     branches: ["prod"]
-  pull_request:
-    branches: ["dev"]
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ out/
 /src/main/generated/
 /src/main/resources/application-local.yml
 /src/main/resources/application-prod.yml
+/src/main/resources/application-dev.yml

--- a/src/main/java/com/dnd/gongmuin/common/config/SwaggerConfig.java
+++ b/src/main/java/com/dnd/gongmuin/common/config/SwaggerConfig.java
@@ -12,12 +12,7 @@ import io.swagger.v3.oas.annotations.servers.Server;
 	info = @Info(
 		title = "GongmuIn API",
 		description = "공무인 API 명세서",
-		version = "v.1.0"),
-	servers = {
-		@Server(url = "https://gongmuin.site", description = "개발 서버"),
-		@Server(url = "https://gongmuin.shop", description = "운영 서버"),
-		@Server(url = "http://localhost:8080", description = "Local Host URL")
-	}
+		version = "v.1.0")
 )
 @Configuration
 public class SwaggerConfig {

--- a/src/main/java/com/dnd/gongmuin/common/config/SwaggerConfig.java
+++ b/src/main/java/com/dnd/gongmuin/common/config/SwaggerConfig.java
@@ -14,7 +14,8 @@ import io.swagger.v3.oas.annotations.servers.Server;
 		description = "공무인 API 명세서",
 		version = "v.1.0"),
 	servers = {
-		@Server(url = "https://gongmuin.site", description = "Deploy Server URL"),
+		@Server(url = "https://gongmuin.site", description = "개발 서버"),
+		@Server(url = "https://gongmuin.shop", description = "운영 서버"),
 		@Server(url = "http://localhost:8080", description = "Local Host URL")
 	}
 )

--- a/src/main/java/com/dnd/gongmuin/security/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/gongmuin/security/config/SecurityConfig.java
@@ -91,7 +91,7 @@ public class SecurityConfig {
 		CorsConfiguration configuration = new CorsConfiguration();
 
 		configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "https://gongmuin.netlify.app",
-			"https://gongmuin.site/", "http://localhost:8080", "/ws/**"));
+			"https://gongmuin.site", "https://gongmuin.shop", "http://localhost:8080", "/ws/**"));
 		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
 		configuration.setAllowedHeaders(Arrays.asList("*"));
 		configuration.setExposedHeaders(Arrays.asList("Set-Cookie", "Authorization"));


### PR DESCRIPTION
### 관련 이슈
- close #173 

### 📑 작업 상세 내용
- 기존 서버는 개발 서버로 두고 운영 서버 신설
  - application.yml prod, dev 분리
  - cd_prod.yml 추가
- 운영 환경 RDS는 private ip없이 ssh tunneling으로 연결
- secret 변수 추가
  -  postfix `prod`, `dev`로 구분
### 💫 작업 요약
- 운영 서버 추가 및 기존 개발 서버 파일명 및 변수명 수정

### 🔍 중점적으로 리뷰 할 부분
- notion에 추가했으니 참고하시면 됩니다~
  - application-prod.yml
  - rds tunneling으로 intellj에 연결 방법 
- swagger url list 삭제 -> 단일 접속
  
