### PR TITLE
[fix #229] JWT 관리 문제 해결

### DIFF
--- a/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/gongmuin/auth/service/AuthService.java
@@ -47,7 +47,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthService {
 
-	private static final String LOGOUT = "logout";
 	private static final String DELETE = "delete";
 	private static final String ANONYMOUS = "ROLE_ANONYMOUS";
 	private static final Pattern nicknamePattern = Pattern.compile("^[a-zA-Z0-9가-힣]+$");
@@ -158,10 +157,10 @@ public class AuthService {
 		}
 
 		Long expiration = tokenProvider.getExpiration(accessToken, new Date());
-		redisUtil.setValues(accessToken, LOGOUT, Duration.ofMillis(expiration));
+		redisUtil.setValues(accessToken, DELETE, Duration.ofMillis(expiration));
 
 		String values = redisUtil.getValues(accessToken);
-		if (!Objects.equals(values, LOGOUT)) {
+		if (!Objects.equals(values, DELETE)) {
 			throw new NotFoundException(MemberErrorCode.LOGOUT_FAILED);
 		}
 

--- a/src/main/java/com/dnd/gongmuin/member/service/MemberService.java
+++ b/src/main/java/com/dnd/gongmuin/member/service/MemberService.java
@@ -42,6 +42,7 @@ public class MemberService {
 		Member member = memberRepository.findBySocialEmail(oauth2Response.createSocialEmail())
 			.map(m -> {
 				m.updateSocialEmail(oauth2Response.createSocialEmail());
+				deleteRefreshTokenIfExists(m);
 				deleteOauthAccessTokenIfExists(m);
 				saveOauth2AccessToken(oauth2Response, m);
 				return m;
@@ -51,18 +52,24 @@ public class MemberService {
 		return memberRepository.save(member);
 	}
 
-	private void saveOauth2AccessToken(Oauth2Response oauth2Response, Member m) {
-		redisUtil.setValues(
-			"AT(oauth):" + m.getSocialEmail(),
-			oauth2Response.getOauth2AccessToken(),
-			Duration.ofMillis(ACCESS_TOKEN_EXPIRATION)
-		);
+	private void deleteRefreshTokenIfExists(Member m) {
+		if (redisUtil.getValues("RT:" + m.getSocialEmail()) != null) {
+			redisUtil.deleteValues("RT:" + m.getSocialEmail());
+		}
 	}
 
 	private void deleteOauthAccessTokenIfExists(Member m) {
 		if (redisUtil.getValues("AT(oauth):" + m.getSocialEmail()) != null) {
 			redisUtil.deleteValues("AT(oauth):" + m.getSocialEmail());
 		}
+	}
+
+	private void saveOauth2AccessToken(Oauth2Response oauth2Response, Member m) {
+		redisUtil.setValues(
+			"AT(oauth):" + m.getSocialEmail(),
+			oauth2Response.getOauth2AccessToken(),
+			Duration.ofMillis(ACCESS_TOKEN_EXPIRATION)
+		);
 	}
 
 	public Provider parseProviderFromSocialEmail(Member member) {

--- a/src/main/java/com/dnd/gongmuin/member/service/MemberService.java
+++ b/src/main/java/com/dnd/gongmuin/member/service/MemberService.java
@@ -60,8 +60,8 @@ public class MemberService {
 	}
 
 	private void deleteOauthAccessTokenIfExists(Member m) {
-		if (redisUtil.getValues("AT(oauth2):" + m.getSocialEmail()) != null) {
-			redisUtil.deleteValues("AT(oauth2):" + m.getSocialEmail());
+		if (redisUtil.getValues("AT(oauth):" + m.getSocialEmail()) != null) {
+			redisUtil.deleteValues("AT(oauth):" + m.getSocialEmail());
 		}
 	}
 

--- a/src/test/java/com/dnd/gongmuin/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/dnd/gongmuin/auth/service/AuthServiceTest.java
@@ -205,7 +205,7 @@ class AuthServiceTest {
 		given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
 		given(tokenProvider.getExpiration(anyString(), any(Date.class))).willReturn(fiveMinutes);
 		given(redisUtil.getValues(anyString())).willReturn("refresh");
-		given(redisUtil.getValues(anyString())).willReturn("logout");
+		given(redisUtil.getValues(anyString())).willReturn("delete");
 
 		willDoNothing().given(redisUtil).setValues(anyString(), anyString(), any(Duration.class));
 


### PR DESCRIPTION
### 관련 이슈
- close #229 

### 📑 작업 상세 내용
- OAuth Token 삭제 시 Key값의 오탈자 수정
- 기존 회원 재 로그인 요청 처리 시 이전 발급 된 RT 제거 로직 추가(`MemberService.deleteRefreshTokenIfExists`)
- 로그아웃 || AT 재발급 시 기존 AT 만료 관리를 과도화게 이원화(`로그아웃`, `블랙리스트`) 관리를 단일화 관리(`블랙리스트`)로 변경

### 💫 작업 요약
- [X] OAuth Token 관리 오탈자 수정
- [X] 자체 만료시킬 AT 기존 관리를 불필요한 이원화(로그아웃, 블랙리스트)로 관리하는 문제 해결
- [X] 기존 회원이 로그인 했을 경우 이전에 발급된 RT가 TTL전까지 누적되서 관리되는 문제 해결


### 🔍 중점적으로 리뷰 할 부분
- 
