### PR TITLE
[refactor #175] 크레딧 저장 내역 함수 통합

### DIFF
--- a/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
+++ b/src/main/java/com/dnd/gongmuin/answer/service/AnswerService.java
@@ -17,6 +17,7 @@ import com.dnd.gongmuin.common.dto.PageMapper;
 import com.dnd.gongmuin.common.dto.PageResponse;
 import com.dnd.gongmuin.common.exception.runtime.NotFoundException;
 import com.dnd.gongmuin.common.exception.runtime.ValidationException;
+import com.dnd.gongmuin.credit_history.domain.CreditType;
 import com.dnd.gongmuin.credit_history.service.CreditHistoryService;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.notification.dto.NotificationEvent;
@@ -104,7 +105,11 @@ public class AnswerService {
 		questionPost.updateIsChosen(answer);
 		questionPost.updateStatus(QuestionPostStatus.CHOSEN_COMPLETED);
 		answer.getMember().increaseCredit(questionPost.getReward());
-		creditHistoryService.saveChosenCreditHistory(questionPost, answer);
+		creditHistoryService.saveCreditHistory(
+			CreditType.CHOSEN,
+			questionPost.getReward(),
+			questionPost.getMember()
+		);
 	}
 
 	private void validateIfQuestionPostExists(Long questionPostId) {

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
@@ -63,7 +63,7 @@ public class ChatInquiryService {
 			ChatInquiryMapper.toChatInquiry(questionPost, inquirer, answerer, request.inquiryMessage())
 		);
 		memberRepository.save(inquirer);
-		creditHistoryService.saveChatCreditHistory(CreditType.CHAT_REQUEST, inquirer);
+		creditHistoryService.saveCreditHistory(CreditType.CHAT_REQUEST, CHAT_REWARD, inquirer);
 		eventPublisher.publishEvent(
 			new NotificationEvent(NotificationType.CHAT_REQUEST, chatInquiry.getId(), inquirer.getId(), answerer)
 		);
@@ -96,7 +96,7 @@ public class ChatInquiryService {
 		ChatInquiry chatInquiry = getChatInquiryById(chatInquiryId);
 		validateIfAnswerer(answerer, chatInquiry);
 		chatInquiry.updateStatusAccepted();
-		creditHistoryService.saveChatCreditHistory(CreditType.CHAT_ACCEPT, answerer);
+		creditHistoryService.saveCreditHistory(CreditType.CHAT_ACCEPT, CHAT_REWARD, answerer);
 
 		ChatRoom chatRoom = chatRoomRepository.save(
 			ChatRoomMapper.toChatRoom(chatInquiry.getQuestionPost(), chatInquiry.getInquirer(), answerer)
@@ -118,7 +118,7 @@ public class ChatInquiryService {
 
 		validateIfAnswerer(answerer, chatInquiry);
 		chatInquiry.updateStatusRejected();
-		creditHistoryService.saveChatCreditHistory(CreditType.CHAT_REFUND, chatInquiry.getInquirer());
+		creditHistoryService.saveCreditHistory(CreditType.CHAT_REFUND, CHAT_REWARD, chatInquiry.getInquirer());
 		eventPublisher.publishEvent(
 			new NotificationEvent(NotificationType.CHAT_REJECT, chatInquiry.getId(), answerer.getId(),
 				chatInquiry.getInquirer())

--- a/src/main/java/com/dnd/gongmuin/common/config/SwaggerConfig.java
+++ b/src/main/java/com/dnd/gongmuin/common/config/SwaggerConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Configuration;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
-import io.swagger.v3.oas.annotations.servers.Server;
 
 @OpenAPIDefinition(
 	info = @Info(

--- a/src/main/java/com/dnd/gongmuin/credit_history/service/CreditHistoryService.java
+++ b/src/main/java/com/dnd/gongmuin/credit_history/service/CreditHistoryService.java
@@ -3,16 +3,13 @@ package com.dnd.gongmuin.credit_history.service;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import com.dnd.gongmuin.answer.domain.Answer;
 import com.dnd.gongmuin.credit_history.domain.CreditHistory;
 import com.dnd.gongmuin.credit_history.domain.CreditType;
 import com.dnd.gongmuin.credit_history.dto.CreditHistoryMapper;
 import com.dnd.gongmuin.credit_history.repository.CreditHistoryRepository;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.repository.MemberRepository;
-import com.dnd.gongmuin.question_post.domain.QuestionPost;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,18 +20,9 @@ public class CreditHistoryService {
 	private final CreditHistoryRepository creditHistoryRepository;
 	private final MemberRepository memberRepository;
 
-	@Transactional
-	public void saveChosenCreditHistory(QuestionPost questionPost, Answer answer) {
+	public void saveCreditHistory(CreditType creditType, int credit, Member member) {
 		creditHistoryRepository.save(
-			CreditHistoryMapper.toCreditHistory(CreditType.CHOSEN, questionPost.getReward(), answer.getMember())
-		);
-	}
-
-	@Transactional
-	public void saveChatCreditHistory(CreditType creditType, Member member) {
-		int chatCredit = 2000;
-		creditHistoryRepository.save(
-			CreditHistoryMapper.toCreditHistory(creditType, chatCredit, member)
+			CreditHistoryMapper.toCreditHistory(creditType, credit, member)
 		);
 	}
 
@@ -44,17 +32,5 @@ public class CreditHistoryService {
 			.map(inquirer -> CreditHistory.of(type, credit, inquirer))
 			.toList();
 		creditHistoryRepository.saveAll(histories);
-	}
-
-	public void saveQuestionPostCreditHistory(int reward, Member member) {
-		creditHistoryRepository.save(
-			CreditHistoryMapper.toCreditHistory(CreditType.WRITE_QUESTION_POST, reward, member)
-		);
-	}
-
-	public void saveRefundQuestionPostCreditHistory(int reward, Member member) {
-		creditHistoryRepository.save(
-			CreditHistoryMapper.toCreditHistory(CreditType.REFUND_QUESTION_POST, reward, member)
-		);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.dnd.gongmuin.common.dto.PageMapper;
 import com.dnd.gongmuin.common.dto.PageResponse;
 import com.dnd.gongmuin.common.exception.runtime.NotFoundException;
+import com.dnd.gongmuin.credit_history.domain.CreditType;
 import com.dnd.gongmuin.credit_history.service.CreditHistoryService;
 import com.dnd.gongmuin.member.domain.JobGroup;
 import com.dnd.gongmuin.member.domain.Member;
@@ -61,7 +62,7 @@ public class QuestionPostService {
 		Member member
 	) {
 		decreaseMemberCredit(request, member);
-		creditHistoryService.saveQuestionPostCreditHistory(request.reward(), member);
+		creditHistoryService.saveCreditHistory(CreditType.WRITE_QUESTION_POST, request.reward(), member);
 
 		QuestionPost questionPost = QuestionPostMapper.toQuestionPost(request, member);
 		return QuestionPostMapper.toRegisterQuestionPostResponse(
@@ -157,7 +158,8 @@ public class QuestionPostService {
 			refundQuestionPostDto.member().increaseCredit(refundQuestionPostDto.reward());
 			memberRepository.save(refundQuestionPostDto.member());
 
-			creditHistoryService.saveRefundQuestionPostCreditHistory(
+			creditHistoryService.saveCreditHistory(
+				CreditType.REFUND_QUESTION_POST,
 				refundQuestionPostDto.reward(),
 				refundQuestionPostDto.member()
 			);

--- a/src/test/java/com/dnd/gongmuin/credit_history/service/CreditHistoryServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/credit_history/service/CreditHistoryServiceTest.java
@@ -35,7 +35,7 @@ class CreditHistoryServiceTest {
 
 	@DisplayName("회원 아이디 리스트에 속하는 회원에 대한 크레딧을 모두 저장할 수 있다.")
 	@Test
-	void test() {
+	void saveCreditHistoryInMemberIds() {
 		//given
 		List<Long> memberIds = List.of(1L, 2L);
 		Member member1 = MemberFixture.member(memberIds.get(0));

--- a/src/test/java/com/dnd/gongmuin/credit_history/service/CreditHistoryServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/credit_history/service/CreditHistoryServiceTest.java
@@ -12,19 +12,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.dnd.gongmuin.answer.domain.Answer;
-import com.dnd.gongmuin.common.fixture.AnswerFixture;
 import com.dnd.gongmuin.common.fixture.CreditHistoryFixture;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
-import com.dnd.gongmuin.common.fixture.QuestionPostFixture;
 import com.dnd.gongmuin.credit_history.domain.CreditHistory;
 import com.dnd.gongmuin.credit_history.domain.CreditType;
 import com.dnd.gongmuin.credit_history.repository.CreditHistoryRepository;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.repository.MemberRepository;
-import com.dnd.gongmuin.question_post.domain.QuestionPost;
 
-@DisplayName("[AnswerService 테스트]")
+@DisplayName("[CreditHistoryService 테스트]")
 @ExtendWith(MockitoExtension.class)
 class CreditHistoryServiceTest {
 
@@ -36,17 +32,6 @@ class CreditHistoryServiceTest {
 
 	@InjectMocks
 	private CreditHistoryService creditHistoryService;
-
-	@DisplayName("[크레딧 내역을 저장할 수 있다.]")
-	@Test
-	void saveChosenCreditHistory() {
-		QuestionPost questionPost = QuestionPostFixture.questionPost(MemberFixture.member(1L));
-		Answer answer = AnswerFixture.answer(questionPost.getId(), MemberFixture.member(2L));
-
-		given(creditHistoryRepository.save(any(CreditHistory.class))).willReturn(any(CreditHistory.class));
-
-		creditHistoryService.saveChosenCreditHistory(questionPost, answer);
-	}
 
 	@DisplayName("회원 아이디 리스트에 속하는 회원에 대한 크레딧을 모두 저장할 수 있다.")
 	@Test

--- a/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.dnd.gongmuin.common.fixture.InteractionCountFixture;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
 import com.dnd.gongmuin.common.fixture.QuestionPostFixture;
+import com.dnd.gongmuin.credit_history.domain.CreditType;
 import com.dnd.gongmuin.credit_history.service.CreditHistoryService;
 import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.member.repository.MemberRepository;
@@ -80,7 +81,11 @@ class QuestionPostServiceTest {
 
 		given(questionPostRepository.save(any(QuestionPost.class))).willReturn(questionPost);
 		given(memberRepository.save(any(Member.class))).willReturn(member);
-		doNothing().when(creditHistoryService).saveQuestionPostCreditHistory(anyInt(), any(Member.class));
+		doNothing().when(creditHistoryService).saveCreditHistory(
+			CreditType.WRITE_QUESTION_POST,
+			questionPost.getReward(),
+			member
+		);
 
 		//when
 		RegisterQuestionPostResponse response = questionPostService.registerQuestionPost(request, member);


### PR DESCRIPTION
### 관련 이슈
- close #175 

### 📑 작업 상세 내용
- creditHistoryService 타입별로 함수 나눠져 있던 거 통합 
  - 서비스 단위 테스트에서 단건 저장은 repository만 호출하므로 테스트 불필요하다고 생각해 삭제
