### PR TITLE
[feat #186] 질문글 삭제 API

### DIFF
--- a/src/main/java/com/dnd/gongmuin/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/dnd/gongmuin/answer/repository/AnswerRepository.java
@@ -28,4 +28,5 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 	Optional<Answer> findByIdWithMember(Long answerId);
 
 	boolean existsByQuestionPostIdAndMember(Long questionPostId, Member member);
+	boolean existsByQuestionPostId(Long questionPostId);
 }

--- a/src/main/java/com/dnd/gongmuin/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/dnd/gongmuin/answer/repository/AnswerRepository.java
@@ -26,4 +26,6 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 	@Query("select a from Answer a "
 		+ "join fetch a.member where a.id = :answerId")
 	Optional<Answer> findByIdWithMember(Long answerId);
+
+	boolean existsByQuestionPostId(Long questionPostId);
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
@@ -3,6 +3,7 @@ package com.dnd.gongmuin.question_post.controller;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -16,6 +17,7 @@ import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.question_post.dto.request.QuestionPostSearchCondition;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.request.UpdateQuestionPostRequest;
+import com.dnd.gongmuin.question_post.dto.response.DeleteQuestionPostResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostSimpleResponse;
 import com.dnd.gongmuin.question_post.dto.response.RecQuestionPostResponse;
@@ -92,6 +94,17 @@ public class QuestionPostController {
 	) {
 		UpdateQuestionPostResponse response
 			= questionPostService.updateQuestionPost(questionPostId, request);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "질문글 삭제 API", description = "답변이 없을 시 질문자가 질문글을 삭제할 수 있다.")
