### PR TITLE
[feat #178] 질문글 작성 전 최소한의 크레딧을 보유하는지 검증한다.

### DIFF
--- a/src/main/java/com/dnd/gongmuin/member/domain/Member.java
+++ b/src/main/java/com/dnd/gongmuin/member/domain/Member.java
@@ -155,4 +155,8 @@ public class Member extends TimeBaseEntity {
 	public int hashCode() {
 		return Objects.hash(id);
 	}
+
+	public boolean hasEnoughCredit(int credit) {
+		return this.credit >= credit;
+	}
 }

--- a/src/main/java/com/dnd/gongmuin/member/domain/Member.java
+++ b/src/main/java/com/dnd/gongmuin/member/domain/Member.java
@@ -156,7 +156,7 @@ public class Member extends TimeBaseEntity {
 		return Objects.hash(id);
 	}
 
-	public boolean hasEnoughCredit(int credit) {
+	public boolean hasMinimumCredit(int credit) {
 		return this.credit >= credit;
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
@@ -17,8 +17,8 @@ import com.dnd.gongmuin.member.domain.Member;
 import com.dnd.gongmuin.question_post.dto.request.QuestionPostSearchCondition;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.request.UpdateQuestionPostRequest;
+import com.dnd.gongmuin.question_post.dto.response.CheckQuestionPostCreditResponse;
 import com.dnd.gongmuin.question_post.dto.response.DeleteQuestionPostResponse;
-import com.dnd.gongmuin.question_post.dto.response.QuestionPostCreditCheckResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostSimpleResponse;
 import com.dnd.gongmuin.question_post.dto.response.RecQuestionPostResponse;
@@ -113,10 +113,10 @@ public class QuestionPostController {
 	@Operation(summary = "질문글 작성 크레딧 검증 API", description = "질문글을 작성하기 전 최소한의 크레딧을 보유하고 있는지 검증한다.")
 	@ApiResponse(useReturnTypeSchema = true)
 	@GetMapping("/api/question-posts/credit")
-	public ResponseEntity<QuestionPostCreditCheckResponse> checkQuestionPostCredit(
+	public ResponseEntity<CheckQuestionPostCreditResponse> checkQuestionPostCredit(
 		@AuthenticationPrincipal Member member
 	) {
-		QuestionPostCreditCheckResponse response = questionPostService.checkQuestionPostCredit(member);
+		CheckQuestionPostCreditResponse response = questionPostService.checkQuestionPostCredit(member);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
@@ -18,6 +18,7 @@ import com.dnd.gongmuin.question_post.dto.request.QuestionPostSearchCondition;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.request.UpdateQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.response.DeleteQuestionPostResponse;
+import com.dnd.gongmuin.question_post.dto.response.QuestionPostCreditCheckResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostSimpleResponse;
 import com.dnd.gongmuin.question_post.dto.response.RecQuestionPostResponse;
@@ -106,6 +107,16 @@ public class QuestionPostController {
 	) {
 		DeleteQuestionPostResponse response
 			= questionPostService.deleteQuestionPost(questionPostId, member);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "질문글 작성 크레딧 검증 API", description = "질문글을 작성하기 전 최소한의 크레딧을 보유하고 있는지 검증한다.")
+	@ApiResponse(useReturnTypeSchema = true)
+	@GetMapping("/api/question-posts/credit")
+	public ResponseEntity<QuestionPostCreditCheckResponse> checkQuestionPostCredit(
+		@AuthenticationPrincipal Member member
+	) {
+		QuestionPostCreditCheckResponse response = questionPostService.checkQuestionPostCredit(member);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/CheckQuestionPostCreditResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/CheckQuestionPostCreditResponse.java
@@ -1,6 +1,6 @@
 package com.dnd.gongmuin.question_post.dto.response;
 
-public record QuestionPostCreditCheckResponse(
+public record CheckQuestionPostCreditResponse(
 	boolean hasEnoughCredit
 ) {
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostCreditCheckResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostCreditCheckResponse.java
@@ -1,0 +1,6 @@
+package com.dnd.gongmuin.question_post.dto.response;
+
+public record QuestionPostCreditCheckResponse(
+	boolean hasEnoughCredit
+) {
+}

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -30,6 +30,7 @@ import com.dnd.gongmuin.question_post.dto.request.QuestionPostSearchCondition;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.request.UpdateQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.response.DeleteQuestionPostResponse;
+import com.dnd.gongmuin.question_post.dto.response.QuestionPostCreditCheckResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostSimpleResponse;
 import com.dnd.gongmuin.question_post.dto.response.RecQuestionPostResponse;
@@ -44,6 +45,8 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class QuestionPostService {
+
+	private static final int BASIC_CREDIT = 2_000;
 
 	private final QuestionPostRepository questionPostRepository;
 	private final InteractionRepository interactionRepository;
@@ -209,5 +212,10 @@ public class QuestionPostService {
 			reward,
 			member
 		);
+	}
+
+	@Transactional(readOnly = true)
+	public QuestionPostCreditCheckResponse checkQuestionPostCredit(Member member) {
+		return new QuestionPostCreditCheckResponse(member.hasEnoughCredit(BASIC_CREDIT));
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -216,6 +216,6 @@ public class QuestionPostService {
 
 	@Transactional(readOnly = true)
 	public CheckQuestionPostCreditResponse checkQuestionPostCredit(Member member) {
-		return new CheckQuestionPostCreditResponse(member.hasEnoughCredit(BASIC_CREDIT));
+		return new CheckQuestionPostCreditResponse(member.hasMinimumCredit(BASIC_CREDIT));
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -29,8 +29,8 @@ import com.dnd.gongmuin.question_post.dto.RefundQuestionPostDto;
 import com.dnd.gongmuin.question_post.dto.request.QuestionPostSearchCondition;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.request.UpdateQuestionPostRequest;
+import com.dnd.gongmuin.question_post.dto.response.CheckQuestionPostCreditResponse;
 import com.dnd.gongmuin.question_post.dto.response.DeleteQuestionPostResponse;
-import com.dnd.gongmuin.question_post.dto.response.QuestionPostCreditCheckResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostSimpleResponse;
 import com.dnd.gongmuin.question_post.dto.response.RecQuestionPostResponse;
@@ -215,7 +215,7 @@ public class QuestionPostService {
 	}
 
 	@Transactional(readOnly = true)
-	public QuestionPostCreditCheckResponse checkQuestionPostCredit(Member member) {
-		return new QuestionPostCreditCheckResponse(member.hasEnoughCredit(BASIC_CREDIT));
+	public CheckQuestionPostCreditResponse checkQuestionPostCredit(Member member) {
+		return new CheckQuestionPostCreditResponse(member.hasEnoughCredit(BASIC_CREDIT));
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/question_post/controller/QuestionPostControllerTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/controller/QuestionPostControllerTest.java
@@ -15,7 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
-import com.dnd.gongmuin.answer.domain.Answer;
 import com.dnd.gongmuin.answer.repository.AnswerRepository;
 import com.dnd.gongmuin.common.fixture.AnswerFixture;
 import com.dnd.gongmuin.common.fixture.InteractionCountFixture;
@@ -374,6 +373,17 @@ class QuestionPostControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.message")
 				.value(QuestionPostErrorCode.CAN_NOT_DELETE_QUESTION_POST.getMessage()))
 			.andDo(MockMvcResultHandlers.print());
+	}
+
+	@DisplayName("[질문글 작성 전 충분한 크레딧을 가지고 있는지 검증한다.]")
+	@Test
+	void checkQuestionPostCredit() throws Exception {
+		// when  // then
+		mockMvc.perform(get("/api/question-posts/credit")
+				.cookie(accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("hasEnoughCredit").value(Boolean.TRUE));
+
 	}
 
 	private void interactPost(Long questionPostId, InteractionType type) {

--- a/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
@@ -8,12 +8,14 @@ import static org.mockito.BDDMockito.*;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.dnd.gongmuin.answer.repository.AnswerRepository;
 import com.dnd.gongmuin.common.exception.runtime.ValidationException;
@@ -34,6 +36,7 @@ import com.dnd.gongmuin.question_post.domain.QuestionPostStatus;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.request.UpdateQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.response.DeleteQuestionPostResponse;
+import com.dnd.gongmuin.question_post.dto.response.QuestionPostCreditCheckResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.RegisterQuestionPostResponse;
 import com.dnd.gongmuin.question_post.dto.response.UpdateQuestionPostResponse;
@@ -320,5 +323,40 @@ class QuestionPostServiceTest {
 
 		assertThat(exception.getMessage())
 			.isEqualTo(QuestionPostErrorCode.NOT_AUTHORIZED.getMessage());
+	}
+
+	@DisplayName("질문글을 작성하기 전 충분한 크레딧을 가지고 있는지 검증한다.")
+	@Test
+	void validateCreditBeforeRegisteringQuestionPost() {
+		// given
+		final int NOT_ENOUGH_CREDIT = 1_000;
+		final int NOT_ENOUGH_CREDIT2 = 1_999;
+		final int ENOUGH_CREDIT = 2_000;
+		final int ENOUGH_CREDIT2 = 2_001;
+
+		Member member1 = MemberFixture.member(1L);
+		Member member2 = MemberFixture.member(2L);
+		Member member3 = MemberFixture.member(3L);
+		Member member4 = MemberFixture.member(4L);
+
+		ReflectionTestUtils.setField(member1, "credit", NOT_ENOUGH_CREDIT);
+		ReflectionTestUtils.setField(member2, "credit", NOT_ENOUGH_CREDIT2);
+		ReflectionTestUtils.setField(member3, "credit", ENOUGH_CREDIT);
+		ReflectionTestUtils.setField(member4, "credit", ENOUGH_CREDIT2);
+
+		// when
+		QuestionPostCreditCheckResponse response1 = questionPostService.checkQuestionPostCredit(member1);
+		QuestionPostCreditCheckResponse response2 = questionPostService.checkQuestionPostCredit(member2);
+		QuestionPostCreditCheckResponse response3 = questionPostService.checkQuestionPostCredit(member3);
+		QuestionPostCreditCheckResponse response4 = questionPostService.checkQuestionPostCredit(member4);
+
+		// then
+		Assertions.assertAll(
+			() -> assertFalse(response1.hasEnoughCredit()),
+			() -> assertFalse(response2.hasEnoughCredit()),
+			() -> assertTrue(response3.hasEnoughCredit()),
+			() -> assertTrue(response4.hasEnoughCredit())
+		);
+
 	}
 }

--- a/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/service/QuestionPostServiceTest.java
@@ -35,8 +35,8 @@ import com.dnd.gongmuin.question_post.domain.QuestionPostImage;
 import com.dnd.gongmuin.question_post.domain.QuestionPostStatus;
 import com.dnd.gongmuin.question_post.dto.request.RegisterQuestionPostRequest;
 import com.dnd.gongmuin.question_post.dto.request.UpdateQuestionPostRequest;
+import com.dnd.gongmuin.question_post.dto.response.CheckQuestionPostCreditResponse;
 import com.dnd.gongmuin.question_post.dto.response.DeleteQuestionPostResponse;
-import com.dnd.gongmuin.question_post.dto.response.QuestionPostCreditCheckResponse;
 import com.dnd.gongmuin.question_post.dto.response.QuestionPostDetailResponse;
 import com.dnd.gongmuin.question_post.dto.response.RegisterQuestionPostResponse;
 import com.dnd.gongmuin.question_post.dto.response.UpdateQuestionPostResponse;
@@ -345,10 +345,10 @@ class QuestionPostServiceTest {
 		ReflectionTestUtils.setField(member4, "credit", ENOUGH_CREDIT2);
 
 		// when
-		QuestionPostCreditCheckResponse response1 = questionPostService.checkQuestionPostCredit(member1);
-		QuestionPostCreditCheckResponse response2 = questionPostService.checkQuestionPostCredit(member2);
-		QuestionPostCreditCheckResponse response3 = questionPostService.checkQuestionPostCredit(member3);
-		QuestionPostCreditCheckResponse response4 = questionPostService.checkQuestionPostCredit(member4);
+		CheckQuestionPostCreditResponse response1 = questionPostService.checkQuestionPostCredit(member1);
+		CheckQuestionPostCreditResponse response2 = questionPostService.checkQuestionPostCredit(member2);
+		CheckQuestionPostCreditResponse response3 = questionPostService.checkQuestionPostCredit(member3);
+		CheckQuestionPostCreditResponse response4 = questionPostService.checkQuestionPostCredit(member4);
 
 		// then
 		Assertions.assertAll(


### PR DESCRIPTION
### 관련 이슈
- close #178 

### 📑 작업 상세 내용
- 질문글 작성 전 최소한의 크레딧(질문글 최소 채택 크레딧 `2_000`)을 보유하고 있는지 검증한다.

### 💫 작업 요약
- 질문글 작성 전 최소한의 크레딧(질문글 최소 채택 크레딧 `2_000`)을 보유하고 있는지 검증한다.

### 🔍 중점적으로 리뷰 할 부분
- 보유 크레딧이 최소 채택 크레딧`2_000` 보다 적을 경우 `false`가 아닌 예외를 던질까 생각했는데, 질문 글 작성 가능 여부를 판단하는 체크리스트 도중 **비정상적인 행위**는 아니라고 생각해서 논리형 응답으로 처리했습니다.
- 해당 API를 `Member` 패키지에 추가할까 하다 질문글 작성 전 검증하는 체크리스트라서 `QuestionPost` 패키지로 선택했습니다.
- Merge 후 프론트 측에 공유하겠습니다.
- 노션 API 명세서에 추가했습니다.