### PR TITLE
[fix #212]  JWT 재발급 API 오류 해결

### DIFF
--- a/.github/workflows/cd_dev.yml
+++ b/.github/workflows/cd_dev.yml
@@ -3,7 +3,9 @@ name: Dev Server Deploy
 on:
   push:
     branches: [ "dev" ]
-
+  pull_request:
+    branches: [ "dev" ]
+    
 permissions:
   contents: read
 

--- a/.github/workflows/cd_dev.yml
+++ b/.github/workflows/cd_dev.yml
@@ -3,9 +3,7 @@ name: Dev Server Deploy
 on:
   push:
     branches: [ "dev" ]
-  pull_request:
-    branches: [ "dev" ]
-    
+
 permissions:
   contents: read
 

--- a/src/main/java/com/dnd/gongmuin/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/auth/exception/AuthErrorCode.java
@@ -12,7 +12,8 @@ public enum AuthErrorCode implements ErrorCode {
 	UNSUPPORTED_SOCIAL_LOGIN("해당 소셜 로그인은 지원되지 않습니다.", "AUTH_001"),
 	NOT_FOUND_PROVIDER("알맞은 Provider를 찾을 수 없습니다.", "AUTH_002"),
 	NOT_FOUND_AUTH("회원의 AUTH를 찾을 수 없습니다.", "AUTH_003"),
-	UNAUTHORIZED_TOKEN("잘못된 토큰입니다.", "AUTH_004");
+	UNAUTHORIZED_TOKEN("잘못된 토큰입니다.", "AUTH_004"),
+	FAIL_REISSUE_TOKEN("토큰 재발급에 실패했습니다.", "AUTH_005");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/dnd/gongmuin/auth/exception/AuthErrorCode.java
@@ -13,7 +13,8 @@ public enum AuthErrorCode implements ErrorCode {
 	NOT_FOUND_PROVIDER("알맞은 Provider를 찾을 수 없습니다.", "AUTH_002"),
 	NOT_FOUND_AUTH("회원의 AUTH를 찾을 수 없습니다.", "AUTH_003"),
 	UNAUTHORIZED_TOKEN("잘못된 토큰입니다.", "AUTH_004"),
-	FAIL_REISSUE_TOKEN("토큰 재발급에 실패했습니다.", "AUTH_005");
+	FAIL_REISSUE_TOKEN("토큰 재발급에 실패했습니다.", "AUTH_005"),
+	MISSING_ACCESS_TOKEN("AT가 존재하지 않습니다.", "AUTH_006");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
@@ -178,20 +178,31 @@ public class AuthService {
 			throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
 		}
 
-		Authentication authentication = tokenProvider.getAuthentication(accessToken);
-		Member member = (Member)authentication.getPrincipal();
+		Member findMember = tokenProvider.getMemberAllowExpired(accessToken);
 
-		String refreshToken = redisUtil.getValues("RT:" + member.getSocialEmail());
+		// RT 만료 여부 확인
+		try {
+			redisUtil.validateExpiredFromKey("RT:" + findMember.getSocialEmail());
 
-		// 로그아웃 또는 토큰 만료 경우 처리
-		if ("false".equals(refreshToken)) {
-			throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
+			String refreshToken = redisUtil.getValues("RT:" + findMember.getSocialEmail());
+
+			// 로그아웃 또는 토큰 만료 경우 처리
+			if ("false".equals(refreshToken)) {
+				throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);
+			}
+		} catch (Exception e) {
+			// 재로그인 요청 처리
+			throw new ValidationException(AuthErrorCode.FAIL_REISSUE_TOKEN);
 		}
 
+		// 기존 RT 만료(제거)
+		redisUtil.deleteValues("RT:" + findMember.getSocialEmail());
+
 		CustomOauth2User customUser = new CustomOauth2User(
-			AuthInfo.of(member.getSocialName(), member.getSocialEmail(), member.getRole()));
-		String reissuedAccessToken = tokenProvider.generateAccessToken(member, customUser, new Date());
-		tokenProvider.generateRefreshToken(member, customUser, new Date());
+			AuthInfo.of(findMember.getSocialName(), findMember.getSocialEmail(), findMember.getRole()));
+
+		String reissuedAccessToken = tokenProvider.generateAccessToken(findMember, customUser, new Date());
+		tokenProvider.generateRefreshToken(findMember, customUser, new Date());
 
 		response.addCookie(cookieUtil.createCookie(reissuedAccessToken));
 

--- a/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
@@ -208,6 +208,7 @@ public class AuthService {
 		String reissuedAccessToken = tokenProvider.generateAccessToken(findMember, customUser, new Date());
 		tokenProvider.generateRefreshToken(findMember, customUser, new Date());
 
+		cookieUtil.deleteCookie(response);
 		response.addCookie(cookieUtil.createCookie(reissuedAccessToken));
 
 		return new ReissueResponse(true);

--- a/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
@@ -173,6 +173,10 @@ public class AuthService {
 	public ReissueResponse reissue(HttpServletRequest request, HttpServletResponse response) {
 		String accessToken = cookieUtil.getCookieValue(request);
 
+		if (Objects.isNull(accessToken)) {
+			throw new NotFoundException(AuthErrorCode.MISSING_ACCESS_TOKEN);
+		}
+
 		// 로그아웃 토큰 처리
 		if ("logout".equals(redisUtil.getValues(accessToken))) {
 			throw new ValidationException(AuthErrorCode.UNAUTHORIZED_TOKEN);

--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenAuthenticationFilter.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenAuthenticationFilter.java
@@ -3,11 +3,14 @@ package com.dnd.gongmuin.security.jwt.util;
 import static org.springframework.http.HttpHeaders.*;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -24,12 +27,24 @@ import lombok.extern.slf4j.Slf4j;
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
 	private static final String TOKEN_PREFIX = "Bearer ";
+	private static final List<String> SKIP_URLS = Arrays.asList(
+		"/error", "/favicon.ico", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/ws/**",
+		"/api/auth/temp-signup", "/api/auth/temp-signin", "/api/auth/reissue/token"
+	);
+	private static final AntPathMatcher pathMatcher = new AntPathMatcher();
 	private final TokenProvider tokenProvider;
 	private final CookieUtil cookieUtil;
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
+
+		for (String pattern : SKIP_URLS) {
+			if (pathMatcher.match(pattern, request.getRequestURI())) {
+				filterChain.doFilter(request, response);
+				return;
+			}
+		}
 
 		String accessToken = cookieUtil.getCookieValue(request);
 

--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenProvider.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenProvider.java
@@ -41,7 +41,7 @@ public class TokenProvider {
 
 	private static final String ROLE_KEY = "ROLE";
 	private static final String[] BLACKLIST = new String[] {"false", "delete"};
-	private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 90L;
+	private static final long ACCESS_TOKEN_EXPIRE_TIME = /*30L;*/1000 * 60 * 90L;
 	private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24L;
 	private final MemberRepository memberRepository;
 	private final RedisUtil redisUtil;
@@ -106,7 +106,11 @@ public class TokenProvider {
 		}
 
 		Claims claims = parseToken(token);
-		return claims.getExpiration().after(date);
+		if (!claims.getExpiration().after(date)) {
+			throw new CustomJwtException(JwtErrorCode.EXPIRED_TOKEN);
+		}
+
+		return true;
 	}
 
 	private Claims parseToken(String token) {
@@ -114,7 +118,7 @@ public class TokenProvider {
 			return Jwts.parser().verifyWith(secretKey).build()
 				.parseSignedClaims(token).getPayload();
 		} catch (ExpiredJwtException e) {
-			throw new CustomJwtException(JwtErrorCode.EXPIRED_TOKEN);
+			return e.getClaims();
 		} catch (MalformedJwtException e) {
 			throw new CustomJwtException(JwtErrorCode.MALFORMED_TOKEN);
 		} catch (JwtException e) {
@@ -142,16 +146,7 @@ public class TokenProvider {
 	}
 
 	public Member getMemberAllowExpired(String token) {
-		Claims claims;
-
-		try {
-			claims = Jwts.parser().verifyWith(secretKey).build()
-				.parseSignedClaims(token).getPayload();
-		} catch (ExpiredJwtException e) {
-			claims = e.getClaims();
-		} catch (Exception e) {
-			throw new CustomJwtException(JwtErrorCode.INVALID_TOKEN);
-		}
+		Claims claims = parseToken(token);
 
 		String subject = claims.getSubject();
 		return memberRepository.findById(Long.valueOf(subject))

--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenProvider.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenProvider.java
@@ -41,7 +41,8 @@ public class TokenProvider {
 
 	private static final String ROLE_KEY = "ROLE";
 	private static final String[] BLACKLIST = new String[] {"false", "delete"};
-	private static final long ACCESS_TOKEN_EXPIRE_TIME = /*30L;*/1000 * 60 * 90L;
+	private static final long ACCESS_TOKEN_EXPIRE_TIME = 30L;/*1000 * 60 * 90L*/
+	;
 	private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24L;
 	private final MemberRepository memberRepository;
 	private final RedisUtil redisUtil;

--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenProvider.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenProvider.java
@@ -141,4 +141,21 @@ public class TokenProvider {
 		return Arrays.asList(BLACKLIST).contains(value);
 	}
 
+	public Member getMemberAllowExpired(String token) {
+		Claims claims;
+
+		try {
+			claims = Jwts.parser().verifyWith(secretKey).build()
+				.parseSignedClaims(token).getPayload();
+		} catch (ExpiredJwtException e) {
+			claims = e.getClaims();
+		} catch (Exception e) {
+			throw new CustomJwtException(JwtErrorCode.INVALID_TOKEN);
+		}
+
+		String subject = claims.getSubject();
+		return memberRepository.findById(Long.valueOf(subject))
+			.orElseThrow(() -> new NotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
+	}
+
 }

--- a/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenProvider.java
+++ b/src/main/java/com/dnd/gongmuin/security/jwt/util/TokenProvider.java
@@ -41,8 +41,7 @@ public class TokenProvider {
 
 	private static final String ROLE_KEY = "ROLE";
 	private static final String[] BLACKLIST = new String[] {"false", "delete"};
-	private static final long ACCESS_TOKEN_EXPIRE_TIME = 30L;/*1000 * 60 * 90L*/
-	;
+	private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 90L;
 	private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24L;
 	private final MemberRepository memberRepository;
 	private final RedisUtil redisUtil;

--- a/src/test/java/com/dnd/gongmuin/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/auth/service/AuthServiceTest.java
@@ -226,11 +226,10 @@ class AuthServiceTest {
 		mockRequest.setCookies(new Cookie("Authorization", "testtesttesttest"));
 
 		Member principal = MemberFixture.member();
-		Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "test");
 
 		given(cookieUtil.getCookieValue(mockRequest)).willReturn("testtesttesttest");
 		given(cookieUtil.createCookie(anyString())).willReturn(new Cookie("Authorization", "reissueToken"));
-		given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
+		given(tokenProvider.getMemberAllowExpired(anyString())).willReturn(principal);
 		given(redisUtil.getValues(anyString())).willReturn("refreshToken");
 		given(tokenProvider.generateAccessToken(
 			any(Member.class),


### PR DESCRIPTION
### 관련 이슈
- close #212 

### 📑 작업 상세 내용
- JWT 만료 후 API 요청 시 만료된 토큰 에러 발생
- 만료된 AT라면 RT를 검색해 재발급을 진행하고 RT가 없다면 에러를, 만료되었다면 재로그인을 요청시킨다.
- reissue() 작업 시 `AT Null` 체크 + 기존 RT 제거 추가 + RT 관련 예외 발생 시 재로그인 요청 처리 에러 던지기
- `ToeknProvider.validateToken()` 만료된 토큰이라면 `return false` -> `throw new CustomJwtException(JwtErrorCode.EXPIRED_TOKEN);`로 변경

- `TokenAuthenticationFilter`에 해당 필터를 넘어갈 `SKIP_URLS` 추가하여 넘어가도록 추가

### 💫 작업 요약
- JWT 만료 후 API 요청 시 만료된 토큰 에러 발생 해결
- `TokenAuthenticationFilter`에 해당 필터를 넘어갈 `SKIP_URLS` 추가하여 넘어가도록 추가하여 예외 발생 문제 해결

### 🔍 중점적으로 리뷰 할 부분
- 실제 배포 후에도 문제가 없는지 확인하고 Merge하고자 CD 스크립트를 수정해 바로 배포 후 문제 여부 확인하곘습니다.
