### PR TITLE
[refactor #193] 채팅 요청 상태 업데이트 함수 수정

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ExpiredChatInquiryDto.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/dto/ExpiredChatInquiryDto.java
@@ -4,13 +4,13 @@ import com.dnd.gongmuin.chat_inquiry.domain.ChatInquiry;
 import com.dnd.gongmuin.member.domain.Member;
 import com.querydsl.core.annotations.QueryProjection;
 
-public record RejectedChatInquiryDto(
+public record ExpiredChatInquiryDto(
 	Long chatInquiryId,
 	Member inquirer,
 	Member answer
 ) {
 	@QueryProjection
-	public RejectedChatInquiryDto(
+	public ExpiredChatInquiryDto(
 		ChatInquiry chatInquiry
 	) {
 		this(

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryResponse;
-import com.dnd.gongmuin.chat_inquiry.dto.RejectedChatInquiryDto;
+import com.dnd.gongmuin.chat_inquiry.dto.ExpiredChatInquiryDto;
 import com.dnd.gongmuin.member.domain.Member;
 
 public interface ChatInquiryQueryRepository {
@@ -15,7 +15,7 @@ public interface ChatInquiryQueryRepository {
 
 	List<Long> getAutoRejectedInquirerIds();
 
-	void updateChatInquiryStatusRejected(LocalDateTime now);
+	void updateChatInquiryStatusRejected(List<Long> expiredChatInquiryIds, LocalDateTime now);
 
-	List<RejectedChatInquiryDto> getAutoRejectedChatInquiries();
+	List<ExpiredChatInquiryDto> getExpiredChatInquires();
 }

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepository.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepository.java
@@ -13,8 +13,6 @@ import com.dnd.gongmuin.member.domain.Member;
 public interface ChatInquiryQueryRepository {
 	Slice<ChatInquiryResponse> getChatInquiresByMember(Member member, Pageable pageable);
 
-	List<Long> getAutoRejectedInquirerIds();
-
 	void updateChatInquiryStatusRejected(List<Long> expiredChatInquiryIds, LocalDateTime now);
 
 	List<ExpiredChatInquiryDto> getExpiredChatInquires();

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepositoryImpl.java
@@ -44,18 +44,6 @@ public class ChatInquiryQueryRepositoryImpl implements ChatInquiryQueryRepositor
 		boolean hasNext = hasNext(pageable.getPageSize(), content);
 		return new SliceImpl<>(content, pageable, hasNext);
 	}
-
-	public List<Long> getAutoRejectedInquirerIds() {
-		return queryFactory
-			.select(chatInquiry.inquirer.id)
-			.from(chatInquiry)
-			.where(
-				chatInquiry.createdAt.loe(LocalDateTime.now().minusWeeks(1)),
-				chatInquiry.status.eq(InquiryStatus.PENDING)
-			)
-			.fetch();
-	}
-
 	public List<ExpiredChatInquiryDto> getExpiredChatInquires() {
 		return queryFactory
 			.select(new QExpiredChatInquiryDto(

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryQueryRepositoryImpl.java
@@ -11,9 +11,9 @@ import org.springframework.data.domain.SliceImpl;
 
 import com.dnd.gongmuin.chat_inquiry.domain.InquiryStatus;
 import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryResponse;
+import com.dnd.gongmuin.chat_inquiry.dto.ExpiredChatInquiryDto;
 import com.dnd.gongmuin.chat_inquiry.dto.QChatInquiryResponse;
-import com.dnd.gongmuin.chat_inquiry.dto.QRejectedChatInquiryDto;
-import com.dnd.gongmuin.chat_inquiry.dto.RejectedChatInquiryDto;
+import com.dnd.gongmuin.chat_inquiry.dto.QExpiredChatInquiryDto;
 import com.dnd.gongmuin.member.domain.Member;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -56,9 +56,9 @@ public class ChatInquiryQueryRepositoryImpl implements ChatInquiryQueryRepositor
 			.fetch();
 	}
 
-	public List<RejectedChatInquiryDto> getAutoRejectedChatInquiries() {
+	public List<ExpiredChatInquiryDto> getExpiredChatInquires() {
 		return queryFactory
-			.select(new QRejectedChatInquiryDto(
+			.select(new QExpiredChatInquiryDto(
 				chatInquiry
 			))
 			.from(chatInquiry)
@@ -69,13 +69,12 @@ public class ChatInquiryQueryRepositoryImpl implements ChatInquiryQueryRepositor
 			.fetch();
 	}
 
-	public void updateChatInquiryStatusRejected(LocalDateTime now) {
+	public void updateChatInquiryStatusRejected(List<Long> expiredChatInquiryIds, LocalDateTime now) {
 		queryFactory.update(chatInquiry)
 			.set(chatInquiry.status, InquiryStatus.REJECTED)
 			.set(chatInquiry.updatedAt, now)
 			.where(
-				chatInquiry.createdAt.loe(LocalDateTime.now().minusWeeks(1)),
-				chatInquiry.status.eq(InquiryStatus.PENDING)
+				chatInquiry.id.in(expiredChatInquiryIds)
 			)
 			.execute();
 	}

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/scheduler/ChatInquiryScheduler.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/scheduler/ChatInquiryScheduler.java
@@ -19,6 +19,6 @@ public class ChatInquiryScheduler {
 	@Transactional
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	public void rejectChatInquiry() {
-		chatInquiryService.rejectChatAuto(LocalDateTime.now());
+		chatInquiryService.autoRejectChatInquiry(LocalDateTime.now());
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryService.java
@@ -19,7 +19,7 @@ import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.CreateChatInquiryRequest;
 import com.dnd.gongmuin.chat_inquiry.dto.CreateChatInquiryResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.RejectChatResponse;
-import com.dnd.gongmuin.chat_inquiry.dto.RejectedChatInquiryDto;
+import com.dnd.gongmuin.chat_inquiry.dto.ExpiredChatInquiryDto;
 import com.dnd.gongmuin.chat_inquiry.exception.ChatInquiryErrorCode;
 import com.dnd.gongmuin.chat_inquiry.repository.ChatInquiryRepository;
 import com.dnd.gongmuin.chatroom.domain.ChatRoom;
@@ -133,16 +133,13 @@ public class ChatInquiryService {
 	}
 
 	@Transactional
-	public void rejectChatAuto(LocalDateTime now) {
-		List<RejectedChatInquiryDto> rejectedChatInquiryDtos = chatInquiryRepository.getAutoRejectedChatInquiries();
-		List<Long> rejectedInquirerIds = getRejectedInquirerIds(rejectedChatInquiryDtos);
-		chatInquiryRepository.updateChatInquiryStatusRejected(now);
-		memberRepository.refundInMemberIds(rejectedInquirerIds, CHAT_REWARD);
-		creditHistoryService.saveCreditHistoryInMemberIds(
-			rejectedInquirerIds, CreditType.CHAT_REFUND, CHAT_REWARD
-		);
+	public void autoRejectChatInquiry(LocalDateTime now) {
+		List<ExpiredChatInquiryDto> expiredChatInquiryDtos = chatInquiryRepository.getExpiredChatInquires();
+		List<Long> expiredChatInquiryIds = getExpiredChatInquiryIds(expiredChatInquiryDtos);
 
-		autoRejectedChatInquiryNotification(rejectedChatInquiryDtos);
+		chatInquiryRepository.updateChatInquiryStatusRejected(expiredChatInquiryIds, now);
+		refundAutoRejectedInquiry(expiredChatInquiryDtos);
+		notifyAutoRejectedInquiry(expiredChatInquiryDtos);
 	}
 
 	private void validateChatAnswerer(Long questionPostId, Member answerer) {
@@ -156,14 +153,28 @@ public class ChatInquiryService {
 		creditHistoryService.saveCreditHistory(CreditType.CHAT_REQUEST, CHAT_REWARD, inquirer);
 	}
 
-	private List<Long> getRejectedInquirerIds(List<RejectedChatInquiryDto> rejectedChatInquiryDtos) {
-		return rejectedChatInquiryDtos.stream()
+	private List<Long> getExpiredChatInquiryIds(List<ExpiredChatInquiryDto> expiredChatInquiryDtos) {
+		return expiredChatInquiryDtos.stream()
+			.map(ExpiredChatInquiryDto::chatInquiryId)
+			.toList();
+	}
+
+	private List<Long> getRejectedInquirerIds(List<ExpiredChatInquiryDto> expiredChatInquiryDtos) {
+		return expiredChatInquiryDtos.stream()
 			.map(dto -> dto.inquirer().getId())
 			.toList();
 	}
 
-	private void autoRejectedChatInquiryNotification(List<RejectedChatInquiryDto> rejectedChatInquiryDtos) {
-		for (RejectedChatInquiryDto rejectChatInquiry : rejectedChatInquiryDtos) {
+	private void refundAutoRejectedInquiry(List<ExpiredChatInquiryDto> expiredChatInquiryDtos) {
+		List<Long> rejectedInquirerIds = getRejectedInquirerIds(expiredChatInquiryDtos);
+		memberRepository.refundInMemberIds(rejectedInquirerIds, CHAT_REWARD);
+		creditHistoryService.saveCreditHistoryInMemberIds(
+			rejectedInquirerIds, CreditType.CHAT_REFUND, CHAT_REWARD
+		);
+	}
+
+	private void notifyAutoRejectedInquiry(List<ExpiredChatInquiryDto> expiredChatInquiryDtos) {
+		for (ExpiredChatInquiryDto rejectChatInquiry : expiredChatInquiryDtos) {
 			eventPublisher.publishEvent(    // 채팅 요청자 알림
 				new NotificationEvent(
 					NotificationType.AUTO_CHAT_REJECT,

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/repository/ChatInquiryRepositoryTest.java
@@ -70,7 +70,7 @@ class ChatInquiryRepositoryTest extends DataJpaTestSupport {
 		);
 	}
 
-	@DisplayName("요청중인 채팅방이 일주일이 지나면, 채팅방 상태를 거절함으로 바꾼다.")
+	@DisplayName("만료된 채팅 요청에 대해, 채팅 요청 상태를 거절함으로 바꾼다.")
 	@Test
 	void updateChatInquiryStatusRejected() {
 		//given
@@ -85,7 +85,10 @@ class ChatInquiryRepositoryTest extends DataJpaTestSupport {
 		ReflectionTestUtils.setField(chatInquiries.get(0), "createdAt", LocalDateTime.now().minusWeeks(1));
 
 		//when
-		chatInquiryRepository.updateChatInquiryStatusRejected(LocalDateTime.now());
+		chatInquiryRepository.updateChatInquiryStatusRejected(
+			List.of(chatInquiries.get(0).getId()),
+			LocalDateTime.now()
+		);
 
 		em.flush();
 		em.clear();

--- a/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/chat_inquiry/service/ChatInquiryServiceTest.java
@@ -27,8 +27,8 @@ import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryDetailResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.ChatInquiryResponse;
 import com.dnd.gongmuin.chat_inquiry.dto.CreateChatInquiryRequest;
 import com.dnd.gongmuin.chat_inquiry.dto.CreateChatInquiryResponse;
+import com.dnd.gongmuin.chat_inquiry.dto.ExpiredChatInquiryDto;
 import com.dnd.gongmuin.chat_inquiry.dto.RejectChatResponse;
-import com.dnd.gongmuin.chat_inquiry.dto.RejectedChatInquiryDto;
 import com.dnd.gongmuin.chat_inquiry.exception.ChatInquiryErrorCode;
 import com.dnd.gongmuin.chat_inquiry.repository.ChatInquiryRepository;
 import com.dnd.gongmuin.chatroom.domain.ChatRoom;
@@ -326,22 +326,25 @@ class ChatInquiryServiceTest {
 		// given
 		final LocalDateTime now = LocalDateTime.now();
 
-		List<RejectedChatInquiryDto> rejectedChatInquiryDtos = List.of(
-			new RejectedChatInquiryDto(1L, MemberFixture.member(1L), MemberFixture.member(2L)),
-			new RejectedChatInquiryDto(2L, MemberFixture.member(3L), MemberFixture.member(4L))
+		List<ExpiredChatInquiryDto> expiredChatInquiryDtos = List.of(
+			new ExpiredChatInquiryDto(1L, MemberFixture.member(1L), MemberFixture.member(2L)),
+			new ExpiredChatInquiryDto(2L, MemberFixture.member(3L), MemberFixture.member(4L))
 		);
-		List<Long> rejectedInquirerIds = rejectedChatInquiryDtos.stream()
+		List<Long> expiredChatInquiryIds = expiredChatInquiryDtos.stream()
+			.map(ExpiredChatInquiryDto::chatInquiryId)
+			.toList();
+		List<Long> rejectedInquirerIds = expiredChatInquiryDtos.stream()
 			.map(dto -> dto.inquirer().getId())
 			.toList();
 
-		given(chatInquiryRepository.getAutoRejectedChatInquiries()).willReturn(rejectedChatInquiryDtos);
+		given(chatInquiryRepository.getExpiredChatInquires()).willReturn(expiredChatInquiryDtos);
 
 		// when
-		chatInquiryService.rejectChatAuto(now);
+		chatInquiryService.autoRejectChatInquiry(now);
 
 		// then
-		verify(chatInquiryRepository).getAutoRejectedChatInquiries();
-		verify(chatInquiryRepository).updateChatInquiryStatusRejected(now);
+		verify(chatInquiryRepository).getExpiredChatInquires();
+		verify(chatInquiryRepository).updateChatInquiryStatusRejected(expiredChatInquiryIds,now);
 		verify(memberRepository).refundInMemberIds(rejectedInquirerIds, CHAT_REWARD);
 		verify(creditHistoryService).saveCreditHistoryInMemberIds(
 			rejectedInquirerIds, CreditType.CHAT_REFUND, CHAT_REWARD


### PR DESCRIPTION
### 관련 이슈
- close #193 

### 📑 작업 상세 내용
- 네이밍 변경 `RejectedChatInquiryDto` -> `ExpiredChatInquiryDto`
  - 만료된 채팅 요청을 조회한 다음 거절하기 때문에  변경하였습니다
  - (조회 당시에는 거절된 상태가 아님)

- 기존 로직) 상태 비교, createdAt으로 비교
  - 먼저 호출되는 getExpiredChatInquires에서 상태 비교, createdAt을 이미 비교하기 때문에 또 비교하는건 불필요하다 생각하였습니다.
     -> 만료된 채팅 아이디 리스트만 비교하도록 수정

- 크레딧 반환하고, credit 기록하는 로직 함수로 추출

- 불필요한 repository 코드 삭제

### 💫 작업 요약
- 

### 🔍 중점적으로 리뷰 할 부분
- 
