### PR TITLE
[feat #216] 질문 검색 API에 상호작용 필드 추가

### DIFF
--- a/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/controller/QuestionPostController.java
@@ -66,11 +66,12 @@ public class QuestionPostController {
 	@ApiResponse(useReturnTypeSchema = true)
 	@GetMapping("/api/question-posts/search")
 	public ResponseEntity<PageResponse<QuestionPostSimpleResponse>> searchQuestionPost(
+		@AuthenticationPrincipal Member member,
 		@Valid @ModelAttribute QuestionPostSearchCondition condition,
 		Pageable pageable
 	) {
 		PageResponse<QuestionPostSimpleResponse> response = questionPostService.searchQuestionPost(
-			condition, pageable);
+			member,condition, pageable);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostSimpleResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostSimpleResponse.java
@@ -40,6 +40,11 @@ public class QuestionPostSimpleResponse {
 		this.recommendCount = recommendCount;
 	}
 
+	public void setIsInteracted(boolean isSaved, boolean isRecommended) {
+		this.isSaved = isSaved;
+		this.isRecommended = isRecommended;
+	}
+
 	@Override
 	public String toString() {
 		return "QuestionPostSimpleResponse{" +

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostSimpleResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostSimpleResponse.java
@@ -11,6 +11,8 @@ public record QuestionPostSimpleResponse(
 	int reward,
 	String createdAt,
 	boolean isChosen,
+	boolean isSaved,
+	boolean isRecommended,
 	int savedCount,
 	int recommendCount
 ) {
@@ -40,5 +42,11 @@ public record QuestionPostSimpleResponse(
 			"questionPostId=" + questionPostId +
 			", title='" + title + '\'' +
 			'}';
+	}
+
+	public QuestionPostSimpleResponse setIsInteracted(boolean isSaved, boolean isRecommended){
+		return new QuestionPostSimpleResponse(
+			questionPostId, title, content, jobGroup, reward, createdAt,
+			isChosen, isSaved, isRecommended, savedCount, recommendCount);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostSimpleResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostSimpleResponse.java
@@ -1,39 +1,43 @@
 package com.dnd.gongmuin.question_post.dto.response;
 
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.querydsl.core.annotations.QueryProjection;
 
-public record QuestionPostSimpleResponse(
-	Long questionPostId,
-	String title,
-	String content,
-	String jobGroup,
-	int reward,
-	String createdAt,
-	boolean isChosen,
-	boolean isSaved,
-	boolean isRecommended,
-	int savedCount,
-	int recommendCount
-) {
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class QuestionPostSimpleResponse {
+	private Long questionPostId;
+	private String title;
+	private String content;
+	private String jobGroup;
+	private int reward;
+	private String createdAt;
+	@JsonProperty("isChosen")
+	private boolean isChosen;
+	@JsonProperty("isSaved")
+	private boolean isSaved;
+	@JsonProperty("isRecommended")
+	private boolean isRecommended;
+	private int savedCount;
+	private int recommendCount;
 
 	@QueryProjection
 	public QuestionPostSimpleResponse(
 		QuestionPost questionPost,
-		int savedCount,
-		int recommendCount
-	) {
-		this(
-			questionPost.getId(),
-			questionPost.getTitle(),
-			questionPost.getContent(),
-			questionPost.getJobGroup().getLabel(),
-			questionPost.getReward(),
-			questionPost.getCreatedAt().toString(),
-			questionPost.getIsChosen(),
-			savedCount,
-			recommendCount
-		);
+		int savedCount, int recommendCount) {
+		this.questionPostId = questionPost.getId();
+		this.title = questionPost.getTitle();
+		this.content = questionPost.getContent();
+		this.jobGroup = questionPost.getJobGroup().getLabel();
+		this.reward = questionPost.getReward();
+		this.createdAt = questionPost.getCreatedAt().toString();
+		this.isChosen = questionPost.getIsChosen();
+		this.savedCount = savedCount;
+		this.recommendCount = recommendCount;
 	}
 
 	@Override
@@ -42,11 +46,5 @@ public record QuestionPostSimpleResponse(
 			"questionPostId=" + questionPostId +
 			", title='" + title + '\'' +
 			'}';
-	}
-
-	public QuestionPostSimpleResponse setIsInteracted(boolean isSaved, boolean isRecommended){
-		return new QuestionPostSimpleResponse(
-			questionPostId, title, content, jobGroup, reward, createdAt,
-			isChosen, isSaved, isRecommended, savedCount, recommendCount);
 	}
 }

--- a/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/repository/QuestionPostQueryRepositoryImpl.java
@@ -1,7 +1,5 @@
 package com.dnd.gongmuin.question_post.repository;
 
-import static com.dnd.gongmuin.question_post.domain.QQuestionPost.*;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -32,16 +30,15 @@ import lombok.RequiredArgsConstructor;
 public class QuestionPostQueryRepositoryImpl implements QuestionPostQueryRepository {
 
 	private final JPAQueryFactory queryFactory;
+	private static final QQuestionPost questionPost = QQuestionPost.questionPost;
+	private static final QInteractionCount saved = new QInteractionCount("saved");
+	private static final QInteractionCount recommend = new QInteractionCount("recommend");
 
 	@Override
 	public Slice<QuestionPostSimpleResponse> searchQuestionPosts(
 		QuestionPostSearchCondition condition,
 		Pageable pageable
 	) {
-		QQuestionPost questionPost = QQuestionPost.questionPost;
-		QInteractionCount saved = new QInteractionCount("saved");
-		QInteractionCount recommend = new QInteractionCount("recommend");
-
 		List<QuestionPostSimpleResponse> content = queryFactory
 			.select(new QQuestionPostSimpleResponse(
 				questionPost,
@@ -73,10 +70,6 @@ public class QuestionPostQueryRepositoryImpl implements QuestionPostQueryReposit
 		JobGroup targetJobGroup,
 		Pageable pageable
 	) {
-		QQuestionPost questionPost = QQuestionPost.questionPost;
-		QInteractionCount saved = new QInteractionCount("saved");
-		QInteractionCount recommend = new QInteractionCount("recommend");
-
 		List<RecQuestionPostResponse> content = queryFactory
 			.select(new QRecQuestionPostResponse(
 				questionPost,

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -1,9 +1,7 @@
 package com.dnd.gongmuin.question_post.service;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import org.springframework.data.domain.Pageable;
@@ -108,22 +106,7 @@ public class QuestionPostService {
 	) {
 		Slice<QuestionPostSimpleResponse> responsePage =
 			questionPostRepository.searchQuestionPosts(condition, pageable);
-
-
-		responsePage.getContent().forEach(dto -> {
-			Long postId = dto.questionPostId();
-			Long memberId = member.getId(); // memberId는 예시로 member 객체에서 가져오는 것으로 가정
-
-			// 각 상호작용 타입에 대해 존재 여부 확인
-			boolean isSaved = interactionRepository.existsByQuestionPostIdAndMemberIdAndTypeAndIsInteractedTrue(
-				postId, memberId, InteractionType.SAVED);
-			boolean isRecommended = interactionRepository.existsByQuestionPostIdAndMemberIdAndTypeAndIsInteractedTrue(
-				postId, memberId, InteractionType.RECOMMEND);
-			System.out.println(postId+" "+isSaved);
-
-			// DTO 설정
-			dto.setIsInteracted(isSaved, isRecommended);
-		});
+		setIsInteracted(member, responsePage);
 
 		return PageMapper.toPageResponse(responsePage);
 	}
@@ -162,6 +145,21 @@ public class QuestionPostService {
 		questionPostRepository.deleteById(questionPostId);
 
 		return new DeleteQuestionPostResponse(questionPost.getMember().getCredit());
+	}
+
+	private void setIsInteracted(Member member, Slice<QuestionPostSimpleResponse> responsePage) {
+		responsePage.getContent().forEach(dto -> {
+			Long questionPostId = dto.getQuestionPostId();
+			Long memberId = member.getId(); // memberId는 예시로 member 객체에서 가져오는 것으로 가정
+
+			// 각 상호작용 타입에 대해 존재 여부 확인
+			boolean isSaved = interactionRepository.existsByQuestionPostIdAndMemberIdAndTypeAndIsInteractedTrue(
+				questionPostId, memberId, InteractionType.SAVED);
+			boolean isRecommended = interactionRepository.existsByQuestionPostIdAndMemberIdAndTypeAndIsInteractedTrue(
+				questionPostId, memberId, InteractionType.RECOMMEND);
+
+			dto.setIsInteracted(isSaved, isRecommended);
+		});
 	}
 
 	private void updateQuestionPostImages(QuestionPost questionPost, List<String> imageUrls) {

--- a/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/service/QuestionPostService.java
@@ -1,7 +1,9 @@
 package com.dnd.gongmuin.question_post.service;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.springframework.data.domain.Pageable;
@@ -100,11 +102,29 @@ public class QuestionPostService {
 
 	@Transactional(readOnly = true)
 	public PageResponse<QuestionPostSimpleResponse> searchQuestionPost(
+		Member member,
 		QuestionPostSearchCondition condition,
 		Pageable pageable
 	) {
 		Slice<QuestionPostSimpleResponse> responsePage =
 			questionPostRepository.searchQuestionPosts(condition, pageable);
+
+
+		responsePage.getContent().forEach(dto -> {
+			Long postId = dto.questionPostId();
+			Long memberId = member.getId(); // memberId는 예시로 member 객체에서 가져오는 것으로 가정
+
+			// 각 상호작용 타입에 대해 존재 여부 확인
+			boolean isSaved = interactionRepository.existsByQuestionPostIdAndMemberIdAndTypeAndIsInteractedTrue(
+				postId, memberId, InteractionType.SAVED);
+			boolean isRecommended = interactionRepository.existsByQuestionPostIdAndMemberIdAndTypeAndIsInteractedTrue(
+				postId, memberId, InteractionType.RECOMMEND);
+			System.out.println(postId+" "+isSaved);
+
+			// DTO 설정
+			dto.setIsInteracted(isSaved, isRecommended);
+		});
+
 		return PageMapper.toPageResponse(responsePage);
 	}
 

--- a/src/test/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepositoryTest.java
+++ b/src/test/java/com/dnd/gongmuin/question_post/repository/QuestionPostRepositoryTest.java
@@ -81,8 +81,8 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 		//then
 		assertAll(
 			() -> assertThat(responses).hasSize(2),
-			() -> assertThat(responses.get(0).questionPostId()).isEqualTo(questionPost2.getId()),
-			() -> assertThat(responses.get(1).questionPostId()).isEqualTo(questionPost1.getId())
+			() -> assertThat(responses.get(0).getQuestionPostId()).isEqualTo(questionPost2.getId()),
+			() -> assertThat(responses.get(1).getQuestionPostId()).isEqualTo(questionPost1.getId())
 		);
 	}
 
@@ -110,8 +110,8 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 		//then
 		assertAll(
 			() -> assertThat(responses).hasSize(2),
-			() -> assertThat(responses.get(0).questionPostId()).isEqualTo(questionPost2.getId()),
-			() -> assertThat(responses.get(1).questionPostId()).isEqualTo(questionPost1.getId())
+			() -> assertThat(responses.get(0).getQuestionPostId()).isEqualTo(questionPost2.getId()),
+			() -> assertThat(responses.get(1).getQuestionPostId()).isEqualTo(questionPost1.getId())
 		);
 	}
 
@@ -139,7 +139,7 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 		//then
 		assertAll(
 			() -> assertThat(responses).hasSize(1),
-			() -> assertThat(responses.get(0).questionPostId()).isEqualTo(questionPost1.getId())
+			() -> assertThat(responses.get(0).getQuestionPostId()).isEqualTo(questionPost1.getId())
 		);
 	}
 
@@ -167,9 +167,9 @@ class QuestionPostRepositoryTest extends DataJpaTestSupport {
 		//then
 		assertAll(
 			() -> assertThat(responses).hasSize(1),
-			() -> assertThat(responses.get(0).questionPostId()).isEqualTo(questionPost.getId()),
-			() -> assertThat(responses.get(0).savedCount()).isEqualTo(1),
-			() -> assertThat(responses.get(0).recommendCount()).isEqualTo(1)
+			() -> assertThat(responses.get(0).getQuestionPostId()).isEqualTo(questionPost.getId()),
+			() -> assertThat(responses.get(0).getSavedCount()).isEqualTo(1),
+			() -> assertThat(responses.get(0).getRecommendCount()).isEqualTo(1)
 		);
 	}
 


### PR DESCRIPTION
### 관련 이슈
- close #216 

### 📑 작업 상세 내용
- 질문 목록 조회 후 stream 돌며 해당 id와 memberid로 상호작용 존재하는 조회
  - boolean 값 dto에 저장
  - stream말고 querydsl 서브쿼리 사용 시 코드가 복잡해지고 exists를 사용하므로 성능이 저하될 수 있다고 판단
- boolean에 @getter 쓰면 is 필드 사라지므로 json property로 명시

### 💫 작업 요약
- 상호작용 필드 추가

### 🔍 중점적으로 리뷰 할 부분
- 
