### PR TITLE
[feat #177] 질문 글 작성 응답 DTO 잔여 크레딧 추가

### DIFF
--- a/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/QuestionPostMapper.java
@@ -57,9 +57,8 @@ public class QuestionPostMapper {
 	}
 
 	public static RegisterQuestionPostResponse toRegisterQuestionPostResponse(
-		QuestionPost questionPost
+		QuestionPost questionPost, Member member
 	) {
-		Member member = questionPost.getMember();
 		return new RegisterQuestionPostResponse(
 			questionPost.getId(),
 			questionPost.getTitle(),
@@ -74,6 +73,7 @@ public class QuestionPostMapper {
 				member.getJobGroup().getLabel(),
 				member.getProfileImageNo()
 			),
+			member.getCredit(),
 			questionPost.getCreatedAt().toString()
 		);
 	}

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/RegisterQuestionPostResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/RegisterQuestionPostResponse.java
@@ -13,6 +13,7 @@ public record RegisterQuestionPostResponse(
 	String targetJobGroup,
 	String status,
 	MemberInfo memberInfo,
+	int remainingCredit,
 	String createdAt
 ) {
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -66,7 +66,8 @@ public class QuestionPostService {
 
 		QuestionPost questionPost = QuestionPostMapper.toQuestionPost(request, member);
 		return QuestionPostMapper.toRegisterQuestionPostResponse(
-			questionPostRepository.save(questionPost)
+			questionPostRepository.save(questionPost),
+			member
 		);
 	}
 

--- a/src/test/java/com/dnd/gongmuin/question_post/controller/QuestionPostControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/controller/QuestionPostControllerTest.java
@@ -65,11 +65,13 @@ class QuestionPostControllerTest extends ApiTestSupport {
 	@DisplayName("[질문글을 등록할 수 있다.]")
 	@Test
 	void registerQuestionPost() throws Exception {
+		final int reward = 2_000;
+
 		RegisterQuestionPostRequest request = new RegisterQuestionPostRequest(
 			"제목",
 			"정정기간에 여석이 있을까요?",
 			List.of("image1.jpg", "image2.jpg"),
-			2000,
+			reward,
 			"공업"
 		);
 
@@ -86,7 +88,8 @@ class QuestionPostControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.targetJobGroup").value(request.targetJobGroup()))
 			.andExpect(jsonPath("$.memberInfo.memberId").value(loginMember.getId()))
 			.andExpect(jsonPath("$.memberInfo.nickname").value(loginMember.getNickname()))
-			.andExpect(jsonPath("$.memberInfo.memberJobGroup").value(loginMember.getJobGroup().getLabel()));
+			.andExpect(jsonPath("$.memberInfo.memberJobGroup").value(loginMember.getJobGroup().getLabel()))
+			.andExpect(jsonPath("$.remainingCredit").value(loginMember.getCredit() - reward));
 	}
 
 	@DisplayName("[보유 크레딧이 부족하면 질문글을 등록할 수 없다.]")

--- a/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
@@ -96,7 +96,8 @@ class QuestionPostServiceTest {
 			() -> assertThat(response.content()).isEqualTo(request.content()),
 			() -> assertThat(response.reward()).isEqualTo(request.reward()),
 			() -> assertThat(response.targetJobGroup()).isEqualTo(request.targetJobGroup()),
-			() -> assertThat(response.status()).isEqualTo(QuestionPostStatus.ANSWER_WAITING.getStatus())
+			() -> assertThat(response.status()).isEqualTo(QuestionPostStatus.ANSWER_WAITING.getStatus()),
+			() -> assertThat(response.remainingCredit()).isEqualTo(member.getCredit())
 		);
 	}
 


### PR DESCRIPTION
### 관련 이슈
- close #177 

### 📑 작업 상세 내용
- 질문 글 작성 응답 DTO 잔여 크레딧 추가
  -`toRegisterQuestionPostResponse()`의 `Member member = questionPost.getMember()`을 이용한 credit 조회 시 변경감지 적용 전으로 인해 잔여 크레딧 정합성 오류 발생 -> 실제 크레딧이 차감된 Member를 직접 파라미터로 넘겨서 사용하도록 변경

### 💫 작업 요약
- 질문 글 작성 응답 DTO 잔여 크레딧 추가

### 🔍 중점적으로 리뷰 할 부분
- 
