### PR TITLE
[feat #203] 프론트 환경에 따른 JWT 쿠키 설정 자동 변경

### DIFF
--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/CookieConfig.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/CookieConfig.java
@@ -1,0 +1,8 @@
+package com.dnd.gongmuin.security.jwt.util;
+
+import jakarta.servlet.http.Cookie;
+
+public interface CookieConfig {
+
+	public Cookie createCookie(String token);
+}

--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/CookieUtil.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/CookieUtil.java
@@ -11,15 +11,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CookieUtil {
 
+	private final CookieConfig cookieConfig;
+
 	public Cookie createCookie(String token) {
-		Cookie cookie = new Cookie("Authorization", token);
-		cookie.setPath("/");
-		cookie.setDomain("gongmuin.site");
-		cookie.setMaxAge(60 * 60);
-		cookie.setHttpOnly(true);
-		cookie.setSecure(true);
-		cookie.setAttribute("SameSite", "Strict");
-		return cookie;
+		return cookieConfig.createCookie(token);
 	}
 
 	public String getCookieValue(HttpServletRequest request) {

--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/DevCookie.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/DevCookie.java
@@ -1,9 +1,11 @@
 package com.dnd.gongmuin.security.jwt.util;
 
 import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
 
 import jakarta.servlet.http.Cookie;
 
+@Component
 @Profile("dev")
 public class DevCookie implements CookieConfig {
 	@Override

--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/DevCookie.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/DevCookie.java
@@ -1,0 +1,20 @@
+package com.dnd.gongmuin.security.jwt.util;
+
+import org.springframework.context.annotation.Profile;
+
+import jakarta.servlet.http.Cookie;
+
+@Profile("dev")
+public class DevCookie implements CookieConfig {
+	@Override
+	public Cookie createCookie(String token) {
+		Cookie cookie = new Cookie("Authorization", token);
+		cookie.setPath("/");
+		cookie.setDomain("gongmuin.site");
+		cookie.setMaxAge(60 * 60);
+		cookie.setHttpOnly(true);
+		cookie.setSecure(true);
+		cookie.setAttribute("SameSite", "Strict");
+		return cookie;
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/LocalCookie.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/LocalCookie.java
@@ -1,9 +1,11 @@
 package com.dnd.gongmuin.security.jwt.util;
 
 import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
 
 import jakarta.servlet.http.Cookie;
 
+@Component
 @Profile("local")
 public class LocalCookie implements CookieConfig {
 

--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/LocalCookie.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/LocalCookie.java
@@ -1,0 +1,20 @@
+package com.dnd.gongmuin.security.jwt.util;
+
+import org.springframework.context.annotation.Profile;
+
+import jakarta.servlet.http.Cookie;
+
+@Profile("local")
+public class LocalCookie implements CookieConfig {
+
+	@Override
+	public Cookie createCookie(String token) {
+		Cookie cookie = new Cookie("Authorization", token);
+		cookie.setPath("/");
+		cookie.setMaxAge(60 * 60);
+		cookie.setHttpOnly(false);
+		cookie.setSecure(false);
+		cookie.setAttribute("SameSite", "None");
+		return cookie;
+	}
+}

--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/ProdCookie.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/ProdCookie.java
@@ -1,0 +1,22 @@
+package com.dnd.gongmuin.security.jwt.util;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.Cookie;
+
+@Component
+@Profile("prod")
+public class ProdCookie implements CookieConfig {
+	@Override
+	public Cookie createCookie(String token) {
+		Cookie cookie = new Cookie("Authorization", token);
+		cookie.setPath("/");
+		cookie.setDomain("gongmuin.site");
+		cookie.setMaxAge(60 * 60);
+		cookie.setHttpOnly(true);
+		cookie.setSecure(true);
+		cookie.setAttribute("SameSite", "Strict");
+		return cookie;
+	}
+}


### PR DESCRIPTION
### 관련 이슈
- close #203 

### 📑 작업 상세 내용
- yml 환경변수 + @Profile()을 통한 JWT 설정 자동 변경되도록 작업함.
  - 다음과 같이 작성하면 dev환경에 맞는 쿠키 생성
  - spring: 
    - profiles:
      - active: dev
- dev와 prod가 아직 다르지 않지만 QA가 끝난 다음을 생각하여 선제적 분리하였음.

### 💫 작업 요약
- yml 환경변수 + @Profile()을 통한 JWT 설정 자동 변경되도록 작업

### 🔍 중점적으로 리뷰 할 부분
- local, dev, prod 모두 yml 업데이트 했습니다. 확인 바랍니다!
