### PR TITLE
[fix #190] 답변자가 스스로에게 채팅 요청 보낼 수 없도록 수정

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/exception/ChatInquiryErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/exception/ChatInquiryErrorCode.java
@@ -13,7 +13,8 @@ public enum ChatInquiryErrorCode implements ErrorCode {
 	UNAUTHORIZED_REQUEST("채팅 요청을 수락을 하거나 거절할 권한이 없습니다.", "CI_002"),
 	UNABLE_TO_CHANGE_STATUS("이미 수락했거나 거절한 요청입니다.", "CI_003"),
 	NOT_FOUND_STATUS("채팅방 상태값을 올바르게 입력해주세요.", "CI_004"),
-	NOT_EXISTS_ANSWERER("해당 아이디의 답변자가 해당 게시글에 존재하지 않습니다.", "CI_005");
+	NOT_EXISTS_ANSWERER("해당 아이디의 답변자가 해당 게시글에 존재하지 않습니다.", "CI_005"),
+	SELF_INQUIRY_NOT_ALLOWED("자기 자신에게 채팅 요청을 보낼 수 없습니다.", "CI_006");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
@@ -62,7 +62,7 @@ public class ChatInquiryService {
 	public CreateChatInquiryResponse createChatInquiry(CreateChatInquiryRequest request, Member inquirer) {
 		QuestionPost questionPost = getQuestionPostById(request.questionPostId());
 		Member answerer = getMemberById(request.answererId());
-		validateChatAnswerer(request.questionPostId(), answerer);
+		validateChatAnswerer(request.questionPostId(), inquirer.getId(), answerer);
 		ChatInquiry chatInquiry = chatInquiryRepository.save(
 			ChatInquiryMapper.toChatInquiry(questionPost, inquirer, answerer, request.inquiryMessage())
 		);
@@ -145,9 +145,12 @@ public class ChatInquiryService {
 		autoRejectedChatInquiryNotification(rejectedChatInquiryDtos);
 	}
 
-	private void validateChatAnswerer(Long questionPostId, Member answerer) {
+	private void validateChatAnswerer(Long questionPostId, Long inquirerId, Member answerer) {
 		if (!answerRepository.existsByQuestionPostIdAndMember(questionPostId, answerer)) {
 			throw new ValidationException(ChatInquiryErrorCode.NOT_EXISTS_ANSWERER);
+		}
+		if (Objects.equals(answerer.getId(), inquirerId)) {
+			throw new ValidationException(ChatInquiryErrorCode.SELF_INQUIRY_NOT_ALLOWED);
 		}
 	}
 

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
@@ -146,9 +146,17 @@ public class ChatInquiryService {
 	}
 
 	private void validateChatAnswerer(Long questionPostId, Long inquirerId, Member answerer) {
+		validateIfAnswererExists(questionPostId, answerer);
+		validateIfNotSelfInquiry(inquirerId, answerer);
+	}
+
+	private void validateIfAnswererExists(Long questionPostId, Member answerer) {
 		if (!answerRepository.existsByQuestionPostIdAndMember(questionPostId, answerer)) {
 			throw new ValidationException(ChatInquiryErrorCode.NOT_EXISTS_ANSWERER);
 		}
+	}
+
+	private void validateIfNotSelfInquiry(Long inquirerId, Member answerer) {
 		if (Objects.equals(answerer.getId(), inquirerId)) {
 			throw new ValidationException(ChatInquiryErrorCode.SELF_INQUIRY_NOT_ALLOWED);
 		}

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
@@ -152,7 +152,6 @@ class ChatInquiryServiceTest {
 		//given
 		Member inquirer = MemberFixture.member(1L);
 		Member answerer = MemberFixture.member(2L);
-		ReflectionTestUtils.setField(inquirer, "credit", CHAT_REWARD);
 		QuestionPost questionPost = QuestionPostFixture.questionPost(inquirer);
 		CreateChatInquiryRequest request = new CreateChatInquiryRequest(
 			questionPost.getId(),
@@ -171,6 +170,32 @@ class ChatInquiryServiceTest {
 		assertThatThrownBy(() -> chatInquiryService.createChatInquiry(request, inquirer))
 			.isInstanceOf(ValidationException.class)
 			.hasMessageContaining(ChatInquiryErrorCode.NOT_EXISTS_ANSWERER.getMessage());
+	}
+
+	@DisplayName("[답변자는 스스로에게 채팅 요청을 할 수 없다.]")
+	@Test
+	void createChatInquiry_fails3() {
+		//given
+		Member questioner = MemberFixture.member(1L);
+		Member answerer = MemberFixture.member(2L);
+		QuestionPost questionPost = QuestionPostFixture.questionPost(questioner);
+		CreateChatInquiryRequest request = new CreateChatInquiryRequest(
+			questionPost.getId(),
+			answerer.getId(),
+			INQUIRY_MESSAGE
+		);
+
+		given(questionPostRepository.findById(questionPost.getId()))
+			.willReturn(Optional.of(questionPost));
+		given(memberRepository.findById(answerer.getId()))
+			.willReturn(Optional.of(answerer));
+		given(answerRepository.existsByQuestionPostIdAndMember(questionPost.getId(), answerer))
+			.willReturn(true);
+
+		//when & then
+		assertThatThrownBy(() -> chatInquiryService.createChatInquiry(request, answerer))
+			.isInstanceOf(ValidationException.class)
+			.hasMessageContaining(ChatInquiryErrorCode.SELF_INQUIRY_NOT_ALLOWED.getMessage());
 	}
 
 	@DisplayName("[채팅 요청 아이디로 채팅 요청 상세를 조회할 수 있다.]")


### PR DESCRIPTION
### 관련 이슈
- close #190 

### 📑 작업 상세 내용
- 답변자와 채팅 요청자 아이디 비교해 같으면 예외 발생
- 예외 테스트에서 불필요한 크레딧 설정 코드 제거

### 💫 작업 요약
- 

### 🔍 중점적으로 리뷰 할 부분
- 