+	@ApiResponse(useReturnTypeSchema = true)
+	@DeleteMapping("/api/question-posts/{questionPostId}")
+	public ResponseEntity<DeleteQuestionPostResponse> updateQuestionPosts(
+		@PathVariable("questionPostId") Long questionPostId
+	) {
+		DeleteQuestionPostResponse response
+			= questionPostService.deleteQuestionPost(questionPostId);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
@@ -101,10 +101,11 @@ public class QuestionPostController {
 	@ApiResponse(useReturnTypeSchema = true)
 	@DeleteMapping("/api/question-posts/{questionPostId}")
 	public ResponseEntity<DeleteQuestionPostResponse> updateQuestionPosts(
-		@PathVariable("questionPostId") Long questionPostId
+		@PathVariable("questionPostId") Long questionPostId,
+		@AuthenticationPrincipal Member member
 	) {
 		DeleteQuestionPostResponse response
-			= questionPostService.deleteQuestionPost(questionPostId);
+			= questionPostService.deleteQuestionPost(questionPostId, member);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/DeleteQuestionPostResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/DeleteQuestionPostResponse.java
@@ -1,0 +1,6 @@
+package com.dnd.gongmuin.question_post.dto.response;
+
+public record DeleteQuestionPostResponse(
+	int remainingCredit
+) {
+}

--- a/src/main/java/com/dnd/gongmuin/question_post/exception/QuestionPostErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/exception/QuestionPostErrorCode.java
@@ -11,7 +11,8 @@ public enum QuestionPostErrorCode implements ErrorCode {
 
 	NOT_FOUND_QUESTION_POST("해당 아이디의 질문 포스트가 존재하지 않습니다.", "QP_001"),
 	NOT_AUTHORIZED("질문글에서 해당 작업 권한이 없습니다.", "QP_002"),
-	NOT_FOUND_QUESTION_POST_STATUS("해당 질문글의 상태를 찾을 수 없습니다.", "QP_003");
+	NOT_FOUND_QUESTION_POST_STATUS("해당 질문글의 상태를 찾을 수 없습니다.", "QP_003"),
+	CAN_NOT_DELETE_QUESTION_POST("답변이 존재하는 질문글은 삭제할 수 없습니다.", "QP_004");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -27,6 +27,7 @@ import com.dnd.gongmuin.question_post.dto.RefundQuestionPostDto;
 import com.dnd.gongmuin.question_post.dto.request.QuestionPostSearchCondition;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.request.UpdateQuestionPostRequest;
+import com.dnd.gongmuin.question_post.dto.response.DeleteQuestionPostResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostSimpleResponse;
 import com.dnd.gongmuin.question_post.dto.response.RecQuestionPostResponse;
@@ -124,6 +125,21 @@ public class QuestionPostService {
 		return QuestionPostMapper.toUpdateQuestionPostResponse(questionPost);
 	}
 
+	@Transactional
+	public DeleteQuestionPostResponse deleteQuestionPost(
+		Long questionPostId
+	){
+		QuestionPost questionPost = questionPostRepository.findById(questionPostId)
+			.orElseThrow(() -> new NotFoundException(QuestionPostErrorCode.NOT_FOUND_QUESTION_POST));
+		if (answerRepository.existsByQuestionPostId(questionPostId)) {
+			throw new ValidationException(QuestionPostErrorCode.CAN_NOT_DELETE_QUESTION_POST);
+		}
+		refundDeletedQuestionPosts(questionPost);
+		questionPostRepository.deleteById(questionPostId);
+
+		return new DeleteQuestionPostResponse(questionPost.getMember().getCredit());
+	}
+
 	private void updateQuestionPostImages(QuestionPost questionPost, List<String> imageUrls) {
 		if (imageUrls != null) { // 수정 사항 존재
 			deleteImages(questionPost); // 기존 이미지 객체 삭제 (새로 비우기 || 수정할 값 존재)
@@ -157,8 +173,11 @@ public class QuestionPostService {
 	}
 
 	private void refundDeletedQuestionPosts(QuestionPost questionPost) {
-		questionPost.getMember().increaseCredit(questionPost.getReward());
-		saveRefundCreditHistory(questionPost.getMember(), questionPost.getReward());
+		Member member = questionPost.getMember();
+		int reward = questionPost.getReward();
+		member.increaseCredit(reward);
+
+		saveRefundCreditHistory(member, reward);
 	}
 
 	private void refundClosedQuestionPosts() {

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -134,7 +134,7 @@ public class QuestionPostService {
 		if (answerRepository.existsByQuestionPostId(questionPostId)) {
 			throw new ValidationException(QuestionPostErrorCode.CAN_NOT_DELETE_QUESTION_POST);
 		}
-		refundDeletedQuestionPosts(questionPost);
+		refundDeletedQuestionPost(questionPost);
 		questionPostRepository.deleteById(questionPostId);
 
 		return new DeleteQuestionPostResponse(questionPost.getMember().getCredit());
@@ -172,7 +172,7 @@ public class QuestionPostService {
 		questionPostRepository.updateQuestionPostStatusAnswerClosed();
 	}
 
-	private void refundDeletedQuestionPosts(QuestionPost questionPost) {
+	private void refundDeletedQuestionPost(QuestionPost questionPost) {
 		Member member = questionPost.getMember();
 		int reward = questionPost.getReward();
 		member.increaseCredit(reward);

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -1,6 +1,7 @@
 package com.dnd.gongmuin.question_post.service;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -127,11 +128,12 @@ public class QuestionPostService {
 
 	@Transactional
 	public DeleteQuestionPostResponse deleteQuestionPost(
-		Long questionPostId
+		Long questionPostId, Member member
 	) {
 		QuestionPost questionPost = questionPostRepository.findById(questionPostId)
 			.orElseThrow(() -> new NotFoundException(QuestionPostErrorCode.NOT_FOUND_QUESTION_POST));
 		validateIfQuestionPostExists(questionPostId);
+		validateIfQuestioner(member, questionPost);
 		refundDeletedQuestionPost(questionPost);
 		questionPostRepository.deleteById(questionPostId);
 
@@ -150,6 +152,12 @@ public class QuestionPostService {
 	private void validateIfQuestionPostExists(Long questionPostId) {
 		if (answerRepository.existsByQuestionPostId(questionPostId)) {
 			throw new ValidationException(QuestionPostErrorCode.CAN_NOT_DELETE_QUESTION_POST);
+		}
+	}
+
+	private void validateIfQuestioner(Member member, QuestionPost questionPost){
+		if (!Objects.equals(member.getId(), questionPost.getMember().getId())){
+			throw new ValidationException(QuestionPostErrorCode.NOT_AUTHORIZED);
 		}
 	}
 

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -128,12 +128,10 @@ public class QuestionPostService {
 	@Transactional
 	public DeleteQuestionPostResponse deleteQuestionPost(
 		Long questionPostId
-	){
+	) {
 		QuestionPost questionPost = questionPostRepository.findById(questionPostId)
 			.orElseThrow(() -> new NotFoundException(QuestionPostErrorCode.NOT_FOUND_QUESTION_POST));
-		if (answerRepository.existsByQuestionPostId(questionPostId)) {
-			throw new ValidationException(QuestionPostErrorCode.CAN_NOT_DELETE_QUESTION_POST);
-		}
+		validateIfQuestionPostExists(questionPostId);
 		refundDeletedQuestionPost(questionPost);
 		questionPostRepository.deleteById(questionPostId);
 
@@ -146,6 +144,12 @@ public class QuestionPostService {
 			if (!imageUrls.isEmpty()) { //수정할 값 담아보냄
 				questionPost.updatePostImages(imageUrls);
 			}
+		}
+	}
+
+	private void validateIfQuestionPostExists(Long questionPostId) {
+		if (answerRepository.existsByQuestionPostId(questionPostId)) {
+			throw new ValidationException(QuestionPostErrorCode.CAN_NOT_DELETE_QUESTION_POST);
 		}
 	}
 
@@ -188,7 +192,7 @@ public class QuestionPostService {
 		});
 	}
 
-	private void saveRefundCreditHistory(Member member, int reward){
+	private void saveRefundCreditHistory(Member member, int reward) {
 		memberRepository.save(member);
 
 		creditHistoryService.saveCreditHistory(

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -7,9 +7,11 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.dnd.gongmuin.answer.repository.AnswerRepository;
 import com.dnd.gongmuin.common.dto.PageMapper;
 import com.dnd.gongmuin.common.dto.PageResponse;
 import com.dnd.gongmuin.common.exception.runtime.NotFoundException;
+import com.dnd.gongmuin.common.exception.runtime.ValidationException;
 import com.dnd.gongmuin.credit_history.domain.CreditType;
 import com.dnd.gongmuin.credit_history.service.CreditHistoryService;
 import com.dnd.gongmuin.member.domain.JobGroup;
@@ -46,6 +48,7 @@ public class QuestionPostService {
 	private final QuestionPostImageRepository questionPostImageRepository;
 	private final MemberRepository memberRepository;
 	private final CreditHistoryService creditHistoryService;
+	private final AnswerRepository answerRepository;
 
 	private static void updateQuestionPost(UpdateQuestionPostRequest request, QuestionPost questionPost) {
 		questionPost.updateQuestionPost(
@@ -149,7 +152,7 @@ public class QuestionPostService {
 
 	@Transactional
 	public void changeQuestionPostStatusAnswerClosed() {
-		refundQuestionPostCredit();
+		refundClosedQuestionPosts();
 		questionPostRepository.updateQuestionPostStatusAnswerClosed();
 	}
 
@@ -157,13 +160,17 @@ public class QuestionPostService {
 		List<RefundQuestionPostDto> refundQuestionPostDtos = questionPostRepository.getRefundQuestionPostDtos();
 		refundQuestionPostDtos.forEach(refundQuestionPostDto -> {
 			refundQuestionPostDto.member().increaseCredit(refundQuestionPostDto.reward());
-			memberRepository.save(refundQuestionPostDto.member());
-
-			creditHistoryService.saveCreditHistory(
-				CreditType.REFUND_QUESTION_POST,
-				refundQuestionPostDto.reward(),
-				refundQuestionPostDto.member()
-			);
+			saveRefundCreditHistory(refundQuestionPostDto.member(), refundQuestionPostDto.reward());
 		});
+	}
+
+	private void saveRefundCreditHistory(Member member, int reward){
+		memberRepository.save(member);
+
+		creditHistoryService.saveCreditHistory(
+			CreditType.REFUND_QUESTION_POST,
+			reward,
+			member
+		);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -156,7 +156,12 @@ public class QuestionPostService {
 		questionPostRepository.updateQuestionPostStatusAnswerClosed();
 	}
 
-	private void refundQuestionPostCredit() {
+	private void refundDeletedQuestionPosts(QuestionPost questionPost) {
+		questionPost.getMember().increaseCredit(questionPost.getReward());
+		saveRefundCreditHistory(questionPost.getMember(), questionPost.getReward());
+	}
+
+	private void refundClosedQuestionPosts() {
 		List<RefundQuestionPostDto> refundQuestionPostDtos = questionPostRepository.getRefundQuestionPostDtos();
 		refundQuestionPostDtos.forEach(refundQuestionPostDto -> {
 			refundQuestionPostDto.member().increaseCredit(refundQuestionPostDto.reward());

--- a/src/test/java/com/dnd/gongmuin/question_post/controller/QuestionPostControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/controller/QuestionPostControllerTest.java
@@ -15,6 +15,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
+import com.dnd.gongmuin.answer.domain.Answer;
+import com.dnd.gongmuin.answer.repository.AnswerRepository;
+import com.dnd.gongmuin.common.fixture.AnswerFixture;
 import com.dnd.gongmuin.common.fixture.InteractionCountFixture;
 import com.dnd.gongmuin.common.fixture.InteractionFixture;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
@@ -33,6 +36,7 @@ import com.dnd.gongmuin.post_interaction.service.InteractionService;
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.request.UpdateQuestionPostRequest;
+import com.dnd.gongmuin.question_post.exception.QuestionPostErrorCode;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 
 @DisplayName("[QuestionPost 통합 테스트]")
@@ -51,12 +55,16 @@ class QuestionPostControllerTest extends ApiTestSupport {
 	private CreditHistoryRepository creditHistoryRepository;
 
 	@Autowired
+	private AnswerRepository answerRepository;
+
+	@Autowired
 	private InteractionService interactionService;
 
 	@AfterEach
 	void teardown() {
 		creditHistoryRepository.deleteAll();
 		memberRepository.deleteAll();
+		answerRepository.deleteAll();
 		questionPostRepository.deleteAll();
 		interactionRepository.deleteAll();
 		interactionCountRepository.deleteAll();
@@ -191,7 +199,7 @@ class QuestionPostControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.content[0].questionPostId").value(questionPost3.getId()));
 	}
 
-	@DisplayName("[질문글을 필터링 직군이 3개 넘어가면 예외가 발생한다.]")
+	@DisplayName("[질문글 필터링 직군이 3개 넘어가면 예외가 발생한다.]")
 	@Test
 	void searchQuestionPostByCategoriesFails() throws Exception {
 		QuestionPost questionPost1 = questionPostRepository.save(QuestionPostFixture.questionPost("기계", loginMember));
@@ -245,7 +253,7 @@ class QuestionPostControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.content[2].questionPostId").value(questionPost2.getId()));
 	}
 
-	@DisplayName("[질문글 업데이트해 게시물 정보를 수정할 수 있다..]")
+	@DisplayName("[질문글 게시물 정보를 수정할 수 있다.]")
 	@Test
 	void updateQuestionPost() throws Exception {
 		QuestionPost questionPost = questionPostRepository.save(QuestionPostFixture.questionPost(loginMember));
@@ -331,6 +339,40 @@ class QuestionPostControllerTest extends ApiTestSupport {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.imageUrls.length()")
 				.value(0))
+			.andDo(MockMvcResultHandlers.print());
+	}
+
+	@DisplayName("[질문글을 삭제할 수 있다.]")
+	@Test
+	void deleteQuestionPost() throws Exception {
+		QuestionPost questionPost = questionPostRepository.save(QuestionPostFixture.questionPost(loginMember));
+
+		int creditBeforeDeletion = loginMember.getCredit();
+		int creditAfterDeletion = creditBeforeDeletion + questionPost.getReward();
+
+		mockMvc.perform(delete("/api/question-posts/{questionPostId}", questionPost.getId())
+				.cookie(accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.remainingCredit")
+				.value(creditAfterDeletion))
+			.andDo(MockMvcResultHandlers.print());
+	}
+
+	@DisplayName("[답변이 있을 경우 질문글을 삭제할 수 없다.]")
+	@Test
+	void deleteQuestionPostFails() throws Exception {
+		QuestionPost questionPost = questionPostRepository.save(
+			QuestionPostFixture.questionPost(loginMember)
+		);
+		answerRepository.save(
+			AnswerFixture.answer(questionPost.getId(), loginMember)
+		);
+
+		mockMvc.perform(delete("/api/question-posts/{questionPostId}", questionPost.getId())
+				.cookie(accessToken))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message")
+				.value(QuestionPostErrorCode.CAN_NOT_DELETE_QUESTION_POST.getMessage()))
 			.andDo(MockMvcResultHandlers.print());
 	}
 

--- a/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
@@ -277,7 +277,8 @@ class QuestionPostServiceTest {
 		given(answerRepository.existsByQuestionPostId(questionPostId)).willReturn(false);
 
 		//when
-		DeleteQuestionPostResponse response = questionPostService.deleteQuestionPost(questionPostId);
+		DeleteQuestionPostResponse response
+			= questionPostService.deleteQuestionPost(questionPostId, member);
 
 		//then
 		assertThat(response.remainingCredit())
@@ -296,9 +297,28 @@ class QuestionPostServiceTest {
 
 		//when & then
 		ValidationException exception = assertThrows(ValidationException.class,
-			() -> questionPostService.deleteQuestionPost(questionPostId));
+			() -> questionPostService.deleteQuestionPost(questionPostId, member));
 
-		assertThat(exception.getCode())
-			.isEqualTo(QuestionPostErrorCode.CAN_NOT_DELETE_QUESTION_POST.getCode());
+		assertThat(exception.getMessage())
+			.isEqualTo(QuestionPostErrorCode.CAN_NOT_DELETE_QUESTION_POST.getMessage());
+	}
+
+	@DisplayName("[질문글 작성자가 아닌 경우 질문글을 삭제할 수 없다.]")
+	@Test
+	void deleteQuestionPostFails2() {
+		//given
+		Long questionPostId = 1L;
+		Member unauthorizedMember = MemberFixture.member(2L);
+		QuestionPost questionPost = QuestionPostFixture.questionPost(unauthorizedMember);
+		given(questionPostRepository.findById(questionPostId))
+			.willReturn(Optional.of(questionPost));
+		given(answerRepository.existsByQuestionPostId(questionPostId)).willReturn(false);
+
+		//when & then
+		ValidationException exception = assertThrows(ValidationException.class,
+			() -> questionPostService.deleteQuestionPost(questionPostId, member));
+
+		assertThat(exception.getMessage())
+			.isEqualTo(QuestionPostErrorCode.NOT_AUTHORIZED.getMessage());
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
@@ -15,6 +15,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.dnd.gongmuin.answer.repository.AnswerRepository;
+import com.dnd.gongmuin.common.exception.runtime.ValidationException;
 import com.dnd.gongmuin.common.fixture.InteractionCountFixture;
 import com.dnd.gongmuin.common.fixture.MemberFixture;
 import com.dnd.gongmuin.common.fixture.QuestionPostFixture;
@@ -31,6 +33,7 @@ import com.dnd.gongmuin.question_post.domain.QuestionPostImage;
 import com.dnd.gongmuin.question_post.domain.QuestionPostStatus;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.request.UpdateQuestionPostRequest;
+import com.dnd.gongmuin.question_post.dto.response.DeleteQuestionPostResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.RegisterQuestionPostResponse;
 import com.dnd.gongmuin.question_post.dto.response.UpdateQuestionPostResponse;
@@ -57,6 +60,9 @@ class QuestionPostServiceTest {
 
 	@Mock
 	private MemberRepository memberRepository;
+
+	@Mock
+	private AnswerRepository answerRepository;
 
 	@Mock
 	private CreditHistoryService creditHistoryService;
@@ -255,5 +261,40 @@ class QuestionPostServiceTest {
 				.isEqualTo(questionPost.getImages().stream()
 					.map(QuestionPostImage::getImageUrl).toList())
 		);
+	}
+
+	@DisplayName("[질문글을 삭제할 수 있다.]")
+	@Test
+	void deleteQuestionPost() {
+		//given
+		Long questionPostId = 1L;
+		int previousCredit = member.getCredit();
+		QuestionPost questionPost = QuestionPostFixture.questionPost(member);
+
+		given(questionPostRepository.findById(questionPostId))
+			.willReturn(Optional.of(questionPost));
+		given(answerRepository.existsByQuestionPostId(questionPostId)).willReturn(false);
+
+		//when
+		DeleteQuestionPostResponse response = questionPostService.deleteQuestionPost(questionPostId);
+
+		//then
+		assertThat(response.remainingCredit())
+			.isEqualTo(previousCredit + questionPost.getReward());
+	}
+
+	@DisplayName("[답변이 존재하는 질문글은 삭제할 수 없다.]")
+	@Test
+	void deleteQuestionPostFails() {
+		//given
+		Long questionPostId = 1L;
+		QuestionPost questionPost = QuestionPostFixture.questionPost(member);
+		given(questionPostRepository.findById(questionPostId))
+			.willReturn(Optional.of(questionPost));
+		given(answerRepository.existsByQuestionPostId(questionPostId)).willReturn(true);
+
+		//when & then
+		assertThrows(ValidationException.class,
+			() -> questionPostService.deleteQuestionPost(questionPostId));
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
@@ -37,6 +37,7 @@ import com.dnd.gongmuin.question_post.dto.response.DeleteQuestionPostResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.RegisterQuestionPostResponse;
 import com.dnd.gongmuin.question_post.dto.response.UpdateQuestionPostResponse;
+import com.dnd.gongmuin.question_post.exception.QuestionPostErrorCode;
 import com.dnd.gongmuin.question_post.repository.QuestionPostImageRepository;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 
@@ -294,7 +295,10 @@ class QuestionPostServiceTest {
 		given(answerRepository.existsByQuestionPostId(questionPostId)).willReturn(true);
 
 		//when & then
-		assertThrows(ValidationException.class,
+		ValidationException exception = assertThrows(ValidationException.class,
 			() -> questionPostService.deleteQuestionPost(questionPostId));
+
+		assertThat(exception.getCode())
+			.isEqualTo(QuestionPostErrorCode.CAN_NOT_DELETE_QUESTION_POST.getCode());
 	}
 }


### PR DESCRIPTION
### 관련 이슈
- close #186 

### 📑 작업 상세 내용
- 질문글 삭제 API
  - 해당 질문글에 답변이 달리지 않았을 경우 삭제 가능
  - 삭제 후 질문 등록 시 걸었던 금액 반환 

### 💫 작업 요약
- 질문글 삭제 API 추가 및 테스트 수행

### 🔍 중점적으로 리뷰 할 부분
- 환불하는 함수가 추가로 생겨, 질문 자동마감 시 환불하는 함수명을 `refundClosedQuestionPosts()`로 수정했습니다.
- 질문 마감, 질문 삭제 시 creditHistory에 저장하는 로직이 똑같아서 함수로 추출했습니다.
