### PR TITLE
[fix #184] 채팅 자동 거절 시 수정일 미변경 해결

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepository.java
@@ -1,5 +1,6 @@
 package com.dnd.gongmuin.chat_inquiry.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
@@ -14,7 +15,7 @@ public interface ChatInquiryQueryRepository {
 
 	List<Long> getAutoRejectedInquirerIds();
 
-	void updateChatInquiryStatusRejected();
+	void updateChatInquiryStatusRejected(LocalDateTime now);
 
 	List<RejectedChatInquiryDto> getAutoRejectedChatInquiries();
 }

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepositoryImpl.java
@@ -69,9 +69,10 @@ public class ChatInquiryQueryRepositoryImpl implements ChatInquiryQueryRepositor
 			.fetch();
 	}
 
-	public void updateChatInquiryStatusRejected() {
+	public void updateChatInquiryStatusRejected(LocalDateTime now) {
 		queryFactory.update(chatInquiry)
 			.set(chatInquiry.status, InquiryStatus.REJECTED)
+			.set(chatInquiry.updatedAt, now)
 			.where(
 				chatInquiry.createdAt.loe(LocalDateTime.now().minusWeeks(1)),
 				chatInquiry.status.eq(InquiryStatus.PENDING)

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/scheduler/ChatInquiryScheduler.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/scheduler/ChatInquiryScheduler.java
@@ -1,5 +1,7 @@
 package com.dnd.gongmuin.chat_inquiry.scheduler;
 
+import java.time.LocalDateTime;
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +19,6 @@ public class ChatInquiryScheduler {
 	@Transactional
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	public void rejectChatInquiry() {
-		chatInquiryService.rejectChatAuto();
+		chatInquiryService.rejectChatAuto(LocalDateTime.now());
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
@@ -1,5 +1,6 @@
 package com.dnd.gongmuin.chat_inquiry.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -135,7 +136,7 @@ public class ChatInquiryService {
 	public void rejectChatAuto() {
 		List<RejectedChatInquiryDto> rejectedChatInquiryDtos = chatInquiryRepository.getAutoRejectedChatInquiries();
 		List<Long> rejectedInquirerIds = getRejectedInquirerIds(rejectedChatInquiryDtos);
-		chatInquiryRepository.updateChatInquiryStatusRejected();
+		chatInquiryRepository.updateChatInquiryStatusRejected(LocalDateTime.now());
 		memberRepository.refundInMemberIds(rejectedInquirerIds, CHAT_REWARD);
 		creditHistoryService.saveCreditHistoryInMemberIds(
 			rejectedInquirerIds, CreditType.CHAT_REFUND, CHAT_REWARD

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
@@ -133,10 +133,10 @@ public class ChatInquiryService {
 	}
 
 	@Transactional
-	public void rejectChatAuto() {
+	public void rejectChatAuto(LocalDateTime now) {
 		List<RejectedChatInquiryDto> rejectedChatInquiryDtos = chatInquiryRepository.getAutoRejectedChatInquiries();
 		List<Long> rejectedInquirerIds = getRejectedInquirerIds(rejectedChatInquiryDtos);
-		chatInquiryRepository.updateChatInquiryStatusRejected(LocalDateTime.now());
+		chatInquiryRepository.updateChatInquiryStatusRejected(now);
 		memberRepository.refundInMemberIds(rejectedInquirerIds, CHAT_REWARD);
 		creditHistoryService.saveCreditHistoryInMemberIds(
 			rejectedInquirerIds, CreditType.CHAT_REFUND, CHAT_REWARD

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepository.java
@@ -1,5 +1,6 @@
 package com.dnd.gongmuin.question_post.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
@@ -23,5 +24,5 @@ public interface QuestionPostQueryRepository {
 
 	List<RefundQuestionPostDto> getRefundQuestionPostDtos();
 
-	void updateQuestionPostStatusAnswerClosed();
+	void updateQuestionPostStatusAnswerClosed(LocalDateTime now);
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepositoryImpl.java
@@ -120,10 +120,11 @@ public class QuestionPostQueryRepositoryImpl implements QuestionPostQueryReposit
 	}
 
 	@Override
-	public void updateQuestionPostStatusAnswerClosed() {
+	public void updateQuestionPostStatusAnswerClosed(LocalDateTime now) {
 		queryFactory
 			.update(questionPost)
 			.set(questionPost.status, QuestionPostStatus.ANSWER_CLOSED)
+			.set(questionPost.updatedAt, now)
 			.where(
 				questionPost.createdAt.loe(LocalDateTime.now().minusWeeks(2)),
 				questionPost.status.eq(QuestionPostStatus.ANSWER_WAITING)

--- a/src/main/java/com/dnd/gongmuin/question_post/scheduler/QuestionPostScheduler.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/scheduler/QuestionPostScheduler.java
@@ -1,5 +1,7 @@
 package com.dnd.gongmuin.question_post.scheduler;
 
+import java.time.LocalDateTime;
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +19,6 @@ public class QuestionPostScheduler {
 	@Transactional
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	public void closeQuestionPost() {
-		questionPostService.changeQuestionPostStatusAnswerClosed();
+		questionPostService.changeQuestionPostStatusAnswerClosed(LocalDateTime.now());
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -1,5 +1,6 @@
 package com.dnd.gongmuin.question_post.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
@@ -150,7 +151,7 @@ public class QuestionPostService {
 	@Transactional
 	public void changeQuestionPostStatusAnswerClosed() {
 		refundQuestionPostCredit();
-		questionPostRepository.updateQuestionPostStatusAnswerClosed();
+		questionPostRepository.updateQuestionPostStatusAnswerClosed(LocalDateTime.now());
 	}
 
 	private void refundQuestionPostCredit() {

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -180,9 +180,9 @@ public class QuestionPostService {
 	}
 
 	@Transactional
-	public void changeQuestionPostStatusAnswerClosed() {
+	public void changeQuestionPostStatusAnswerClosed(LocalDateTime now) {
 		refundClosedQuestionPosts();
-		questionPostRepository.updateQuestionPostStatusAnswerClosed(LocalDateTime.now());
+		questionPostRepository.updateQuestionPostStatusAnswerClosed(now);
 	}
 
 	private void refundDeletedQuestionPost(QuestionPost questionPost) {

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -156,8 +156,8 @@ public class QuestionPostService {
 		}
 	}
 
-	private void validateIfQuestioner(Member member, QuestionPost questionPost){
-		if (!Objects.equals(member.getId(), questionPost.getMember().getId())){
+	private void validateIfQuestioner(Member member, QuestionPost questionPost) {
+		if (!Objects.equals(member.getId(), questionPost.getMember().getId())) {
 			throw new ValidationException(QuestionPostErrorCode.NOT_AUTHORIZED);
 		}
 	}
@@ -181,7 +181,7 @@ public class QuestionPostService {
 
 	@Transactional
 	public void changeQuestionPostStatusAnswerClosed() {
-		refundQuestionPostCredit();
+		refundClosedQuestionPosts();
 		questionPostRepository.updateQuestionPostStatusAnswerClosed(LocalDateTime.now());
 	}
 

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryRepositoryTest.java
@@ -86,7 +86,7 @@ class ChatInquiryRepositoryTest extends DataJpaTestSupport {
 		ReflectionTestUtils.setField(chatInquiries.get(0), "createdAt", LocalDateTime.now().minusWeeks(1));
 
 		//when
-		chatInquiryRepository.updateChatInquiryStatusRejected();
+		chatInquiryRepository.updateChatInquiryStatusRejected(LocalDateTime.now());
 
 		em.flush();
 		em.clear();
@@ -115,13 +115,13 @@ class ChatInquiryRepositoryTest extends DataJpaTestSupport {
 
 		List<ChatInquiry> chatInquiries = chatInquiryRepository.saveAll(List.of(chatInquiry1, chatInquiry2));
 		ReflectionTestUtils.setField(chatInquiry1, "createdAt", LocalDateTime.now().minusWeeks(1));
-
-		// when
 		ReflectionTestUtils.setField(chatInquiry1, "updatedAt", LocalDateTime.now().minusWeeks(1));
-		chatInquiryRepository.updateChatInquiryStatusRejected();
-
+		ReflectionTestUtils.setField(chatInquiry2, "updatedAt", LocalDateTime.now().minusWeeks(1));
 		em.flush();
 		em.clear();
+
+		// when
+		chatInquiryRepository.updateChatInquiryStatusRejected(LocalDateTime.now());
 
 		// then
 		ChatInquiry findChatInquiry1 = chatInquiryRepository.findById(chatInquiries.get(0).getId()).orElseThrow();

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryRepositoryTest.java
@@ -3,7 +3,6 @@ package com.dnd.gongmuin.chat_inquiry.repository;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -97,40 +96,6 @@ class ChatInquiryRepositoryTest extends DataJpaTestSupport {
 		assertAll(
 			() -> assertThat(chatInquiry1.getStatus()).isEqualTo(InquiryStatus.REJECTED),
 			() -> assertThat(chatInquiry2.getStatus()).isEqualTo(InquiryStatus.PENDING)
-		);
-	}
-
-	@DisplayName("채팅 요청의 status가 변경되었을 때, updated_at 필드가 변경된다.")
-	@Test
-	void changeUpdatedAtWhenChangeStatusOfChatInquiry() {
-		// given
-		final LocalDate today = LocalDate.now();
-
-		Member questioner = memberRepository.save(MemberFixture.member());
-		Member answerer = memberRepository.save(MemberFixture.member());
-		QuestionPost questionPost = questionPostRepository.save(QuestionPostFixture.questionPost(questioner));
-
-		ChatInquiry chatInquiry1 = ChatInquiryFixture.chatInquiry(questionPost, questioner, answerer, chatMessage);
-		ChatInquiry chatInquiry2 = ChatInquiryFixture.chatInquiry(questionPost, questioner, answerer, chatMessage);
-
-		List<ChatInquiry> chatInquiries = chatInquiryRepository.saveAll(List.of(chatInquiry1, chatInquiry2));
-		ReflectionTestUtils.setField(chatInquiry1, "createdAt", LocalDateTime.now().minusWeeks(1));
-		ReflectionTestUtils.setField(chatInquiry1, "updatedAt", LocalDateTime.now().minusWeeks(1));
-		ReflectionTestUtils.setField(chatInquiry2, "updatedAt", LocalDateTime.now().minusWeeks(1));
-		em.flush();
-		em.clear();
-
-		// when
-		chatInquiryRepository.updateChatInquiryStatusRejected(LocalDateTime.now());
-
-		// then
-		ChatInquiry findChatInquiry1 = chatInquiryRepository.findById(chatInquiries.get(0).getId()).orElseThrow();
-		ChatInquiry findChatInquiry2 = chatInquiryRepository.findById(chatInquiries.get(1).getId()).orElseThrow();
-		assertAll(
-			() -> assertThat(findChatInquiry1.getStatus()).isEqualTo(InquiryStatus.REJECTED),
-			() -> assertThat(findChatInquiry2.getStatus()).isEqualTo(InquiryStatus.PENDING),
-			() -> assertThat(findChatInquiry1.getUpdatedAt().toLocalDate()).isEqualTo(today),
-			() -> assertThat(findChatInquiry2.getUpdatedAt().toLocalDate()).isEqualTo(today)
 		);
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryRepositoryTest.java
@@ -3,6 +3,7 @@ package com.dnd.gongmuin.chat_inquiry.repository;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -96,6 +97,40 @@ class ChatInquiryRepositoryTest extends DataJpaTestSupport {
 		assertAll(
 			() -> assertThat(chatInquiry1.getStatus()).isEqualTo(InquiryStatus.REJECTED),
 			() -> assertThat(chatInquiry2.getStatus()).isEqualTo(InquiryStatus.PENDING)
+		);
+	}
+
+	@DisplayName("채팅 요청의 status가 변경되었을 때, updated_at 필드가 변경된다.")
+	@Test
+	void changeUpdatedAtWhenChangeStatusOfChatInquiry() {
+		// given
+		final LocalDate today = LocalDate.now();
+
+		Member questioner = memberRepository.save(MemberFixture.member());
+		Member answerer = memberRepository.save(MemberFixture.member());
+		QuestionPost questionPost = questionPostRepository.save(QuestionPostFixture.questionPost(questioner));
+
+		ChatInquiry chatInquiry1 = ChatInquiryFixture.chatInquiry(questionPost, questioner, answerer, chatMessage);
+		ChatInquiry chatInquiry2 = ChatInquiryFixture.chatInquiry(questionPost, questioner, answerer, chatMessage);
+
+		List<ChatInquiry> chatInquiries = chatInquiryRepository.saveAll(List.of(chatInquiry1, chatInquiry2));
+		ReflectionTestUtils.setField(chatInquiry1, "createdAt", LocalDateTime.now().minusWeeks(1));
+
+		// when
+		ReflectionTestUtils.setField(chatInquiry1, "updatedAt", LocalDateTime.now().minusWeeks(1));
+		chatInquiryRepository.updateChatInquiryStatusRejected();
+
+		em.flush();
+		em.clear();
+
+		// then
+		ChatInquiry findChatInquiry1 = chatInquiryRepository.findById(chatInquiries.get(0).getId()).orElseThrow();
+		ChatInquiry findChatInquiry2 = chatInquiryRepository.findById(chatInquiries.get(1).getId()).orElseThrow();
+		assertAll(
+			() -> assertThat(findChatInquiry1.getStatus()).isEqualTo(InquiryStatus.REJECTED),
+			() -> assertThat(findChatInquiry2.getStatus()).isEqualTo(InquiryStatus.PENDING),
+			() -> assertThat(findChatInquiry1.getUpdatedAt().toLocalDate()).isEqualTo(today),
+			() -> assertThat(findChatInquiry2.getUpdatedAt().toLocalDate()).isEqualTo(today)
 		);
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -338,7 +339,7 @@ class ChatInquiryServiceTest {
 
 		// then
 		verify(chatInquiryRepository).getAutoRejectedChatInquiries();
-		verify(chatInquiryRepository).updateChatInquiryStatusRejected();
+		verify(chatInquiryRepository).updateChatInquiryStatusRejected(LocalDateTime.now());
 		verify(memberRepository).refundInMemberIds(rejectedInquirerIds, CHAT_REWARD);
 		verify(creditHistoryService).saveCreditHistoryInMemberIds(
 			rejectedInquirerIds, CreditType.CHAT_REFUND, CHAT_REWARD

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
@@ -324,6 +324,8 @@ class ChatInquiryServiceTest {
 	@Test
 	void rejectChatAuto() {
 		// given
+		final LocalDateTime now = LocalDateTime.now();
+
 		List<RejectedChatInquiryDto> rejectedChatInquiryDtos = List.of(
 			new RejectedChatInquiryDto(1L, MemberFixture.member(1L), MemberFixture.member(2L)),
 			new RejectedChatInquiryDto(2L, MemberFixture.member(3L), MemberFixture.member(4L))
@@ -335,11 +337,11 @@ class ChatInquiryServiceTest {
 		given(chatInquiryRepository.getAutoRejectedChatInquiries()).willReturn(rejectedChatInquiryDtos);
 
 		// when
-		chatInquiryService.rejectChatAuto();
+		chatInquiryService.rejectChatAuto(now);
 
 		// then
 		verify(chatInquiryRepository).getAutoRejectedChatInquiries();
-		verify(chatInquiryRepository).updateChatInquiryStatusRejected(LocalDateTime.now());
+		verify(chatInquiryRepository).updateChatInquiryStatusRejected(now);
 		verify(memberRepository).refundInMemberIds(rejectedInquirerIds, CHAT_REWARD);
 		verify(creditHistoryService).saveCreditHistoryInMemberIds(
 			rejectedInquirerIds, CreditType.CHAT_REFUND, CHAT_REWARD

--- a/src/test/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepositoryTest.java
@@ -291,7 +291,7 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 		ReflectionTestUtils.setField(questionPost3, "createdAt", LocalDateTime.now().minusWeeks(2));
 
 		// when
-		questionPostRepository.updateQuestionPostStatusAnswerClosed();
+		questionPostRepository.updateQuestionPostStatusAnswerClosed(LocalDateTime.now());
 
 		em.flush();
 		em.clear();


### PR DESCRIPTION
### 관련 이슈
- close #184 

### 📑 작업 상세 내용
- 채팅 자동 거절 시 수정일 변경 실패 테스트 코드 작성

### 💫 작업 요약
- 

### 🔍 중점적으로 리뷰 할 부분
- 상황: 
  - QA 일정 지연으로 인한 QA 채팅 요청 데이터가 Auth Rejected
  - Rejected 된 chat_inquriy의 `updatedAt필드 갱신이 이루어지지 않음`
  - `@LastModifiedDate`를 의심했는데 잘 이루어지고 있음.
- 결론:
  -  테스트가 잘못 이루어졌는지 애매하네요. 테스트가 문제인지 QA 데이터 삽입 시 발생한 문제인지 찾아보고 있는데, 잘 되지 않아 도움 요청 드립니다.
