### PR TITLE
[feat #225] 질문 글 좋아요 낙관적 락을 이용한 동시성 제어

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,6 +147,8 @@ dependencies {
 
     // WebSocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    implementation 'org.springframework.retry:spring-retry'
 }
 
 // Querydsl

--- a/src/main/java/com/dnd/gongmuin/common/config/RetryConfig.java
+++ b/src/main/java/com/dnd/gongmuin/common/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package com.dnd.gongmuin.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@EnableRetry
+@Configuration
+public class RetryConfig {
+}

--- a/src/main/java/com/dnd/gongmuin/post_interaction/domain/InteractionCount.java
+++ b/src/main/java/com/dnd/gongmuin/post_interaction/domain/InteractionCount.java
@@ -43,6 +43,7 @@ public class InteractionCount extends TimeBaseEntity {
 		this.count = 1;
 		this.type = type;
 		this.questionPostId = questionPostId;
+		this.version = 0L;
 	}
 
 	public static InteractionCount of(InteractionType type, Long questionPostId) {

--- a/src/main/java/com/dnd/gongmuin/post_interaction/domain/InteractionCount.java
+++ b/src/main/java/com/dnd/gongmuin/post_interaction/domain/InteractionCount.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,6 +35,9 @@ public class InteractionCount extends TimeBaseEntity {
 	@Enumerated(EnumType.STRING)
 	@Column(name = "type")
 	private InteractionType type;
+
+	@Version
+	private Long version;
 
 	private InteractionCount(InteractionType type, Long questionPostId) {
 		this.count = 1;

--- a/src/main/java/com/dnd/gongmuin/post_interaction/repository/InteractionCountRepository.java
+++ b/src/main/java/com/dnd/gongmuin/post_interaction/repository/InteractionCountRepository.java
@@ -3,13 +3,18 @@ package com.dnd.gongmuin.post_interaction.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 import com.dnd.gongmuin.post_interaction.domain.InteractionCount;
 import com.dnd.gongmuin.post_interaction.domain.InteractionType;
 
+import jakarta.persistence.LockModeType;
+
 @Repository
 public interface InteractionCountRepository extends JpaRepository<InteractionCount, Long> {
+
+	@Lock(LockModeType.OPTIMISTIC)
 	Optional<InteractionCount> findByQuestionPostIdAndType(
 		Long questionPostId,
 		InteractionType type

--- a/src/main/java/com/dnd/gongmuin/post_interaction/service/InteractionService.java
+++ b/src/main/java/com/dnd/gongmuin/post_interaction/service/InteractionService.java
@@ -1,5 +1,9 @@
 package com.dnd.gongmuin.post_interaction.service;
 
+import org.hibernate.dialect.lock.OptimisticEntityLockException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,9 +22,11 @@ import com.dnd.gongmuin.question_post.exception.QuestionPostErrorCode;
 import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class InteractionService {
 
 	private final InteractionRepository interactionRepository;
@@ -28,6 +34,11 @@ public class InteractionService {
 	private final QuestionPostRepository questionPostRepository;
 
 	@Transactional
+	@Retryable(
+		retryFor = {ObjectOptimisticLockingFailureException.class, OptimisticEntityLockException.class},
+		maxAttempts = 10,
+		backoff = @Backoff(delay = 150)
+	)
 	public InteractionResponse activateInteraction(
 		Long questionPostId,
 		Long memberId,
@@ -46,7 +57,7 @@ public class InteractionService {
 
 		int count = interactionCountRepository
 			.findByQuestionPostIdAndType(questionPostId, type)
-			.map(InteractionCount::increaseCount)
+			.map(interactionCount -> interactionCount.increaseCount())
 			.orElseGet(() -> interactionCountRepository.save(
 				InteractionMapper.toInteractionCount(questionPostId, type)
 			).getCount());

--- a/src/test/java/com/dnd/gongmuin/post_interaction/service/InteractionTransactionTest.java
+++ b/src/test/java/com/dnd/gongmuin/post_interaction/service/InteractionTransactionTest.java
@@ -1,0 +1,90 @@
+package com.dnd.gongmuin.post_interaction.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.dnd.gongmuin.common.fixture.InteractionCountFixture;
+import com.dnd.gongmuin.common.fixture.InteractionFixture;
+import com.dnd.gongmuin.common.fixture.MemberFixture;
+import com.dnd.gongmuin.common.fixture.QuestionPostFixture;
+import com.dnd.gongmuin.common.support.TestContainerSupport;
+import com.dnd.gongmuin.member.domain.Member;
+import com.dnd.gongmuin.post_interaction.domain.Interaction;
+import com.dnd.gongmuin.post_interaction.domain.InteractionCount;
+import com.dnd.gongmuin.post_interaction.domain.InteractionType;
+import com.dnd.gongmuin.post_interaction.repository.InteractionCountRepository;
+import com.dnd.gongmuin.post_interaction.repository.InteractionRepository;
+import com.dnd.gongmuin.question_post.domain.QuestionPost;
+import com.dnd.gongmuin.question_post.repository.QuestionPostRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@SpringBootTest
+class InteractionTransactionTest extends TestContainerSupport {
+
+	private final Member questioner = MemberFixture.member(1L);
+
+	@Autowired
+	private InteractionRepository interactionRepository;
+
+	@Autowired
+	private InteractionCountRepository interactionCountRepository;
+
+	@Autowired
+	private QuestionPostRepository questionPostRepository;
+
+	@Autowired
+	private InteractionService interactionService;
+
+	@DisplayName("동시성 게시글 좋아요 카운트")
+	@Test
+	void lockingPostInteractionCountActive() throws InterruptedException {
+		// given
+		QuestionPost savedQuestion = questionPostRepository.save(QuestionPostFixture.questionPost(questioner));
+		Interaction savedInteraction = interactionRepository.save(InteractionFixture.interaction(
+			InteractionType.RECOMMEND, questioner.getId(), savedQuestion.getId())
+		);
+		InteractionCount savedInteractionCnt = interactionCountRepository.save(
+			InteractionCountFixture.interactionCount(InteractionType.RECOMMEND, savedQuestion.getId())
+		);
+
+		int threadCount = 10;
+		ExecutorService executorService = Executors.newFixedThreadPool(32);
+
+		CountDownLatch latch = new CountDownLatch(threadCount);
+		AtomicLong memberIdGenerator = new AtomicLong(234);
+
+		// when
+		for (int i = 0; i < threadCount; i++) {
+			executorService.submit(() -> {
+				try {
+					long uniqueMemberId = memberIdGenerator.getAndIncrement();
+					interactionService.activateInteraction(savedQuestion.getId(), uniqueMemberId,
+						InteractionType.RECOMMEND);
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();//다른 쓰레드에서 수행중인 작업이 완료될때까지 기다려줌
+
+		// when
+		InteractionCount result = interactionCountRepository.findById(savedInteractionCnt.getId()).get();
+
+		// then
+		assertThat(result.getCount()).isEqualTo(threadCount + 1);
+
+	}
+}
+


### PR DESCRIPTION
### 관련 이슈
- close #225 

### 📑 작업 상세 내용
- `InteractionCount` 낙관적 락을 위한 `version`필드 추가
- 재시도  로직 처리를 위한 `spring-retry` 라이브러리 및 confing 추가

### 💫 작업 요약
- 질문 글 좋아요 낙관적 락을 이용한 동시성 제어

### 🔍 중점적으로 리뷰 할 부분
- 비관적 락 적용시 성능 저하가 일어나고 좋아요 동시성 충돌이 많이 일어나지 않는다고 예상되어 낙관적 락을 사용했습니다.
