### PR TITLE
[fix #206] 검색 결과 응답 필드에 boolean 변수 중복 생성 문제 해결

### DIFF
--- a/src/main/java/com/dnd/gongmuin/chat_inquiry/controller/ChatInquiryController.java
+++ b/src/main/java/com/dnd/gongmuin/chat_inquiry/controller/ChatInquiryController.java
@@ -43,7 +43,7 @@ public class ChatInquiryController {
 		return ResponseEntity.ok(response);
 	}
 
-	@Operation(summary = "채팅 요청 상세 조회 API", description = "채팅방 요청을 조회한다.")
+	@Operation(summary = "채팅 요청 상세 조회 API", description = "아이디로 채팅방 요청을 조회한다.")
 	@GetMapping("/api/chat/inquiries/{chatInquiryId}")
 	public ResponseEntity<ChatInquiryDetailResponse> getChatInquiryById(
 		@PathVariable("chatInquiryId") Long chatInquiryId,
@@ -53,7 +53,7 @@ public class ChatInquiryController {
 		return ResponseEntity.ok(response);
 	}
 
-	@Operation(summary = "채팅 요청 목록 조회 API", description = "회원의 채팅 목록을 조회한다.")
+	@Operation(summary = "채팅 요청 목록 조회 API", description = "회원의 채팅 요청 목록을 조회한다.")
 	@GetMapping("/api/chat/inquiries")
 	public ResponseEntity<PageResponse<ChatInquiryResponse>> getChatInquiresByMember(
 		@AuthenticationPrincipal Member member,

--- a/src/main/java/com/dnd/gongmuin/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/dnd/gongmuin/chatroom/controller/ChatRoomController.java
@@ -49,7 +49,7 @@ public class ChatRoomController {
 
 	@Operation(summary = "채팅방 상세조회 API", description = "채팅방 아이디로 채팅방을 조회한다.")
 	@GetMapping("/api/chat-rooms/{chatRoomId}")
-	public ResponseEntity<ChatRoomDetailResponse> createChatRoom(
+	public ResponseEntity<ChatRoomDetailResponse> getChatRoomById(
 		@PathVariable("chatRoomId") Long chatRoomId,
 		@AuthenticationPrincipal Member member
 	) {

--- a/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostSimpleResponse.java
+++ b/src/main/java/com/dnd/gongmuin/question_post/dto/response/QuestionPostSimpleResponse.java
@@ -1,7 +1,6 @@
 package com.dnd.gongmuin.question_post.dto.response;
 
 import com.dnd.gongmuin.question_post.domain.QuestionPost;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.querydsl.core.annotations.QueryProjection;
 
 import lombok.Getter;
@@ -16,11 +15,8 @@ public class QuestionPostSimpleResponse {
 	private String jobGroup;
 	private int reward;
 	private String createdAt;
-	@JsonProperty("isChosen")
 	private boolean isChosen;
-	@JsonProperty("isSaved")
 	private boolean isSaved;
-	@JsonProperty("isRecommended")
 	private boolean isRecommended;
 	private int savedCount;
 	private int recommendCount;
@@ -51,5 +47,17 @@ public class QuestionPostSimpleResponse {
 			"questionPostId=" + questionPostId +
 			", title='" + title + '\'' +
 			'}';
+	}
+
+	public boolean getIsChosen() {
+		return isChosen;
+	}
+
+	public boolean getIsSaved() {
+		return isSaved;
+	}
+
+	public boolean getIsRecommended() {
+		return isRecommended;
 	}
 }


### PR DESCRIPTION
### 관련 이슈
- close #206 

### 📑 작업 상세 내용
- 검색결과 응답 필드 조회 시 isXXX, XXX 필드 같이 출력됨
  - Wrapper 타입 Boolean으로 수정하면 해당 문제 없어지나 null 불필요하게 저장
  - `@jsonproperty` 삭제
  - boolean 필드 getter 직접 명시
